### PR TITLE
Fix dependabot config to reduce PR spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "monthly"
       day: "monday"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 14
       semver-major-days: 30
@@ -22,10 +22,21 @@ updates:
           - "pytest*"
           - "mypy*"
           - "basedpyright*"
+      python-types:
+        patterns:
+          - "types-*"
+      python-web-framework:
+        patterns:
+          - "fastapi*"
+          - "starlette*"
+          - "uvicorn*"
+          - "httpx*"
       python-updates:
         update-types:
           - "minor"
           - "patch"
+        patterns:
+          - "*"
         exclude-patterns:
           - "pylint*"
           - "ruff*"
@@ -35,12 +46,17 @@ updates:
           - "pytest*"
           - "mypy*"
           - "basedpyright*"
+          - "types-*"
+          - "fastapi*"
+          - "starlette*"
+          - "uvicorn*"
+          - "httpx*"
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
       interval: "monthly"
       day: "wednesday"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 14
       semver-major-days: 30
@@ -60,15 +76,18 @@ updates:
         patterns:
           - "@testing-library/*"
           - "@biomejs/*"
-          - "eslint*"
+          - "*eslint*"
           - "vite*"
           - "tailwindcss*"
           - "jsdom*"
           - "@types/*"
+          - "msw*"
       frontend-updates:
         update-types:
           - "minor"
           - "patch"
+        patterns:
+          - "*"
         exclude-patterns:
           - "react*"
           - "@types/react*"
@@ -78,11 +97,12 @@ updates:
           - "react-router*"
           - "@testing-library/*"
           - "@biomejs/*"
-          - "eslint*"
+          - "*eslint*"
           - "vite*"
           - "tailwindcss*"
           - "jsdom*"
           - "@types/*"
+          - "msw*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -91,7 +111,6 @@ updates:
     open-pull-requests-limit: 1
     cooldown:
       default-days: 14
-      semver-major-days: 30
     groups:
       github-actions:
         update-types:
@@ -105,7 +124,6 @@ updates:
     open-pull-requests-limit: 2
     cooldown:
       default-days: 14
-      semver-major-days: 60
   - package-ecosystem: "docker"
     directory: "/.devcontainer"
     schedule:
@@ -113,4 +131,4 @@ updates:
     open-pull-requests-limit: 1
     cooldown:
       default-days: 30
-      semver-major-days: 90
+


### PR DESCRIPTION
## Summary

This PR fixes the dependabot configuration to drastically reduce the number of individual PRs from 5-10 per month to 1-2 grouped PRs per ecosystem.

## Changes

### Configuration Fixes
- Removed unsupported `semver-major-days` from `github-actions` ecosystem (was causing validation errors)
- Removed unsupported `semver-major-days` from both `docker` ecosystems (was causing validation errors)

### Improved Grouping for Python/uv
- Added `python-types` group to catch all `types-*` packages (types-python-dateutil, types-aiofiles, etc.)
- Added `python-web-framework` group for fastapi, starlette, uvicorn, httpx
- Added wildcard pattern `*` to `python-updates` catch-all group to ensure everything is grouped

### Improved Grouping for Frontend/npm
- Fixed pattern `eslint*` → `*eslint*` to properly catch `typescript-eslint`
- Added `msw*` to `frontend-dev-tools` group
- Added wildcard pattern `*` to `frontend-updates` catch-all group to ensure everything is grouped

### Stricter Limits
- Reduced `open-pull-requests-limit` from 2 → 1 for both `uv` and `npm` ecosystems

## Expected Impact

Instead of receiving 5-10 individual dependabot PRs on schedule day, you should now get at most **1 grouped PR per ecosystem per month**:

- **Python (Monday)**: One PR containing either dev tools, type stubs, web framework updates, or other minor/patch updates
- **Frontend (Wednesday)**: One PR containing either React ecosystem, dev tools, or other minor/patch updates
- **GitHub Actions (Friday)**: One PR with all action updates grouped together
- **Docker**: Updates grouped by directory

The cooldown settings will continue to help spread updates over time rather than all at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)