### PR TITLE
feat: Add file-based locking to prevent concurrent test runs

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Color codes for output
 RED='\033[0;31m'
@@ -99,6 +99,19 @@ fi
 if [ -z "$PYTEST_ARGS" ]; then
     PYTEST_ARGS="tests --ignore=scratch"
 fi
+
+# Acquire exclusive lock to prevent concurrent test runs
+LOCK_FILE="$HOME/.poe-test.lock"
+exec 200>"$LOCK_FILE"
+
+echo "${BLUE}Acquiring test lock...${NC}"
+if ! flock --exclusive --timeout 300 200; then
+    echo "${RED}❌ Error: Could not acquire lock after waiting 5 minutes.${NC}" >&2
+    echo "${YELLOW}Another test run is still in progress. Please wait or investigate:${NC}" >&2
+    echo "${YELLOW}  Lock file: $LOCK_FILE${NC}" >&2
+    exit 1
+fi
+echo "${GREEN}✓ Lock acquired${NC}"
 
 # Overall timer
 OVERALL_START=$(date +%s)


### PR DESCRIPTION
## Summary

Implement exclusive locking for `poe test` to ensure only one test run can execute at a time on a machine. This prevents resource conflicts and interference between concurrent test invocations.

## Implementation

- **Lock mechanism**: Use `flock` with 5-minute timeout for efficient, non-polling wait behavior
- **Lock file location**: `~/.poe-test.lock` in the home directory
- **Shell requirement**: Changed shebang from `#!/bin/sh` to `#!/bin/bash` (required for file descriptor syntax)
- **Queueing behavior**: Second invocation waits up to 5 minutes for lock availability instead of failing immediately
- **Automatic cleanup**: Lock is automatically released when script exits (normal exit, Ctrl+C, or error)

## Benefits

- **Prevents retry storms**: Claude Code won't repeatedly retry failed tests when another run is in progress
- **Better resource management**: Queues concurrent test runs instead of allowing resource contention
- **User-friendly**: Clear feedback showing lock acquisition status

## Test Plan

Tested by running two concurrent `poe test` invocations:
1. First test acquired lock and ran successfully
2. Second test waited for lock, acquired it when first completed, and ran successfully
3. Both tests passed with no interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)