### PR TITLE
Fix navigation menu text wrapping and dropdown positioning

### DIFF
--- a/frontend/src/components/ui/navigation-menu.tsx
+++ b/frontend/src/components/ui/navigation-menu.tsx
@@ -34,7 +34,7 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
 const navigationMenuTriggerStyle = cva(
-  'group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50'
+  'group inline-flex h-10 items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50 whitespace-nowrap'
 );
 
 const NavigationMenuTrigger = React.forwardRef<
@@ -58,7 +58,7 @@ const NavigationMenuContent = React.forwardRef<
   <NavigationMenuPrimitive.Content
     ref={ref}
     className={cn(
-      'top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto',
+      'left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto',
       className
     )}
     {...props}
@@ -85,10 +85,10 @@ const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => (
-  <div className="absolute left-0 top-full flex w-full justify-start">
+  <div className="absolute left-0 top-full flex justify-center">
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        'relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-[var(--radix-navigation-menu-viewport-width)] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90',
+        'origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-auto',
         className
       )}
       ref={ref}

--- a/frontend/src/shared/Layout.tsx
+++ b/frontend/src/shared/Layout.tsx
@@ -78,12 +78,12 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         {/* Desktop Navigation */}
         <div className="hidden md:block">
           <NavigationMenu className="mx-auto max-w-full">
-            <NavigationMenuList className="flex-nowrap justify-start gap-2 px-4 py-3 overflow-x-auto">
+            <NavigationMenuList className="flex-nowrap justify-start gap-1 px-4 py-3 overflow-x-auto">
               {/* Assistant Data */}
               <NavigationMenuItem>
-                <NavigationMenuTrigger className="text-sm">
-                  <FileText className="mr-2 h-4 w-4" />
-                  Data
+                <NavigationMenuTrigger className="text-sm whitespace-nowrap">
+                  <FileText className="mr-2 h-4 w-4 flex-shrink-0" />
+                  <span className="whitespace-nowrap">Data</span>
                 </NavigationMenuTrigger>
                 <NavigationMenuContent>
                   <div className="grid gap-3 p-4 w-[200px]">
@@ -107,9 +107,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
               {/* Documents */}
               <NavigationMenuItem>
-                <NavigationMenuTrigger className="text-sm">
-                  <FolderOpen className="mr-2 h-4 w-4" />
-                  Documents
+                <NavigationMenuTrigger className="text-sm whitespace-nowrap">
+                  <FolderOpen className="mr-2 h-4 w-4 flex-shrink-0" />
+                  <span className="whitespace-nowrap">Documents</span>
                 </NavigationMenuTrigger>
                 <NavigationMenuContent>
                   <div className="grid gap-3 p-4 w-[200px]">
@@ -143,19 +143,19 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                   <NavLink
                     to="/chat"
                     isActive={currentPage === 'chat'}
-                    className="whitespace-nowrap"
+                    className="whitespace-nowrap inline-flex items-center"
                   >
-                    <MessageCircle className="mr-2 h-4 w-4" />
-                    Chat
+                    <MessageCircle className="mr-2 h-4 w-4 flex-shrink-0" />
+                    <span className="whitespace-nowrap">Chat</span>
                   </NavLink>
                 </NavigationMenuLink>
               </NavigationMenuItem>
 
               <NavigationMenuItem>
                 <NavigationMenuLink asChild>
-                  <ExternalNavLink href="/history">
-                    <History className="mr-2 h-4 w-4" />
-                    History
+                  <ExternalNavLink href="/history" className="inline-flex items-center">
+                    <History className="mr-2 h-4 w-4 flex-shrink-0" />
+                    <span className="whitespace-nowrap">History</span>
                   </ExternalNavLink>
                 </NavigationMenuLink>
               </NavigationMenuItem>
@@ -164,9 +164,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
               {/* Automation */}
               <NavigationMenuItem>
-                <NavigationMenuTrigger className="text-sm">
-                  <Zap className="mr-2 h-4 w-4" />
-                  Automation
+                <NavigationMenuTrigger className="text-sm whitespace-nowrap">
+                  <Zap className="mr-2 h-4 w-4 flex-shrink-0" />
+                  <span className="whitespace-nowrap">Automation</span>
                 </NavigationMenuTrigger>
                 <NavigationMenuContent>
                   <div className="grid gap-3 p-4 w-[200px]">
@@ -190,9 +190,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
               {/* Internal/Admin */}
               <NavigationMenuItem>
-                <NavigationMenuTrigger className="text-sm">
-                  <Cog className="mr-2 h-4 w-4" />
-                  Internal
+                <NavigationMenuTrigger className="text-sm whitespace-nowrap">
+                  <Cog className="mr-2 h-4 w-4 flex-shrink-0" />
+                  <span className="whitespace-nowrap">Internal</span>
                 </NavigationMenuTrigger>
                 <NavigationMenuContent>
                   <div className="grid gap-3 p-4 w-[200px]">
@@ -223,9 +223,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
               {/* Help */}
               <NavigationMenuItem>
                 <NavigationMenuLink asChild>
-                  <ExternalNavLink href="/docs/">
-                    <HelpCircle className="mr-2 h-4 w-4" />
-                    Help
+                  <ExternalNavLink href="/docs/" className="inline-flex items-center">
+                    <HelpCircle className="mr-2 h-4 w-4 flex-shrink-0" />
+                    <span className="whitespace-nowrap">Help</span>
                   </ExternalNavLink>
                 </NavigationMenuLink>
               </NavigationMenuItem>


### PR DESCRIPTION
## Summary
- Fixed text wrapping issue in navigation menu items (especially "Chat" menu item)
- Improved dropdown menu positioning to appear closer to parent menu items
- Enhanced overall navigation bar layout and consistency

## Changes Made
1. **Navigation Menu Component (`navigation-menu.tsx`)**:
   - Added `whitespace-nowrap` to trigger styles to prevent text wrapping
   - Adjusted viewport positioning for better dropdown alignment
   - Added `origin-top-center` for proper animation origin

2. **Layout Component (`Layout.tsx`)**:
   - Wrapped menu item text in `<span>` elements with `whitespace-nowrap`
   - Added `flex-shrink-0` to icons to prevent them from shrinking
   - Improved spacing between menu items
   - Ensured consistent styling across all navigation items

## Test Results
- All tests pass successfully ✅
- Frontend build completes without errors
- Visual testing confirms fixes work as expected

## Screenshots
Before: Chat text was wrapping to a second line, dropdowns appeared at far left
After: All menu items display on single line, dropdowns appear closer to their triggers

🤖 Generated with [Claude Code](https://claude.ai/code)