### PR TITLE
fix: Update highlight_image tool to use Gemini bounding box format

### DIFF
--- a/tests/functional/test_attachment_id_injection.py
+++ b/tests/functional/test_attachment_id_injection.py
@@ -201,12 +201,7 @@ async def test_attachment_id_injected_and_referenceable(
                             "image_attachment_id": captured_attachment_id,
                             "regions": [
                                 {
-                                    "box": {
-                                        "x_min": 100,
-                                        "y_min": 100,
-                                        "x_max": 200,
-                                        "y_max": 200,
-                                    },
+                                    "box": [100, 100, 200, 200],
                                     "label": "eagle statue",
                                     "color": "red",
                                 }

--- a/tests/functional/test_attachment_tools.py
+++ b/tests/functional/test_attachment_tools.py
@@ -439,14 +439,15 @@ class TestHighlightImageTool:
 
             # Define regions with bounding box format (normalized [0, 1000] coordinates)
             # For an 800x600 image, these will be scaled to pixel coordinates
+            # Bounding box format is: y_min, x_min, y_max, x_max
             regions = [
                 {
-                    "box": {"x_min": 100, "y_min": 200, "x_max": 400, "y_max": 600},
+                    "box": [200, 100, 600, 400],
                     "label": "test_region_1",
                     "color": "red",
                 },
                 {
-                    "box": {"x_min": 500, "y_min": 300, "x_max": 800, "y_max": 700},
+                    "box": [300, 500, 700, 800],
                     "label": "test_region_2",
                     "color": "blue",
                 },
@@ -538,7 +539,7 @@ class TestHighlightImageTool:
 
             regions = [
                 {
-                    "box": {"x_min": 100, "y_min": 100, "x_max": 200, "y_max": 200},
+                    "box": [100, 100, 200, 200],
                     "label": "test",
                 },
             ]
@@ -614,7 +615,7 @@ class TestHighlightImageTool:
             # Region with missing required field (box)
             regions = [
                 {
-                    "box": {"x_min": 100, "y_min": 100, "x_max": 200, "y_max": 200},
+                    "box": [100, 100, 200, 200],
                     "label": "valid_region",
                 },
                 {
@@ -695,7 +696,7 @@ class TestHighlightImageTool:
             # Region with invalid shape
             regions = [
                 {
-                    "box": {"x_min": 100, "y_min": 100, "x_max": 200, "y_max": 200},
+                    "box": [100, 100, 200, 200],
                     "label": "test",
                     "shape": "triangle",  # Invalid shape
                 },


### PR DESCRIPTION
## Summary

Updated the `highlight_image` tool to match Gemini's object detection API specification for bounding boxes.

## Changes

- **Tool definition**: Changed `box` parameter from object with named fields to array format
  - Old: `{"x_min": 100, "y_min": 200, "x_max": 300, "y_max": 400}`
  - New: `[200, 100, 400, 300]` (format: `[y_min, x_min, y_max, x_max]`)
- **Implementation**: Updated coordinate extraction to unpack array values
- **Tests**: Updated all test cases to use new array format
- **Validation**: Simplified validation logic for cleaner error messages

## Rationale

Gemini's object detection API returns bounding boxes in the format `[y_min, x_min, y_max, x_max]` normalized to `[0, 1000]`. By matching this format exactly, the tool can now accept Gemini's detection results directly without transformation.

Reference: https://ai.google.dev/gemini-api/docs/image-understanding#object-detection

## Test Plan

- [x] All unit tests pass
- [x] All functional tests pass
- [x] Linting passes
- [x] Frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)