### PR TITLE
Add GitHub Actions workflow for container builds

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -3,6 +3,8 @@ name: Build and Push Containers
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       tag:
@@ -54,7 +56,7 @@ jobs:
       with:
         context: .devcontainer
         file: .devcontainer/Dockerfile
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-devcontainer:${{ needs.prepare.outputs.tag }}
           ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-devcontainer:latest
@@ -86,7 +88,7 @@ jobs:
       with:
         context: .
         file: Dockerfile
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         tags: |
           ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}:${{ needs.prepare.outputs.tag }}
           ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}:latest


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically build and push Docker containers when main branch is pushed
- Build both devcontainer and main application containers with timestamp-based tags
- Support manual workflow dispatch with custom tags

## Changes
- Added `.github/workflows/build-containers.yml` workflow that:
  - Builds and pushes devcontainer image to `ghcr.io/<repo>-devcontainer`
  - Builds and pushes main application image to `ghcr.io/<repo>`
  - Uses centralized tag generation to ensure consistency across jobs
  - Leverages GitHub Actions cache for faster subsequent builds
  - Uses GitHub Container Registry (ghcr.io) for public accessibility
  - Runs on PRs for testing (build only, no push to registry)

## Test plan
- [ ] Workflow runs successfully on this PR (build only)
- [ ] Both container images build successfully
- [ ] On merge to main: images are pushed to GHCR
- [ ] Manual workflow dispatch with custom tag works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)