### PR TITLE
Remove pytest -x flag in CI

### DIFF
--- a/.github/workflows/ci-with-devcontainer.yml
+++ b/.github/workflows/ci-with-devcontainer.yml
@@ -104,7 +104,7 @@ jobs:
             -e UV_CACHE_DIR=/opt/uv-cache \
             -u claude \
             ${{ needs.prepare.outputs.image-name }} \
-            bash -c 'cd /workspace && .venv/bin/pytest -xq --timeout=300 --db sqlite -m "not postgres"'
+            bash -c 'cd /workspace && .venv/bin/pytest -q --timeout=300 --db sqlite -m "not postgres"'
 
   test-postgres:
     needs: [prepare, build-devcontainer]
@@ -141,7 +141,7 @@ jobs:
             -e UV_CACHE_DIR=/opt/uv-cache \
             -u claude \
             ${{ needs.prepare.outputs.image-name }} \
-            bash -c 'cd /workspace && .venv/bin/pytest --postgres -xq --timeout=300'
+            bash -c 'cd /workspace && .venv/bin/pytest --postgres -q --timeout=300'
 
   # Require all test jobs to pass
   all-tests:


### PR DESCRIPTION
## Summary
- keep running tests in CI but don't stop after the first failure

## Testing
- `scripts/format-and-lint.sh`
- `pytest -xq` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_6881efd0c44c8330aff62976f5c6ca24