### PR TITLE
Fix document reindex task ID collision error

### DIFF
--- a/src/family_assistant/web/routers/documents_api.py
+++ b/src/family_assistant/web/routers/documents_api.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import pathlib
+import uuid
 from datetime import date, datetime, timezone
 from typing import Annotated, Any
 
@@ -181,7 +182,7 @@ async def reindex_document(
     API endpoint to re-index a document.
     """
     await db_context.tasks.enqueue(
-        task_id=f"reindex_document_{document_id}",
+        task_id=f"reindex_document_{document_id}_{uuid.uuid4()}",
         task_type="reindex_document",
         payload={"document_id": document_id},
     )


### PR DESCRIPTION
## Summary
Fixes the `RuntimeError: Task ID 'reindex_document_194' already exists` error that occurs when users attempt to reindex the same document multiple times.

## Changes
- Import `uuid` module in `documents_api.py`
- Update task ID format from `f"reindex_document_{document_id}"` to `f"reindex_document_{document_id}_{uuid.uuid4()}"`

## Why this fix
- **Eliminates task ID collisions**: Each reindex request now generates a unique task ID
- **Consistent with codebase**: Follows existing patterns used throughout the project (e.g., `index_note_{id}_{uuid.uuid4()}`, `reindex-doc-{id}-{uuid.uuid4()}`)
- **Preserves task history**: Multiple reindex attempts are stored as separate tasks rather than failing

## Testing
- ✅ All tests pass (977 passed, 25 skipped)
- ✅ Unit test verified that task IDs are unique across multiple calls
- ✅ Code quality checks pass (linting, formatting, type checking)

## Test plan
- [x] Verify task ID generation produces unique UUIDs for same document
- [x] Confirm existing reindexing functionality still works
- [x] Ensure no regressions in related tests
- [x] Validate code follows project patterns and style guidelines

Users can now reindex documents multiple times without encountering task ID collision errors.

🤖 Generated with [Claude Code](https://claude.ai/code)