### PR TITLE
fix: change search_documents tool parameter from query_text to query

### DIFF
--- a/frontend/src/test/toolTestData.js
+++ b/frontend/src/test/toolTestData.js
@@ -403,7 +403,7 @@ export const toolTestCases = {
         type: 'function',
         function: {
           name: 'search_documents',
-          arguments: '{"source_types": ["email"], "query_text": "school newsletter"}',
+          arguments: '{"source_types": ["email"], "query": "school newsletter"}',
         },
       },
       tool_response: {
@@ -421,7 +421,7 @@ export const toolTestCases = {
         type: 'function',
         function: {
           name: 'search_documents',
-          arguments: '{"source_types": ["email"], "query_text": "Welcome 1L to Term 3"}',
+          arguments: '{"source_types": ["email"], "query": "Welcome 1L to Term 3"}',
         },
       },
       tool_response: {
@@ -439,7 +439,7 @@ export const toolTestCases = {
         type: 'function',
         function: {
           name: 'search_documents',
-          arguments: '{"query_text": "Term 2 2025 dates"}',
+          arguments: '{"query": "Term 2 2025 dates"}',
         },
       },
       tool_response: {

--- a/tests/functional/indexing/test_document_retrieval.py
+++ b/tests/functional/indexing/test_document_retrieval.py
@@ -133,7 +133,7 @@ class TestDocumentRetrieval:
             search_results = await search_documents_tool(
                 exec_context=exec_context,
                 embedding_generator=mock_embedding_generator,
-                query_text="test PDF document",
+                query="test PDF document",
                 limit=5,
             )
 
@@ -281,7 +281,7 @@ class TestDocumentRetrieval:
             search_results = await search_documents_tool(
                 exec_context=exec_context,
                 embedding_generator=mock_embedding_generator,
-                query_text="test text document",
+                query="test text document",
                 limit=5,
             )
 

--- a/tests/functional/test_vector_storage.py
+++ b/tests/functional/test_vector_storage.py
@@ -374,7 +374,7 @@ async def test_search_documents_tool(pg_vector_db_engine: AsyncEngine) -> None:
         logger.info(f"Executing search_documents tool with query: '{test_query}'")
         tool_result = await local_provider.execute_tool(
             name="search_documents",
-            arguments={"query_text": test_query},  # Pass arguments as dict
+            arguments={"query": test_query},  # Pass arguments as dict
             context=tool_context,
         )
 


### PR DESCRIPTION
## Summary
- Fixed parameter mismatch in `search_documents` tool where LLM was calling with `query` but tool expected `query_text`
- This was causing "unexpected keyword argument" errors when the LLM tried to use the search tool

## Changes
- Updated tool definition parameter name from `query_text` to `query`
- Updated function signature and all internal references  
- Fixed tests to use new parameter name
- Updated frontend test data to match new parameter

## Test plan
- [x] All tests pass (989 passed, 2 skipped)
- [x] Frontend tests pass (169 passed, 3 skipped)  
- [x] Linting passes
- [x] Verified web UI already correctly displays `args.query`, so no UI changes needed

🤖 Generated with [Claude Code](https://claude.ai/code)