### PR TITLE
fix: update stop hook to show only unpushed commits to upstream branch

### DIFF
--- a/.claude/stop-feedback-hook.sh
+++ b/.claude/stop-feedback-hook.sh
@@ -23,12 +23,16 @@ if [ "$stop_hook_active" = "false" ]; then
     fi
     
     # Check for unpushed commits
-    unpushed_commits=$(git log --oneline origin/main..HEAD 2>/dev/null)
-    if [ -n "$unpushed_commits" ]; then
-        echo "• There are unpushed commits. You may want to push them." >&2
-        echo "  Unpushed commits:" >&2
-        echo "$unpushed_commits" | sed 's/^/    /' >&2
-        echo >&2
+    # Get the upstream tracking branch
+    upstream=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null)
+    if [ -n "$upstream" ]; then
+        unpushed_commits=$(git log --oneline "$upstream"..HEAD 2>/dev/null)
+        if [ -n "$unpushed_commits" ]; then
+            echo "• There are unpushed commits. You may want to push them." >&2
+            echo "  Unpushed commits:" >&2
+            echo "$unpushed_commits" | sed 's/^/    /' >&2
+            echo >&2
+        fi
     fi
     
     # Always remind to check if request is fulfilled


### PR DESCRIPTION
## Summary

- Fixed the stop hook to correctly show only unpushed commits instead of all commits different from main
- Now uses the upstream tracking branch (`@{u}`) instead of hardcoded `origin/main`

## Details

Previously, the stop hook was comparing against `origin/main..HEAD`, which showed all commits since branching from main. This was confusing as it would show commits that were already pushed to the feature branch.

The fix detects the current branch's upstream tracking branch and compares against that, so it only shows commits that haven't been pushed yet.

## Test plan

- [x] Modified the stop hook
- [x] Tested that it correctly shows only unpushed commits
- [x] Verified it works with the current branch tracking configuration

🤖 Generated with [Claude Code](https://claude.ai/code)