### PR TITLE
feat: Add Telegram bot token support to devcontainer

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - BRAVE_API_KEY=${BRAVE_API_KEY:-}
       - HOMEASSISTANT_API_KEY=${HOMEASSISTANT_API_KEY:-}
       - GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY:-}
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
       - DEBUG_LLM_MESSAGES=true
     volumes:
       # Mount workspace - you can change this to your desired host directory


### PR DESCRIPTION
## Summary
- Adds `TELEGRAM_BOT_TOKEN` environment variable to the backend service in devcontainer
- Enables conditional Telegram client startup based on token availability
- Application automatically starts Telegram service when token is provided
- Falls back to web-only mode when no token is set

## Changes
- Modified `.devcontainer/docker-compose.yml` to pass through `TELEGRAM_BOT_TOKEN` environment variable

## Testing
The application already has built-in logic to conditionally start the Telegram service, so this change simply exposes the configuration option to the devcontainer environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)