### PR TITLE
Fix flaky test_conversation_persistence_and_switching test

### DIFF
--- a/tests/functional/web/pages/chat_page.py
+++ b/tests/functional/web/pages/chat_page.py
@@ -492,6 +492,10 @@ class ChatPage(BasePage):
         start_time = time.time()
         current_conv_id = await self.get_current_conversation_id()
 
+        # First ensure streaming is complete before checking if saved
+        # This prevents the reload from interrupting message processing
+        await self.wait_for_streaming_complete(timeout=10000)
+
         while time.time() - start_time < timeout / 1000:
             try:
                 # Force a reload to ensure the conversation list is up-to-date

--- a/tests/functional/web/test_chat_ui_flow.py
+++ b/tests/functional/web/test_chat_ui_flow.py
@@ -170,11 +170,8 @@ async def test_conversation_persistence_and_switching(
         )
     first_conv_id = await chat_page.get_current_conversation_id()
 
-    # Wait for conversation to be saved
+    # Wait for conversation to be saved (this now includes wait_for_streaming_complete)
     await chat_page.wait_for_conversation_saved()
-
-    # Ensure streaming has completely finished before switching conversations
-    await chat_page.wait_for_streaming_complete()
 
     # Create a new chat
     await chat_page.create_new_chat()


### PR DESCRIPTION
## Summary
- Fixed intermittent test failure in `test_conversation_persistence_and_switching`
- The test was failing because page reloads were interrupting message streaming/saving
- Added proper synchronization to ensure streaming completes before reloading

## Problem
The test was failing intermittently in CI with messages being truncated. The error showed:
```
TimeoutError: Timeout waiting for expected content. Got messages: [{'role': 'user', 'content': 'This is my first conversation'}, {'role': 'assistant', 'content': 'This is the response'}]
```

The assistant message should have been "This is the response for the first conversation." but was truncated.

## Root Cause
The `wait_for_conversation_saved()` method was doing a page reload to check if the conversation appeared in the sidebar. This reload could happen before the streaming response was fully processed and saved to the database, causing the message to appear truncated when loaded after the reload.

## Solution
Modified `wait_for_conversation_saved()` to call `wait_for_streaming_complete()` before doing the page reload. This ensures the message is fully processed and saved before checking the sidebar.

## Testing
Tested with 20 consecutive runs using pytest-flakefinder - all passed successfully:
```bash
pytest tests/functional/web/test_chat_ui_flow.py::test_conversation_persistence_and_switching --flake-finder --flake-runs=20 -xq --postgres
# Result: 20 passed in 176.44s
```

🤖 Generated with [Claude Code](https://claude.ai/code)