### PR TITLE
feat: add Claude Code hook to prevent commits on main branch

### DIFF
--- a/.claude/check_main_branch_commit.py
+++ b/.claude/check_main_branch_commit.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+PreToolHook script to prevent commits on the main branch.
+Reads input from stdin and returns 0 to allow, 2 to block with message.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+# Read the hook input from stdin
+try:
+    input_data = json.load(sys.stdin)
+except json.JSONDecodeError as e:
+    print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+    sys.exit(1)
+
+tool_name = input_data.get("tool_name", "")
+tool_input = input_data.get("tool_input", {})
+command = tool_input.get("command", "")
+
+# Only check Bash tool calls with git commit commands
+if tool_name != "Bash" or not command:
+    sys.exit(0)
+
+# Check if this is a git commit command (but not with --no-verify)
+if not re.search(r"\bgit\s+commit\b", command) or "--no-verify" in command:
+    sys.exit(0)
+
+# Get the current branch
+result = subprocess.run(
+    ["git", "branch", "--show-current"], capture_output=True, text=True, cwd=os.getcwd()
+)
+
+# Check if the command succeeded
+if result.returncode != 0:
+    # If we can't determine the branch, allow the commit
+    print(
+        f"Warning: Could not determine current branch: {result.stderr}", file=sys.stderr
+    )
+    sys.exit(0)
+
+current_branch = result.stdout.strip()
+
+# Check if we're on the main branch
+if current_branch in ["main", "master"]:
+    print(
+        f"• You're currently on the '{current_branch}' branch. Direct commits to the main branch are not allowed.",
+        file=sys.stderr,
+    )
+    print(
+        "• Please create a feature branch first: git checkout -b feature-name",
+        file=sys.stderr,
+    )
+    print(
+        "• Then you can commit your changes and create a pull request.", file=sys.stderr
+    )
+    sys.exit(2)
+
+# Allow commits on feature branches
+sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,10 @@
           },
           {
             "type": "command",
+            "command": "/usr/bin/env python3 .claude/check_main_branch_commit.py"
+          },
+          {
+            "type": "command",
             "command": "/bin/bash .claude/review-hook.sh",
             "timeout": 300
           }


### PR DESCRIPTION
## Summary
- Add a pre-tool hook that prevents direct commits to the main/master branch
- Encourages proper git workflow by requiring feature branches for all changes
- Hook can be bypassed with `--no-verify` if absolutely necessary

## Implementation
- Created `.claude/check_main_branch_commit.py` script that intercepts git commit commands
- Integrated the hook into `.claude/settings.json` as a PreToolUse hook for Bash commands
- Hook checks current branch and blocks commits if on main/master, suggesting to create a feature branch instead

## Test plan
- [x] Tested that commits work normally on feature branches
- [x] Verified the hook would block commits on main branch (with helpful error message)
- [x] Confirmed that `--no-verify` flag allows bypassing the hook
- [x] Fixed issues identified by code review hook (subprocess error handling, formatting)

🤖 Generated with [Claude Code](https://claude.ai/code)