### PR TITLE
Optimize frontend bundling

### DIFF
--- a/frontend/src/errors/ErrorsApp.jsx
+++ b/frontend/src/errors/ErrorsApp.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import ErrorsList from './components/ErrorsList';
 import ErrorDetail from './components/ErrorDetail';
+import './errors.css';
 
 const ErrorsApp = () => {
   // Set the page title

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,9 +7,6 @@ import './styles/globals.css';
 // Import our custom CSS
 import './custom.css';
 
-// Import vanilla-jsoneditor and make it globally available
-import { createJSONEditor } from 'vanilla-jsoneditor';
-
 // Log that the frontend is loaded (for development)
 // console.log('Family Assistant frontend loaded');
 
@@ -18,6 +15,3 @@ window.FamilyAssistant = {
   version: '0.1.0',
   loaded: true,
 };
-
-// Make vanilla-jsoneditor available globally for Jinja2 templates
-window.createJSONEditor = createJSONEditor;

--- a/frontend/src/shared/AppRouter.jsx
+++ b/frontend/src/shared/AppRouter.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import Layout from './Layout.tsx';
 
 // Lazy load all route components for code splitting
+const Layout = lazy(() => import('./Layout.tsx'));
 const ChatPage = lazy(() => import('../chat/ChatApp'));
 const ToolsApp = lazy(() => import('../tools/ToolsApp'));
 const ErrorsApp = lazy(() => import('../errors/ErrorsApp'));
@@ -45,6 +45,14 @@ const FallbackRedirect = () => {
   );
 };
 
+const withLayout = (element) => (
+  <Suspense fallback={<LoadingSpinner />}>
+    <Layout>
+      <Suspense fallback={<LoadingSpinner />}>{element}</Suspense>
+    </Layout>
+  </Suspense>
+);
+
 const AppRouter = () => {
   return (
     <BrowserRouter>
@@ -60,148 +68,40 @@ const AppRouter = () => {
         />
 
         {/* Tools routes */}
-        <Route
-          path="/tools"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <ToolsApp />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/tools" element={withLayout(<ToolsApp />)} />
 
         {/* Errors routes */}
-        <Route
-          path="/errors/*"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <ErrorsApp />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/errors/*" element={withLayout(<ErrorsApp />)} />
 
         {/* Context page (test conversion) */}
-        <Route
-          path="/context"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <ContextPage />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/context" element={withLayout(<ContextPage />)} />
 
         {/* Notes routes */}
-        <Route
-          path="/notes/*"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <NotesApp />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/notes/*" element={withLayout(<NotesApp />)} />
 
         {/* Tasks routes */}
-        <Route
-          path="/tasks/*"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <TasksApp />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/tasks/*" element={withLayout(<TasksApp />)} />
 
         {/* Event Listeners routes */}
-        <Route
-          path="/event-listeners/*"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <EventListenersApp />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/event-listeners/*" element={withLayout(<EventListenersApp />)} />
 
         {/* Events routes */}
-        <Route
-          path="/events/*"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <EventsApp />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/events/*" element={withLayout(<EventsApp />)} />
 
         {/* History routes */}
-        <Route
-          path="/history/*"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <HistoryApp />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/history/*" element={withLayout(<HistoryApp />)} />
 
         {/* Documentation routes */}
-        <Route
-          path="/docs/*"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <DocumentationApp />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/docs/*" element={withLayout(<DocumentationApp />)} />
 
         {/* Settings routes */}
-        <Route
-          path="/settings/tokens"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <TokenManagement />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/settings/tokens" element={withLayout(<TokenManagement />)} />
 
         {/* Documents routes */}
-        <Route
-          path="/documents/*"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <DocumentsPage />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/documents/*" element={withLayout(<DocumentsPage />)} />
 
         {/* Vector Search routes */}
-        <Route
-          path="/vector-search/*"
-          element={
-            <Layout>
-              <Suspense fallback={<LoadingSpinner />}>
-                <VectorSearchPage />
-              </Suspense>
-            </Layout>
-          }
-        />
+        <Route path="/vector-search/*" element={withLayout(<VectorSearchPage />)} />
 
         {/* Default redirect to chat */}
         <Route path="/" element={<Navigate to="/chat" replace />} />

--- a/frontend/src/shared/router-entry.jsx
+++ b/frontend/src/shared/router-entry.jsx
@@ -5,8 +5,6 @@ import { ThemeProvider } from './ThemeProvider';
 
 // Import Tailwind CSS and custom styles
 import '../styles/globals.css';
-import '../tools/tools.css';
-import '../errors/errors.css';
 
 // Ensure the DOM is ready before mounting
 function mountApp() {

--- a/frontend/src/tools/ToolsApp.jsx
+++ b/frontend/src/tools/ToolsApp.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import './tools.css';
 
 // Global variable to cache the dynamic import promise
 let jsonEditorImportPromise = null;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -80,9 +80,9 @@ export default defineConfig(({ mode }) => ({
         'tool-test-bench': path.resolve(__dirname, 'tool-test-bench.html'),
       },
       output: {
-        // Manual chunks configuration to split vendor libraries
+        // Manual chunks configuration to avoid loading page-specific deps globally
         manualChunks: (id) => {
-          // Split node_modules into vendor chunks
+          // Let Rollup create chunks for node_modules when needed
           if (id.includes('node_modules')) {
             // DON'T manually chunk React - let it be included in the entry bundle
             // This ensures React is always available when the app starts
@@ -119,13 +119,18 @@ export default defineConfig(({ mode }) => ({
               return undefined;
             }
 
+            // Icon libraries - keep them with importing modules
+            if (id.includes('lucide-react')) {
+              return undefined;
+            }
+
             // Chat-specific UI components
             if (id.includes('@assistant-ui')) {
               return 'assistant-ui';
             }
 
-            // All other vendor libraries
-            return 'vendor';
+            // Let other dependencies stay with the importing chunk
+            return undefined;
           }
           // Keep app code in the default chunks
         },


### PR DESCRIPTION
## Summary
- Load Tools and Error styles only on their respective routes
- Keep page-specific dependencies out of global vendor bundle
- Leave vendor-less modules with their importing chunks to trim initial payloads

## Testing
- `npm run lint --prefix frontend`
- `npm run build --prefix frontend`
- `uv run poe test` *(fails: Browser.new_context connection errors, 2 failed and 129 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68975488af88833086f67dfd1b2a5530