### PR TITLE
Run sqlite tests when postgres missing

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -36,6 +36,18 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# Auto-select SQLite backend when PostgreSQL isn't available
+if ! echo " $PYTEST_ARGS " | grep -Eq ' --db(=| )| --postgres '; then
+    if command -v docker >/dev/null 2>&1 || \
+       command -v podman >/dev/null 2>&1 || \
+       [ -n "$TEST_DATABASE_URL" ]; then
+        :
+    else
+        echo "${YELLOW}PostgreSQL not detected - running SQLite-only tests${NC}"
+        PYTEST_ARGS="--db sqlite $PYTEST_ARGS"
+    fi
+fi
+
 # Default pytest arguments if none provided
 if [ -z "$PYTEST_ARGS" ]; then
     PYTEST_ARGS="tests"


### PR DESCRIPTION
## Summary
- run tests with sqlite if postgres/docker aren't available directly from run-tests.sh

## Testing
- `poetry run poe test` *(fails: 2 failed, 340 passed, 17 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687a1e50b0008330b2ad91393f1265d0