### PR TITLE
fix: Handle ToolResult attachments in script tool execution

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -251,7 +251,7 @@ service_profiles:
       provider: "google"
       llm_model: "gemini-2.5-pro"
       prompts:
-        system_prompt: "You are an automated event handler assistant. You are responding to events from scripts and automations. Provide clear, concise responses focused on the event context. Current time is {current_time}."
+        system_prompt: "You are an automated event handler assistant. You are responding to events from scripts and automations. Provide clear, concise responses focused on the event context.\n\nCurrent time: {current_time}\n\n{aggregated_other_context}"
       max_history_messages: 1 # Minimal history for event processing
       history_max_age_hours: 0.5 # 30 minutes - events are typically immediate
       delegation_security_level: "blocked" # Cannot delegate to other services

--- a/src/family_assistant/scripting/engine.py
+++ b/src/family_assistant/scripting/engine.py
@@ -237,8 +237,13 @@ class StarlarkEngine:
                     tool_name = tool_info["name"]
 
                     # Create a closure to capture the tool name
-                    def make_tool_wrapper(name: str) -> Callable[..., str]:
-                        def tool_wrapper(*args: Any, **kwargs: Any) -> str:  # noqa: ANN401 # Tool args can be any type
+                    def make_tool_wrapper(
+                        name: str,
+                    ) -> Callable[..., str | dict[str, Any]]:
+                        def tool_wrapper(
+                            *args: Any,  # noqa: ANN401 # Tool args can be any type
+                            **kwargs: Any,  # noqa: ANN401
+                        ) -> str | dict[str, Any]:
                             """Execute the tool with the given arguments."""
                             # If positional args are provided, we need to map them to kwargs
                             # This requires knowing the parameter names of the tool


### PR DESCRIPTION
## Summary

Fixes bug where scripts calling tools that return ToolResult with attachments were receiving string representations instead of actual attachment IDs.

## Changes

- **Modified ToolsAPI.execute()** to detect ToolResult with attachments, store them in registry, and return IDs
- **Use Python's mimetypes.guess_extension()** for file extensions instead of custom code
- **Return format**: single ID as string for convenience, dict for multiple attachments or when text is present
- **Updated return types** throughout scripting layer (`str | dict[str, Any]`)
- **Added context providers** to event_handler profile system prompt for wake_llm calls
- **Added comprehensive end-to-end test** verifying attachment flow

## Test Coverage

The new test `test_script_tool_result_attachment_to_wake_llm()` verifies:
- Script calls tool returning ToolResult with attachment
- Script extracts attachment_id from result (handles both dict and string)
- Attachment is stored in registry with correct content and mime type
- wake_llm receives valid attachment ID string
- Attachment file exists on disk with correct content

## Related Issue

Fixes the issue where `get_camera_snapshot()` returns ToolResult with attachment but script receives string representation like `"ToolResult(text=\"Retrieved snapshot...\", attachments=[...])"` instead of the attachment ID.