### PR TITLE
Prevent stash restore conflicts from leaving dirty tree

### DIFF
--- a/.claude/review-hook.py
+++ b/.claude/review-hook.py
@@ -131,6 +131,17 @@ class ReviewHook:
             print("✅ Stashed changes restored successfully", file=sys.stderr)
         else:
             print("⚠️ Failed to restore stashed changes cleanly", file=sys.stderr)
+            # If stash apply fails it can leave conflict markers behind. Clean up the
+            # working tree by restoring the index contents so the user keeps their
+            # staged/ formatted changes without conflict artifacts.
+            cleanup = subprocess.run(
+                ["git", "checkout-index", "-a", "-f"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if cleanup.returncode != 0 and cleanup.stderr:
+                print(cleanup.stderr, file=sys.stderr)
             print(
                 f"Your changes are preserved in stash: {self.stash_ref[:8]}",
                 file=sys.stderr,


### PR DESCRIPTION
## Summary
- clean up the working tree if restoring the temporary stash fails
- keep staged formatting intact by resetting the worktree to the index when a stash apply conflict occurs

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3911f1fe48330afb42540ef6a475b