### PR TITLE
fix: eliminate race condition in web test port binding

### DIFF
--- a/src/family_assistant/assistant.py
+++ b/src/family_assistant/assistant.py
@@ -3,6 +3,7 @@ import contextlib
 import copy
 import logging
 import os
+import socket
 from datetime import datetime, timezone
 from typing import Any
 
@@ -140,7 +141,7 @@ class Assistant:
         config: dict[str, Any],
         llm_client_overrides: dict[str, LLMInterface] | None = None,
         database_engine: AsyncEngine | None = None,
-        server_socket: Any | None = None,
+        server_socket: socket.socket | None = None,
     ) -> None:
         self.config = config
         self._injected_database_engine = database_engine

--- a/tests/functional/web/conftest.py
+++ b/tests/functional/web/conftest.py
@@ -110,8 +110,6 @@ def find_free_port_with_socket() -> tuple[int, socket.socket]:
     Returns:
         tuple[int, socket.socket]: Port number and bound socket. Caller must close the socket.
     """
-    import socket
-
     # Simple approach: let the OS choose a free port and keep the socket bound
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
## Summary

Fixes the failing CI test `test_profile_switching_creates_new_conversation` that was experiencing a race condition where the port returned by `find_free_port()` could be claimed by another process before uvicorn started, resulting in "address already in use" errors.

## Changes

- **Added `find_free_port_with_socket()`** - Returns both port and bound socket to prevent race conditions
- **Added `api_socket_and_port` fixture** - Manages socket lifecycle properly throughout test execution  
- **Modified Assistant class** - Accepts optional `server_socket` parameter
- **Updated uvicorn configuration** - Uses pre-bound socket via file descriptor when available
- **Simplified port allocation** - Removed complex worker-specific port ranges since socket stays bound

## Root Cause

The original `find_free_port()` function had a Time-of-check to time-of-use (TOCTOU) race condition:
1. Creates socket, binds to check if port is free
2. **Immediately closes socket** (race condition window)
3. Returns port number
4. Another process could claim the port before uvicorn starts

## Solution

Keep the socket open and pass it directly to uvicorn, completely eliminating the race condition window.

## Test Results

✅ Local test of the failing test now passes consistently
✅ Full test suite passes (`poe test` - 627 tests, 3 skipped)
✅ All linting and type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)