### PR TITLE
Mark all playwright tests

### DIFF
--- a/tests/functional/web/test_documents_flow.py
+++ b/tests/functional/web/test_documents_flow.py
@@ -11,6 +11,7 @@ from tests.functional.web.pages.documents_page import DocumentsPage
 from .conftest import WebTestFixture
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 @pytest.mark.postgres
 @pytest.mark.skip(
@@ -143,6 +144,7 @@ async def test_upload_document_with_file_flow(web_test_fixture: WebTestFixture) 
         Path(temp_file_path).unlink(missing_ok=True)
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 @pytest.mark.postgres
 @pytest.mark.skip(
@@ -209,6 +211,7 @@ async def test_upload_document_with_content_parts_flow(
     assert "submitted" in success_msg.lower() or "success" in success_msg.lower()
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 @pytest.mark.postgres
 async def test_view_document_detail_flow(web_test_fixture: WebTestFixture) -> None:
@@ -256,6 +259,7 @@ async def test_view_document_detail_flow(web_test_fixture: WebTestFixture) -> No
         assert chunk_count >= 0  # At least verify the page loaded without error
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 @pytest.mark.postgres
 async def test_file_validation_flow(web_test_fixture: WebTestFixture) -> None:
@@ -303,6 +307,7 @@ async def test_file_validation_flow(web_test_fixture: WebTestFixture) -> None:
     # Note: The exact error message will depend on the API validation
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 @pytest.mark.postgres
 async def test_metadata_json_validation(web_test_fixture: WebTestFixture) -> None:
@@ -333,6 +338,7 @@ async def test_metadata_json_validation(web_test_fixture: WebTestFixture) -> Non
     # The API should return an error about invalid JSON
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_empty_documents_state(web_test_fixture: WebTestFixture) -> None:
     """Test the empty state display when no documents exist."""
@@ -356,6 +362,7 @@ async def test_empty_documents_state(web_test_fixture: WebTestFixture) -> None:
         assert not await docs_page.is_empty_state_visible()
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 @pytest.mark.postgres
 async def test_reindex_document_flow(web_test_fixture: WebTestFixture) -> None:
@@ -394,6 +401,7 @@ async def test_reindex_document_flow(web_test_fixture: WebTestFixture) -> None:
         assert await docs_page.is_document_present(test_title)
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 @pytest.mark.postgres
 async def test_multiple_document_upload_flow(web_test_fixture: WebTestFixture) -> None:
@@ -437,6 +445,7 @@ async def test_multiple_document_upload_flow(web_test_fixture: WebTestFixture) -
             )
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_pagination_flow(web_test_fixture: WebTestFixture) -> None:
     """Test pagination controls on the documents list page."""

--- a/tests/functional/web/test_enhanced_fixtures_simple.py
+++ b/tests/functional/web/test_enhanced_fixtures_simple.py
@@ -7,6 +7,7 @@ import pytest
 from tests.functional.web.pages import BasePage
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_authenticated_page_fixture(authenticated_page: Any) -> None:
     """Test that authenticated_page fixture provides a valid page."""
@@ -17,6 +18,7 @@ async def test_authenticated_page_fixture(authenticated_page: Any) -> None:
     assert "blank" in authenticated_page.url
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_console_error_checker_basic(
     page: Any,
@@ -47,6 +49,7 @@ async def test_console_error_checker_basic(
     console_error_checker.assert_no_errors()  # Should pass now
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_console_error_checker_warnings(
     page: Any,
@@ -71,6 +74,7 @@ async def test_console_error_checker_warnings(
     assert "Found 1 console warnings" in str(exc_info.value)
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_base_page_with_fixtures(web_test_fixture: Any) -> None:
     """Test that BasePage works with web fixtures."""

--- a/tests/functional/web/test_history_flow.py
+++ b/tests/functional/web/test_history_flow.py
@@ -97,6 +97,7 @@ async def create_test_conversation(
 class TestHistoryNavigation:
     """Test basic navigation and display of message history."""
 
+    @pytest.mark.playwright
     async def test_history_page_loads(
         self, history_page: HistoryPage, web_test_fixture: Any
     ) -> None:
@@ -125,6 +126,7 @@ class TestHistoryNavigation:
             == 1
         )
 
+    @pytest.mark.playwright
     async def test_history_ui_elements(
         self, history_page: HistoryPage, web_test_fixture: Any
     ) -> None:

--- a/tests/functional/web/test_notes_flow.py
+++ b/tests/functional/web/test_notes_flow.py
@@ -8,6 +8,7 @@ from tests.functional.web.pages.notes_page import NotesPage
 from .conftest import WebTestFixture
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_create_note_full_flow(web_test_fixture: WebTestFixture) -> None:
     """Test complete note creation flow from UI."""
@@ -44,6 +45,7 @@ async def test_create_note_full_flow(web_test_fixture: WebTestFixture) -> None:
     assert note_data["include_in_prompt"] is True
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_edit_note_flow(web_test_fixture: WebTestFixture) -> None:
     """Test editing an existing note through the UI."""
@@ -81,6 +83,7 @@ async def test_edit_note_flow(web_test_fixture: WebTestFixture) -> None:
     assert note_data["include_in_prompt"] is False
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_delete_note_flow(web_test_fixture: WebTestFixture) -> None:
     """Test deleting a note through the UI."""
@@ -111,6 +114,7 @@ async def test_delete_note_flow(web_test_fixture: WebTestFixture) -> None:
     assert new_count == initial_count - 1
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="Search functionality not yet implemented in UI")
 async def test_search_notes_flow(web_test_fixture: WebTestFixture) -> None:
@@ -119,6 +123,7 @@ async def test_search_notes_flow(web_test_fixture: WebTestFixture) -> None:
     pass  # Should show all created notes
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_empty_state_display(web_test_fixture: WebTestFixture) -> None:
     """Test that empty state is shown when no notes exist."""
@@ -141,6 +146,7 @@ async def test_empty_state_display(web_test_fixture: WebTestFixture) -> None:
         assert not await notes_page.is_empty_state_visible()
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_note_form_validation(web_test_fixture: WebTestFixture) -> None:
     """Test form validation for note creation."""
@@ -186,6 +192,7 @@ async def test_note_form_validation(web_test_fixture: WebTestFixture) -> None:
     await page.wait_for_url(f"{web_test_fixture.base_url}/")
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_concurrent_note_operations(web_test_fixture: WebTestFixture) -> None:
     """Test that the UI handles concurrent operations gracefully."""

--- a/tests/functional/web/test_page_object_basic.py
+++ b/tests/functional/web/test_page_object_basic.py
@@ -7,6 +7,7 @@ import pytest
 from tests.functional.web.pages import BasePage
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_base_page_navigation(web_test_fixture: Any) -> None:
     """Test that the base page can navigate to different routes."""
@@ -23,6 +24,7 @@ async def test_base_page_navigation(web_test_fixture: Any) -> None:
     assert "/notes" in web_test_fixture.page.url
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_base_page_console_errors(web_test_fixture: Any) -> None:
     """Test that we can capture console errors."""

--- a/tests/functional/web/test_playwright_basic.py
+++ b/tests/functional/web/test_playwright_basic.py
@@ -5,6 +5,7 @@ import pytest
 from tests.functional.web.conftest import WebTestFixture
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_homepage_loads_with_playwright(web_test_fixture: WebTestFixture) -> None:
     """Test that the homepage loads successfully using Playwright."""
@@ -44,6 +45,7 @@ async def test_homepage_loads_with_playwright(web_test_fixture: WebTestFixture) 
     assert body_text is not None and len(body_text) > 0, "Page should have content"
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_notes_page_accessible(web_test_fixture: WebTestFixture) -> None:
     """Test that the notes page is accessible and renders correctly."""
@@ -82,6 +84,7 @@ async def test_notes_page_accessible(web_test_fixture: WebTestFixture) -> None:
     assert form_element is not None, "Add note page should have a form"
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_backend_api_accessible(web_test_fixture: WebTestFixture) -> None:
     """Test that the backend API is accessible from the frontend."""
@@ -117,6 +120,7 @@ async def test_backend_api_accessible(web_test_fixture: WebTestFixture) -> None:
     )
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_page_navigation_elements(web_test_fixture: WebTestFixture) -> None:
     """Test that main navigation elements are present and functional."""
@@ -146,6 +150,7 @@ async def test_page_navigation_elements(web_test_fixture: WebTestFixture) -> Non
     assert len(internal_links) > 0, "Page should have internal navigation links"
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_responsive_design(web_test_fixture: WebTestFixture) -> None:
     """Test that the UI is responsive and works on mobile viewport."""
@@ -167,6 +172,7 @@ async def test_responsive_design(web_test_fixture: WebTestFixture) -> None:
     await page.set_viewport_size({"width": 1280, "height": 720})
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_add_note_with_javascript(web_test_fixture: WebTestFixture) -> None:
     """Test adding a note using the UI with JavaScript/CSS functionality."""
@@ -222,6 +228,7 @@ async def test_add_note_with_javascript(web_test_fixture: WebTestFixture) -> Non
     assert await note_element.is_visible(), "Created note should be visible in the list"
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_css_and_styling_loads(web_test_fixture: WebTestFixture) -> None:
     """Test that CSS stylesheets are properly loaded through Vite."""

--- a/tests/functional/web/test_ui_endpoints_playwright.py
+++ b/tests/functional/web/test_ui_endpoints_playwright.py
@@ -99,6 +99,7 @@ async def check_endpoint(
     return failures, warnings
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_ui_endpoint_accessibility_playwright(
     web_test_fixture: Any,
@@ -138,6 +139,7 @@ async def test_ui_endpoint_accessibility_playwright(
         print("Warnings encountered:\n" + "\n".join(all_warnings))
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_navigation_links_work(
     web_test_fixture: Any,
@@ -177,6 +179,7 @@ async def test_navigation_links_work(
     console_error_checker.assert_no_errors()
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_responsive_design_mobile(
     web_test_fixture: Any,
@@ -213,6 +216,7 @@ async def test_responsive_design_mobile(
     console_error_checker.assert_no_errors()
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_form_interactions(
     web_test_fixture: Any,
@@ -250,6 +254,7 @@ async def test_form_interactions(
     console_error_checker.assert_no_errors()
 
 
+@pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_loading_states(
     web_test_fixture: Any,


### PR DESCRIPTION
## Summary
- add pytest.mark.playwright decorators for all Playwright-based tests

## Testing
- `scripts/format-and-lint.sh tests/functional/web/test_playwright_basic.py tests/functional/web/test_documents_flow.py tests/functional/web/test_enhanced_fixtures_simple.py tests/functional/web/test_history_flow.py tests/functional/web/test_notes_flow.py tests/functional/web/test_page_object_basic.py tests/functional/web/test_ui_endpoints_playwright.py`
- `PYTHONPATH=src pytest tests/functional/web/test_playwright_basic.py::test_homepage_loads_with_playwright -xq --db sqlite`

------
https://chatgpt.com/codex/tasks/task_e_688a286bcad48330896fbfa65a78ffae