### PR TITLE
Add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+    - name: Install dependencies
+      run: uv pip install -e '.[dev]'
+    - name: Run tests
+      run: poe test


### PR DESCRIPTION
## Summary
- run `poe test` for PRs and pushes to main

## Testing
- `scripts/format-and-lint.sh --fast $(git diff --name-only --cached | grep '\.py$')`
- `pytest -xq` *(fails: ModuleNotFoundError: No module named 'family_assistant')*

------
https://chatgpt.com/codex/tasks/task_e_687b7128a1648330b571542d7090da55