### PR TITLE
feat: add frontend Vitest test suite to CI workflow

### DIFF
--- a/.github/workflows/ci-with-devcontainer.yml
+++ b/.github/workflows/ci-with-devcontainer.yml
@@ -84,6 +84,44 @@ jobs:
                 ln -s /opt/frontend/node_modules frontend/node_modules; \
               fi && \
               scripts/format-and-lint.sh'
+  test-frontend:
+    needs: [prepare, build-devcontainer]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run frontend tests in devcontainer
+        run: |
+          docker run \
+            --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -e CLAUDE_PROJECT_REPO="" \
+            -e UV_CACHE_DIR=/opt/uv-cache \
+            -e CI=true \
+            -u claude \
+            ${{ needs.prepare.outputs.image-name }} \
+            bash -c 'cd /workspace && \
+              if [ -d "/opt/frontend/node_modules" ] && [ ! -d "frontend/node_modules" ]; then \
+                echo "Symlinking pre-installed node_modules for frontend tests..."; \
+                ln -s /opt/frontend/node_modules frontend/node_modules; \
+              fi && \
+              mkdir -p test-results && \
+              npm test --prefix frontend -- --run --reporter=json --reporter=verbose --outputFile=test-results/frontend-report.json'
+      - name: Upload frontend test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: frontend-test-results-${{ github.run_id }}
+          path: test-results/frontend-report.json
+          retention-days: 7
+          if-no-files-found: ignore
   test-sqlite:
     needs: [prepare, build-devcontainer]
     runs-on: ubuntu-latest
@@ -219,13 +257,14 @@ jobs:
           echo "💡 Download with: gh run download ${{ github.run_id }} --name playwright-artifacts-postgres-${{ github.run_id }}"
   # Require all test jobs to pass
   all-tests:
-    needs: [lint, test-sqlite, test-postgres]
+    needs: [lint, test-frontend, test-sqlite, test-postgres]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check all tests passed
         run: |
           if [[ "${{ needs.lint.result }}" != "success" || \
+                "${{ needs.test-frontend.result }}" != "success" || \
                 "${{ needs.test-sqlite.result }}" != "success" || \
                 "${{ needs.test-postgres.result }}" != "success" ]]; then
             echo "One or more test jobs failed"


### PR DESCRIPTION
## Summary
- Added frontend Vitest test suite to CI pipeline
- Tests now run automatically on every push and pull request
- Configured dual reporting (JSON + verbose) for better debugging

## Changes
- **New `test-frontend` job**: Runs Vitest tests in the devcontainer environment
- **Dual reporting**: Outputs both JSON (for artifacts) and verbose (for human-readable logs) in a single test run
- **Test artifacts**: Uploads JSON test results for debugging failed tests
- **Updated dependency check**: `all-tests` job now includes frontend tests as a requirement

## Test plan
- [x] Verified frontend tests run locally with `npm test --prefix frontend`
- [x] Confirmed dual reporter setup works (JSON + verbose output)
- [x] Ran full test suite with `poe test` - all tests pass
- [x] Validated CI YAML syntax

This ensures frontend React component tests are part of the CI process, catching UI issues early in development.

🤖 Generated with [Claude Code](https://claude.ai/code)