### PR TITLE
fix: standardize markdown formatting and document auto-formatting tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ This script runs:
 
 **IMPORTANT**: `scripts/format-and-lint.sh` MUST pass before committing. NEVER use
 `git commit --no-verify` -- all lint failures must be fixed or properly disabled.
+
 ### Using the `llm` CLI
 
 - `cat myscript.py | llm 'explain this code'` - Analyze a script
@@ -51,7 +52,6 @@ This script runs:
 - `llm -f error.log 'debug this error'` - Debug from log files
 - `cat file1.py file2.py | llm 'how do these interact?'` - Analyze multiple files
 - Use `llm chat` for multi-line inputs (paste errors/tracebacks with `!multi` and `!end`)
-
 
 ### Testing
 
@@ -837,7 +837,8 @@ The development environment runs in Kubernetes using a StatefulSet with persiste
 - If no tag is provided, it defaults to timestamp format: `YYYYMMDD_HHMMSS`
 - Example: `.devcontainer/build-and-push.sh` (uses timestamp tag)
 - Example: `.devcontainer/build-and-push.sh v1.2.3` (uses custom tag)
-- This script builds the container with podman, pushes to the registry, and updates the Kubernetes StatefulSet
+- This script builds the container with podman, pushes to the registry, and updates the Kubernetes
+  StatefulSet
 
 ### Automatic Git Synchronization
 

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -200,3 +200,61 @@ This project follows the patterns defined in CLAUDE.md:
 - All code must pass linting (ruff, basedpyright, pylint)
 - Use virtualenv in .venv
 - Follow existing code conventions in the codebase
+
+## Auto-Formatting Tools
+
+This project uses automatic code formatting tools. **The reviewer should NOT suggest style changes
+that conflict with these tools**:
+
+### Python Formatting
+
+- **Tool**: `ruff format --preview`
+- **Configuration**: Automatic formatting with preview features enabled
+- **What it handles**: Indentation, spacing, line breaks, import ordering, quote consistency
+- **Important**: Do NOT flag Python style issues that ruff would automatically fix
+
+### Python Linting
+
+- **Tool**: `ruff check --fix --preview --ignore=E501`
+- **Configuration**: Auto-fixes enabled, line length (E501) ignored
+- **What it handles**: Code style violations, unused imports, common errors
+- **Important**: The reviewer should focus on logic and design issues, not style
+
+### Markdown Formatting
+
+- **Tool**: `mdformat --wrap 100`
+- **Configuration**: `.mdformat.toml` with 100-character line wrap
+- **What it handles**:
+  - Consistent heading styles
+  - List formatting and indentation
+  - Line wrapping at 100 characters
+  - Code block formatting
+  - Table formatting
+- **Important**: Do NOT flag Markdown style issues that mdformat would automatically fix
+
+### Pre-commit Hooks
+
+The project uses pre-commit hooks that run these formatters automatically:
+
+- Python files: `ruff check --fix --preview` and `ruff format --preview`
+- Markdown files: `mdformat --wrap 100`
+
+### Review Focus
+
+Given the auto-formatting tools in place, the reviewer should focus on:
+
+1. **Logic errors** and algorithmic correctness
+2. **Security vulnerabilities** and safety issues
+3. **Design patterns** and architecture decisions
+4. **Performance issues** and efficiency concerns
+5. **Missing error handling** or edge cases
+6. **Documentation completeness** (not formatting)
+7. **Test coverage** and quality
+
+The reviewer should **NOT** focus on:
+
+1. Code formatting (handled by ruff)
+2. Markdown formatting (handled by mdformat)
+3. Import ordering (handled by ruff)
+4. Line length in Python (explicitly ignored with E501)
+5. Whitespace or indentation issues

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -281,8 +281,10 @@ graph TD
   provided by `KnownUsersContextProvider`.
 
 - \*\*Weather Context Provider:\*\*Fetches and formats weather information from the WillyWeather API
-- **Home Assistant Context Provider (`HomeAssistantContextProvider`):** Provides context from a running Home Assistant instance if configured.
   (requires `WILLYWEATHER_API_KEY` and `WILLYWEATHER_LOCATION_ID` in `.env`).
+
+- **Home Assistant Context Provider (`HomeAssistantContextProvider`):** Provides context from a
+  running Home Assistant instance if configured.
 
 - **(Future) Reminders:** \*Set reminders via natural language (stored on a dedicated 'Reminders'
   calendar, requiring write access and configuration as described above). \*Receive notifications
@@ -483,7 +485,9 @@ The following features from the specification are currently implemented:
 - \*\*Known Users Context Provider (`KnownUsersContextProvider`):\*\*As previously specified.
 
 - \*\*Weather Context Provider (`WeatherContextProvider`):\*\*New provider using WillyWeather API.
-- **Home Assistant Context Provider (`HomeAssistantContextProvider`):** Provides context from a running Home Assistant instance if configured.
+
+- **Home Assistant Context Provider (`HomeAssistantContextProvider`):** Provides context from a
+  running Home Assistant instance if configured.
 
 - \*\*Processing Profiles with LLM Models:\*\*As previously specified.
 


### PR DESCRIPTION
## Summary
- Apply consistent mdformat formatting to all markdown files
- Add comprehensive auto-formatting documentation to REVIEW_GUIDELINES.md
- Fix incorrect documentation about Home Assistant Context Provider configuration

## Changes
This PR ensures all formatting tools (scripts/format-and-lint.sh, pre-commit hooks, and the auto-reviewer) have aligned expectations about code style:

1. **REVIEW_GUIDELINES.md**: Added detailed documentation about auto-formatting tools
   - Python: ruff format/check with preview features
   - Markdown: mdformat with 100-character wrap
   - Instructs reviewer to focus on logic/design rather than style

2. **Markdown formatting**: Applied consistent mdformat to ensure no persistent diffs
   - Fixed blank line consistency
   - Applied 100-character line wrapping
   - Fixed documentation error where Home Assistant provider incorrectly referenced WillyWeather config

## Test plan
- [x] All markdown files pass mdformat checks
- [x] Pre-commit hooks pass
- [x] Auto-reviewer no longer flags formatting issues

🤖 Generated with [Claude Code](https://claude.ai/code)