### PR TITLE
fix: Eliminate profile selector accessibility test flakiness

### DIFF
--- a/tests/functional/web/test_profile_switching_ui.py
+++ b/tests/functional/web/test_profile_switching_ui.py
@@ -350,6 +350,10 @@ class TestProfileSwitchingUI:
         profile_selector = page.locator('button[role="combobox"]').first
         await expect(profile_selector).to_have_attribute("role", "combobox")
 
+        # Wait for element to be fully interactive before testing keyboard accessibility
+        await expect(profile_selector).to_be_visible()
+        await expect(profile_selector).to_be_enabled()
+
         # Should be keyboard accessible
         await profile_selector.focus()
         await expect(profile_selector).to_be_focused()


### PR DESCRIPTION
## Summary

Fixes intermittent test failure in `test_profile_selector_accessibility` that occurred only in PostgreSQL CI runs.

## Problem

The test failed with:
```
AssertionError: Locator expected to be focused. Actual value: inactive
```

**Root cause**: Race condition where the profile selector button existed and had correct ARIA attributes, but React hadn't finished hydrating the component yet. PostgreSQL's slower DB operations exposed this timing issue that was hidden in SQLite runs.

## Solution

Added explicit waits for the element to be fully interactive before attempting to focus:

```python
# Wait for element to be fully interactive before testing keyboard accessibility
await expect(profile_selector).to_be_visible()
await expect(profile_selector).to_be_enabled()

# Now safe to focus
await profile_selector.focus()
await expect(profile_selector).to_be_focused()
```

This follows the testing principle from `tests/CLAUDE.md`: *"Always wait for the specific condition you care about"*

## Testing

✅ Single test run with PostgreSQL: PASSED  
✅ Flake-finder with 50 runs: **50/50 PASSED**  
✅ Full test suite (`poe test`): All 595 tests pass

Confirms flakiness is completely resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)