### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add dependabot.yml to keep uv, npm, GitHub Actions, and Docker dependencies updated weekly
- include devcontainer Dockerfiles in dependabot checks

## Testing
- `uvx pre-commit run --files .github/dependabot.yml`
- `uvx --with '.[dev]' pytest tests/unit -xq` *(fails: Alembic config file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2984844088330bdad4078bb5854dd