### PR TITLE
Add interface-aware history configuration for web UI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -119,6 +119,9 @@ default_profile_settings:
     timezone: "UTC"
     max_history_messages: 3
     history_max_age_hours: 2
+    # Web-specific history settings for better conversation context
+    # web_max_history_messages: 100  # Uncomment to override default of 100
+    # web_history_max_age_hours: 720  # Uncomment to override default of 720 (30 days)
     delegation_security_level: "confirm" # Default: "blocked", "confirm", or "unrestricted"
   tools_config:
     # `enable_local_tools` are not explicitly listed here for the default profile.

--- a/src/family_assistant/__main__.py
+++ b/src/family_assistant/__main__.py
@@ -149,6 +149,9 @@ def load_config(config_file_path: str = CONFIG_FILE_PATH) -> dict[str, Any]:
                 "timezone": "UTC",
                 "max_history_messages": 5,
                 "history_max_age_hours": 24,
+                # Web-specific history settings for better conversation context
+                "web_max_history_messages": 100,  # Much higher for web conversations
+                "web_history_max_age_hours": 720,  # 30 days - web conversations can be resumed later
                 # Default LLM model for profiles, can be overridden per profile
                 "llm_model": "gemini/gemini-2.5-pro-preview-05-06",  # Use actual default model string
             },
@@ -497,6 +500,8 @@ def load_config(config_file_path: str = CONFIG_FILE_PATH) -> dict[str, Any]:
                 "timezone",
                 "max_history_messages",
                 "history_max_age_hours",
+                "web_max_history_messages",
+                "web_history_max_age_hours",
                 "delegation_security_level",  # Add delegation_security_level here
             ]:
                 if scalar_key in profile_def["processing_config"]:

--- a/src/family_assistant/assistant.py
+++ b/src/family_assistant/assistant.py
@@ -632,6 +632,12 @@ class Assistant:
                 timezone_str=profile_proc_conf_dict["timezone"],
                 max_history_messages=profile_proc_conf_dict["max_history_messages"],
                 history_max_age_hours=profile_proc_conf_dict["history_max_age_hours"],
+                web_max_history_messages=profile_proc_conf_dict.get(
+                    "web_max_history_messages"
+                ),
+                web_history_max_age_hours=profile_proc_conf_dict.get(
+                    "web_history_max_age_hours"
+                ),
                 tools_config=profile_tools_conf_dict,
                 delegation_security_level=profile_proc_conf_dict.get(
                     "delegation_security_level", "confirm"


### PR DESCRIPTION
## Summary

This PR implements interface-aware history configuration, allowing the web UI to maintain much longer conversation context while keeping Telegram interactions efficient with limited history.

## Changes

- Add  and  to 
- Web interface now retrieves up to 100 messages within 30 days by default
- Other interfaces (Telegram) keep existing limits (5 messages, 24 hours)
- Add  helper method to avoid code duplication
- Fix logic to properly handle zero values for web-specific settings (using explicit None checks instead of truthiness)
- Add comprehensive tests including edge cases (zero values, fallback behavior)
- Update config.yaml with commented examples for easy configuration

## Benefits

- **Web UI users** get full conversation context, improving response quality in longer sessions
- **Telegram users** maintain efficient, time-bounded context suitable for mobile messaging
- **Backward compatible** - existing behavior unchanged for non-web interfaces
- **Configurable** - values can be overridden in config.yaml per profile

## Test Plan

- [x] Added unit tests for web-specific configuration
- [x] Added unit tests for fallback behavior
- [x] Added unit tests for zero value handling
- [x] All existing tests pass (644 passed, 15 skipped)
- [x] Linting and type checking pass

🤖 Generated with [Claude Code](https://claude.ai/code)