### PR TITLE
fix: Split uv sync to preserve Docker cache and fix CI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,9 +124,9 @@ USER root
 # Copy dependency definition files
 COPY --chown=appuser:appuser pyproject.toml uv.lock* ./
 
-# Install Python dependencies
+# Install Python dependencies (without installing the project itself yet)
 USER appuser
-RUN uv sync --extra local-embeddings
+RUN uv sync --no-install-project --extra local-embeddings
 
 # --- Frontend Build Stage ---
 # Copy frontend package files first for layer caching
@@ -151,11 +151,10 @@ USER root
 COPY --chown=appuser:appuser . .
 
 # --- Install the Package ---
-# Install the package in editable mode. This is useful for development, but for production
-# a standard installation is often preferred. Since this is a single image for both,
-# this is a reasonable compromise.
+# Install the package using uv sync to ensure uv.lock continues to apply.
+# This completes the installation by adding the project itself.
 USER appuser
-RUN uv pip install -e .
+RUN uv sync --extra local-embeddings
 
 # --- Runtime Configuration ---
 # Expose the port the web server listens on


### PR DESCRIPTION
## Problem

CI builds were failing with:
```
× Failed to build `family-assistant @ file:///app`
╰─▶ Call to `setuptools.build_meta.build_editable` failed (exit status: 1)
```

The issue was that `uv sync` at line 129 tried to build the package before the source code was copied (which happens at line 151).

## Solution

Split the `uv sync` into two stages to maintain optimal Docker layer caching:

1. **First stage (line 129)**: `uv sync --no-install-project --extra local-embeddings`
   - Installs all dependencies from `uv.lock` without installing the project itself
   - Only requires `pyproject.toml` and `uv.lock` (already copied at this point)
   - Cache layer invalidates **only when dependencies change** ✅

2. **Second stage (line 157)**: `uv sync --extra local-embeddings`
   - Completes installation by adding the project itself
   - Runs after all source code is copied
   - Ensures `uv.lock` continues to apply (not bypassed)
   - Cache layer invalidates when source changes (expected behavior)

## Benefits

- ✅ Fixes CI build failures
- ✅ Preserves optimal cache performance
- ✅ Dependencies rebuild only when `pyproject.toml` or `uv.lock` change
- ✅ Source code changes don't invalidate the expensive dependency installation layer
- ✅ Ensures `uv.lock` is respected throughout the entire build

## Testing

- All local tests pass (`poe test`)
- CI build should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)