### PR TITLE
fix: Increase delays in multiple messages test for CI reliability

### DIFF
--- a/frontend/src/chat/__tests__/ChatApp.test.tsx
+++ b/frontend/src/chat/__tests__/ChatApp.test.tsx
@@ -147,14 +147,18 @@ describe('ChatApp', () => {
     // NOTE: This delay is necessary for @assistant-ui/react's internal state to fully settle
     // after streaming completes. Even though the input appears enabled and empty, the library
     // needs additional time before it can successfully accept and submit a new message.
-    // This mirrors similar delays in the Playwright tests (wait_for_timeout after typing).
-    // Without this, pressing Enter after typing doesn't submit the message.
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    // The Playwright tests have a 3000ms wait in send_message after pressing Enter, which gives
+    // the library time to process the response before the next message starts.
+    // Without sufficient delay, pressing Enter after typing doesn't submit the message.
+    await new Promise((resolve) => setTimeout(resolve, 2000));
 
     // Get a fresh reference and send second message
     const input2 = screen.getByPlaceholderText('Write a message...');
     await user.click(input2);
     await user.type(input2, 'Second message');
+
+    // Wait for input processing before pressing Enter (matches Playwright send_message pattern)
+    await new Promise((resolve) => setTimeout(resolve, 500));
     await user.keyboard('{Enter}');
 
     // Wait for second message to be sent


### PR DESCRIPTION
## Summary

Fixes the failing "handles multiple messages in a conversation" test in CI that was introduced in #259.

The test was failing in CI because the 500ms delay between messages wasn't sufficient. This PR increases the delays to match the Playwright test timing:

- 2000ms between messages (down from Playwright's 3000ms, but still sufficient)
- 500ms after typing before pressing Enter (matches Playwright's pattern)

## Context

The Playwright test's `send_message` method has:
- 500ms wait after typing, before pressing Enter
- 3000ms wait after pressing Enter

Between sending two messages, there's at minimum 3000ms + typing time. The increased delays mirror this pattern.

## Why Fixed Delays

These delays are necessary workarounds for @assistant-ui/react's internal state management. Multiple attempts to find observable conditions to wait for (message count, loading indicators, input enabled/empty) were unsuccessful - the library needs time for internal state settling that has no visible DOM manifestation.

The Playwright tests use the same pattern and work reliably.

## Testing

- ✅ Test passes locally (3.57s duration)
- ✅ All other ChatApp tests still pass
- ✅ Waiting for CI to confirm fix