### PR TITLE
fix: Preserve JPEG format and resize oversized Telegram attachments

### DIFF
--- a/src/family_assistant/tools/image_tools.py
+++ b/src/family_assistant/tools/image_tools.py
@@ -180,6 +180,9 @@ async def highlight_image_tool(
         # Load image with PIL
         try:
             with Image.open(io.BytesIO(original_content)) as original_img:
+                # Save format before any conversion (e.g., "JPEG", "PNG")
+                original_format = original_img.format or "PNG"
+
                 # Convert to RGB if necessary for drawing
                 if original_img.mode != "RGB":
                     img = original_img.convert("RGB")
@@ -283,9 +286,16 @@ async def highlight_image_tool(
                             f"circle at ({center_x},{center_y}) radius {radius}{label_str} in {region.get('color', 'red')}"
                         )
 
-                # Save highlighted image to bytes
+                # Save highlighted image to bytes preserving original format
                 output_buffer = io.BytesIO()
-                highlighted_img.save(output_buffer, format="PNG")
+                if original_format == "JPEG":
+                    # Use JPEG with good quality and optimization for photos
+                    highlighted_img.save(
+                        output_buffer, format="JPEG", quality=85, optimize=True
+                    )
+                else:
+                    # Preserve other formats (PNG, etc.)
+                    highlighted_img.save(output_buffer, format=original_format)
                 highlighted_content = output_buffer.getvalue()
 
         except Exception as e:


### PR DESCRIPTION
## Problem
- **highlight_image tool converted JPEGs to PNG**: 4.1MB JPEG → 31.6MB PNG (8x size increase!)
- **Telegram rejects photos >10MB**: Attachments failed silently, users received nothing
- **No fallback mechanism**: When send failed, attachment was lost

## Root Cause
The `highlight_image` tool was saving all images as PNG (line 288 in image_tools.py), regardless of input format. This caused massive size increases for JPEG photos. When these oversized files hit Telegram's 10MB photo limit, the send failed and users got no feedback.

## Solution

### 1. Format Preservation (`image_tools.py`)
- Capture original format (`JPEG`, `PNG`, etc.) before any conversion
- Save highlighted images in their original format
- Use `quality=85, optimize=True` for JPEGs to maintain reasonable size
- **Result**: 4.1MB JPEG stays ~4MB, not 31.6MB PNG

### 2. Smart Image Resizing (`telegram_bot.py`)
- New `_resize_image_if_needed()` helper function
- Target ~20 megapixels (~8MB JPEG) - fits 10MB limit with safety margin
- Calculate target dimensions once based on megapixels (not iterative)
- Verify result is actually <10MB, fallback to document if not
- Generate caption with link to full-resolution attachment

### 3. Media Group Support  
- Restore `send_media_group` functionality (was removed in this branch)
- Resize each image before adding to media group
- Handle oversized images: exclude from group, send separately as documents
- Include **all** resize notes in caption (up to Telegram's 1024 char limit)
- Preserve `reply_to_message_id` for thread integrity

### 4. Code Quality
- Extract `TELEGRAM_PHOTO_SIZE_LIMIT` as module constant
- Eliminate magic number duplication (`10*1024*1024`)
- Document memory tradeoff for media group functionality

## Testing
✅ All tests pass (208 frontend + full pytest suite)
✅ Verified `highlight_image` preserves JPEG format  
✅ Linters pass (ruff, basedpyright, pylint)
✅ Handles edge cases (resize failure → send as document)

## Example Scenario (Fixed)
**Before**: User sends camera snapshot → highlight_image creates 31.6MB PNG → Telegram rejects → user gets nothing

**After**: User sends camera snapshot → highlight_image creates 4.1MB JPEG → fits within limit → user receives highlighted image with reply threading intact

If image were >10MB: → auto-resize to ~20MP (~8MB) → send with caption linking to full resolution → user gets preview + full-res link

🤖 Generated with [Claude Code](https://claude.com/claude-code)