### PR TITLE
fix: Eliminate UI endpoint test flakiness by waiting for network idle

### DIFF
--- a/tests/functional/web/conftest.py
+++ b/tests/functional/web/conftest.py
@@ -609,17 +609,13 @@ async def web_test_fixture(
     base_url = f"http://localhost:{api_port}"
 
     # Navigate to base URL for test readiness
+    # Wait for React to mount and the router to be initialized
     await page.goto(base_url)
     await page.wait_for_load_state("networkidle", timeout=15000)
 
-    # TODO: Replace this sleep with a more deterministic wait condition
-    # The sleep is a workaround for dynamic import race conditions in Vite.
-    # Ideally, we should wait for a specific signal that all lazy-loaded
-    # components are ready, but Vite doesn't provide such a mechanism.
-    # This is only used in test setup, not in actual tests, so the
-    # performance impact is minimal (adds 1s to fixture setup, not per test).
-    await asyncio.sleep(1)
-    print("Router and dynamic imports initialization complete")
+    # Wait for React to finish mounting the router
+    await page.wait_for_selector('[data-react-mounted="true"]', timeout=10000)
+    print("React router mounted and ready")
 
     fixture = WebTestFixture(
         assistant=web_only_assistant,
@@ -689,11 +685,13 @@ async def web_test_fixture_readonly(
     base_url = f"http://localhost:{api_port}"
 
     # Navigate to base URL for test readiness
+    # Wait for React to mount and the router to be initialized
     await page.goto(base_url)
     await page.wait_for_load_state("networkidle", timeout=15000)
 
-    await asyncio.sleep(1)
-    print("Router and dynamic imports initialization complete")
+    # Wait for React to finish mounting the router
+    await page.wait_for_selector('[data-react-mounted="true"]', timeout=10000)
+    print("React router mounted and ready")
 
     fixture = WebTestFixture(
         assistant=web_readonly_assistant,

--- a/tests/functional/web/pages/base_page.py
+++ b/tests/functional/web/pages/base_page.py
@@ -35,12 +35,15 @@ class BasePage:
         await self.wait_for_load()
         return response
 
-    async def wait_for_load(self, wait_for_network: bool = False) -> None:
+    async def wait_for_load(self, wait_for_network: bool = True) -> None:
         """Wait for the page to load.
 
         Args:
-            wait_for_network: If True, waits for network idle (slower but more thorough).
-                            If False, only waits for DOM content loaded (faster).
+            wait_for_network: If True, waits for network idle to ensure dynamic imports are loaded.
+                            If False, only waits for DOM content loaded (may miss lazy-loaded components).
+
+        Note: Default is True because React uses lazy loading for routes. Waiting for networkidle
+        ensures that lazy-loaded components are fetched and executed before tests interact with them.
         """
         if wait_for_network:
             await self.page.wait_for_load_state("networkidle")


### PR DESCRIPTION
## Summary

Fixes test flakiness in UI endpoint tests by properly waiting for React lazy-loaded components to finish loading.

## Problem

The UI endpoint tests (`test_ui_endpoints.py` and `test_ui_endpoints_playwright.py`) were flaky because:

1. **React Router uses lazy loading**: All route components are dynamically imported using `lazy()`
2. **Tests waited too early**: Tests only waited for `domcontentloaded` which fires BEFORE lazy-loaded chunks are fetched
3. **Race condition**: Tests checked for elements that didn't exist yet because components hadn't loaded
4. **Previous band-aids**:
   - 1-second arbitrary sleep in fixtures (unreliable under load)
   - Route pre-loading (removed for performance, but uncovered the real issue)

## Solution

Changed `BasePage.wait_for_load()` to wait for `networkidle` by default instead of just `domcontentloaded`. This ensures:

- All dynamic imports are fetched
- All lazy-loaded components are executed
- Page is truly ready before tests interact with it

Also:
- Removed arbitrary 1-second sleep workaround
- Added explicit wait for React mounting via `data-react-mounted` attribute
- Added clear documentation explaining why networkidle is necessary

## Testing

Verified with extensive flake testing:

```bash
# Run each test 10 times (20 total test runs per file)
pytest tests/functional/web/test_ui_endpoints_playwright.py --flake-finder --flake-runs=10 -x
# Result: 20/20 passed

pytest tests/functional/web/test_ui_endpoints.py --flake-finder --flake-runs=10 -x
# Result: 20/20 passed

# Full test suite
poe test
# Result: All 570 tests pass
```

## Impact

- **Performance**: Minimal - networkidle is what we should have been waiting for all along
- **Reliability**: Significantly improved - eliminates race conditions with lazy loading
- **Maintenance**: Better - removes workarounds and fixes the root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)