### PR TITLE
Fix flaky tests and VCR configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1082,6 +1082,10 @@ async def radicale_server(
 @pytest.fixture(scope="module")
 def vcr_config() -> dict[str, Any]:
     """Configure VCR for recording and replaying HTTP interactions."""
+    # Only use "once" mode if explicitly requested via environment variable
+    # Default to "none" mode which will only use existing cassettes
+    record_mode = os.getenv("VCR_RECORD_MODE", "none")
+
     return {
         # Filter sensitive headers
         "filter_headers": [
@@ -1093,8 +1097,8 @@ def vcr_config() -> dict[str, Any]:
         ],
         # Filter sensitive query parameters
         "filter_query_parameters": ["api_key", "key"],
-        # Default to "once" mode - record if cassette doesn't exist
-        "record_mode": os.getenv("VCR_RECORD_MODE", "once"),
+        # Default to "none" mode - only replay existing cassettes, don't record
+        "record_mode": record_mode,
         # Match requests on these attributes
         "match_on": ["method", "scheme", "host", "port", "path", "query", "body"],
         # Store cassettes in organized directory structure

--- a/tests/functional/indexing/test_email_indexing.py
+++ b/tests/functional/indexing/test_email_indexing.py
@@ -558,11 +558,27 @@ async def test_vector_ranking(
     logger.info("\n--- Running Vector Ranking Test ---")
 
     # --- Arrange: Mock Embeddings ---
-    # Create embeddings with controlled distances
-    base_vec = np.random.rand(TEST_EMBEDDING_DIMENSION).astype(np.float32)
-    vec_close = (base_vec + np.random.rand(TEST_EMBEDDING_DIMENSION) * 0.01).tolist()
-    vec_medium = (base_vec + np.random.rand(TEST_EMBEDDING_DIMENSION) * 0.1).tolist()
-    vec_far = (base_vec + np.random.rand(TEST_EMBEDDING_DIMENSION) * 0.5).tolist()
+    # Create embeddings with controlled distances using deterministic vectors
+    # Use a fixed seed for reproducibility
+    rng = np.random.RandomState(42)
+    base_vec = rng.rand(TEST_EMBEDDING_DIMENSION).astype(np.float32)
+
+    # Create vectors with deterministic offsets to ensure proper ordering
+    # vec_close is very close to base_vec
+    vec_close = base_vec.copy()
+    vec_close[0] += 0.01  # Small deterministic offset
+    vec_close = vec_close.tolist()
+
+    # vec_medium is further from base_vec
+    vec_medium = base_vec.copy()
+    vec_medium[0] += 0.3  # Medium deterministic offset
+    vec_medium = vec_medium.tolist()
+
+    # vec_far is furthest from base_vec
+    vec_far = base_vec.copy()
+    vec_far[0] += 0.8  # Large deterministic offset
+    vec_far = vec_far.tolist()
+
     query_vec = base_vec.tolist()  # Query is the base vector
 
     email1_body = "Content for the closest document."
@@ -576,10 +592,18 @@ async def test_vector_ranking(
     email2_title = "Rank Test Medium"
     email3_title = "Rank Test Far"
 
-    # Add mock embeddings for titles
-    title1_vec = (base_vec + np.random.rand(TEST_EMBEDDING_DIMENSION) * 0.05).tolist()
-    title2_vec = (base_vec + np.random.rand(TEST_EMBEDDING_DIMENSION) * 0.06).tolist()
-    title3_vec = (base_vec + np.random.rand(TEST_EMBEDDING_DIMENSION) * 0.07).tolist()
+    # Add mock embeddings for titles (also deterministic)
+    title1_vec = base_vec.copy()
+    title1_vec[1] += 0.02  # Small offset on different dimension
+    title1_vec = title1_vec.tolist()
+
+    title2_vec = base_vec.copy()
+    title2_vec[1] += 0.25  # Medium offset on different dimension
+    title2_vec = title2_vec.tolist()
+
+    title3_vec = base_vec.copy()
+    title3_vec[1] += 0.7  # Large offset on different dimension
+    title3_vec = title3_vec.tolist()
 
     embedding_map = {
         email1_body: vec_close,

--- a/tests/functional/indexing/test_reindexing.py
+++ b/tests/functional/indexing/test_reindexing.py
@@ -196,6 +196,7 @@ async def test_reindex_document_e2e(
         calendar_config={},
         timezone_str="UTC",
         embedding_generator=mock_embedding_generator,
+        engine=pg_vector_db_engine,
     )
     worker.register_task_handler(
         "process_uploaded_document", buggy_indexer.process_document


### PR DESCRIPTION
## Summary
- Fixed VCR configuration to prevent tests from attempting to record without explicit permission
- Fixed flaky reindexing test by passing correct database engine to TaskWorker
- Fixed flaky vector ranking test by using deterministic embeddings

## Details

### VCR Configuration Fix
Changed the default VCR record mode from "once" to "none". This prevents tests from trying to record new cassettes when API keys are not available, which was causing test failures in CI and development environments.

### Reindexing Test Fix
The `test_reindex_document_e2e` test was failing because the TaskWorker was not being passed the test database engine parameter. This caused it to use the default engine instead of the test-specific PostgreSQL database, leading to tasks not being picked up.

### Vector Ranking Test Fix
The `test_vector_ranking` test was using random vectors for embeddings, which made the distance calculations non-deterministic. Replaced with fixed offsets to ensure consistent ordering in vector similarity tests.

## Test plan
- [x] Run `pytest tests/functional/indexing/test_reindexing.py::test_reindex_document_e2e -xq --postgres` - passes
- [x] Run `pytest tests/functional/indexing/test_email_indexing.py::test_vector_ranking -xq --postgres` - passes
- [x] Run `pytest tests/integration/llm/test_providers.py::test_basic_completion -xq` - passes without trying to record

🤖 Generated with [Claude Code](https://claude.ai/code)