### PR TITLE
chore: use nightly gemini cli in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -90,7 +90,7 @@ ENV PATH="/usr/local/bin:/home/claude/.local/bin:/usr/lib/postgresql/17/bin:$PAT
 
 # Install Claude Code CLI and LLM tools as claude user
 # Pin playwright to 1.55.0 to match Python version
-RUN npm install -g @anthropic-ai/claude-code @google/gemini-cli playwright@1.55.0 && \
+RUN npm install -g @anthropic-ai/claude-code @google/gemini-cli@nightly playwright@1.55.0 && \
     uv tool install --with llm-gemini --with llm-openrouter --with llm-fragments-github llm
 
 # Set Playwright browsers path to user's home to avoid permission issues

--- a/.devcontainer/setup-workspace.sh
+++ b/.devcontainer/setup-workspace.sh
@@ -40,7 +40,7 @@ if [ "$HOME_IS_MOUNTED" = "true" ] && [ ! -f "/home/claude/.npm-global/bin/claud
     
     # Install tools
     npm install -g @anthropic-ai/claude-code
-    npm install -g @google/gemini-cli
+    npm install -g @google/gemini-cli@nightly
     npm install -g playwright
     
     # Install Playwright browsers


### PR DESCRIPTION
## Summary
- use @google/gemini-cli@nightly in setup-workspace script
- pin devcontainer Dockerfile to @google/gemini-cli@nightly

## Testing
- `bash -n .devcontainer/setup-workspace.sh`
- `pytest tests/unit/test_llm_multimodal_processing.py -xq` *(fails: ModuleNotFoundError: No module named 'family_assistant')*


------
https://chatgpt.com/codex/tasks/task_e_68ba800544648330ae2455c7d94431b3