### PR TITLE
Ensure tool execution records include processing profile

### DIFF
--- a/src/family_assistant/processing.py
+++ b/src/family_assistant/processing.py
@@ -616,6 +616,7 @@ class ProcessingService:
             db_context=db_context,
             chat_interface=chat_interface,
             timezone_str=self.timezone_str,
+            processing_profile_id=self.service_config.id,
             request_confirmation_callback=request_confirmation_callback,
             processing_service=self,
             clock=self.clock,

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -524,6 +524,11 @@ class TaskWorker:
                 db_context=db_context,
                 chat_interface=self.chat_interface,
                 timezone_str=self.timezone_str,
+                processing_profile_id=(
+                    self.processing_service.service_config.id
+                    if self.processing_service
+                    else None
+                ),
                 update_activity_callback=self._update_last_activity,  # Pass activity callback
                 processing_service=self.processing_service,
                 embedding_generator=self.embedding_generator,

--- a/src/family_assistant/tools/types.py
+++ b/src/family_assistant/tools/types.py
@@ -56,6 +56,9 @@ class ToolExecutionContext:
     chat_interface: Optional["ChatInterface"] = None  # Replaced application
     # Add other context elements as needed, e.g., timezone_str
     timezone_str: str = "UTC"  # Default, should be overridden
+    processing_profile_id: str | None = (
+        None  # Processing profile associated with the request
+    )
     request_confirmation_callback: (
         Callable[
             [

--- a/tests/functional/telegram/test_telegram_send_message_tool.py
+++ b/tests/functional/telegram/test_telegram_send_message_tool.py
@@ -213,6 +213,17 @@ async def test_send_message_to_user_tool(
     try:
         await fix.handler.message_handler(update_alice, context_alice)
 
+        async with fix.get_db_context_func() as db_context:
+            bob_history_all = await db_context.message_history.get_recent(
+                interface_type="telegram",
+                conversation_id=str(bob_chat_id),
+            )
+            bob_history_filtered = await db_context.message_history.get_recent(
+                interface_type="telegram",
+                conversation_id=str(bob_chat_id),
+                processing_profile_id=fix.processing_service.service_config.id,
+            )
+
         # Assert
         with soft_assertions():  # type: ignore[attr-defined]
             # 1. LLM Calls
@@ -271,6 +282,17 @@ async def test_send_message_to_user_tool(
 
             # 3. Confirmation Manager (should not be called for this tool by default)
             fix.mock_confirmation_manager.request_confirmation.assert_not_awaited()
+
+            # 4. Message history records include processing profile identifier
+            assert_that(bob_history_all).described_as(
+                "History entries for Bob's conversation"
+            ).is_not_empty()
+            assert_that(bob_history_filtered).described_as(
+                "History entries when filtering by processing profile"
+            ).is_not_empty()
+            assert_that([
+                msg.get("processing_profile_id") for msg in bob_history_all
+            ]).contains(fix.processing_service.service_config.id)
     finally:
         # Restore original context providers
         fix.processing_service.context_providers = original_providers


### PR DESCRIPTION
## Summary
- propagate the active processing profile ID through `ToolExecutionContext` creation, including background task executions, so tool history is recorded under the correct profile
- extend the send_message_to_user functional test to verify history queries succeed when filtering by processing profile

## Testing
- PYTHONPATH=src pytest tests/functional/telegram/test_telegram_send_message_tool.py -xq --db sqlite -n 0

------
https://chatgpt.com/codex/tasks/task_e_68d2633edc5883309ab743920d2399a9