### PR TITLE
feat: add shpool to dev container via multi-stage build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,7 @@
+# Build stage for shpool
+FROM rust:latest AS shpool-builder
+RUN cargo install shpool
+
 FROM ubuntu:24.04
 
 # Prevent interactive prompts during package installation
@@ -12,6 +16,9 @@ RUN apt-get update && apt-get install -y \
 
 # Create symbolic link for fd (fd-find installs as fdfind)
 RUN ln -s /usr/bin/fdfind /usr/bin/fd
+
+# Copy shpool binary from builder stage
+COPY --from=shpool-builder /usr/local/cargo/bin/shpool /usr/local/bin/shpool
 
 # Development tools not in pyproject.toml
 # ast-grep is required by CLAUDE.md instructions


### PR DESCRIPTION
## Summary
- Adds [shpool](https://github.com/shell-pool/shpool) (shell pooling utility) to the dev container
- Uses multi-stage Docker build for efficiency
- No systemd setup required - uses shpool's autodaemonization mode

## Implementation Details
- Uses `rust:latest` as builder stage to compile shpool from source
- Copies only the binary to the main image (keeps image size down)
- Binary installed at `/usr/local/bin/shpool`
- Intentionally using unpinned versions for latest features

## Test plan
- [ ] Build the dev container with the new Dockerfile
- [ ] Verify shpool is available and functional

🤖 Generated with [Claude Code](https://claude.ai/code)