### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary
- add dependabot.yml to keep uv, npm, GitHub Actions, and Docker dependencies updated daily
- include devcontainer Dockerfiles in dependabot checks

## Testing
- `uvx pre-commit run --files .github/dependabot.yml`
- `uvx --with '.[dev]' pytest tests/unit -xq` *(fails: hangs while bringing up nodes)*

------
https://chatgpt.com/codex/tasks/task_e_68b2984844088330bdad4078bb5854dd