### PR TITLE
Fix flaky Playwright tests and improve test reliability

### DIFF
--- a/tests/functional/web/pages/chat_page.py
+++ b/tests/functional/web/pages/chat_page.py
@@ -428,11 +428,12 @@ class ChatPage(BasePage):
         if not await self.is_sidebar_open():
             await self.toggle_sidebar()
 
-        # Click on the conversation item - use the data-conversation-id attribute
+        # Use locator instead of ElementHandle to avoid race conditions
+        # Locators automatically retry and handle element detachment during React re-renders
         selector = f'[data-conversation-id="{conversation_id}"]'
-        conv_item = await self.page.wait_for_selector(selector)
-        if conv_item:
-            await conv_item.click()
+        conv_item = self.page.locator(selector)
+        await conv_item.wait_for(state="visible", timeout=10000)
+        await conv_item.click()
 
         # Wait for the conversation to load
         await self.wait_for_load()

--- a/tests/functional/web/test_ui_endpoints_playwright.py
+++ b/tests/functional/web/test_ui_endpoints_playwright.py
@@ -104,15 +104,14 @@ async def check_endpoint(
 @pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_ui_endpoint_accessibility_playwright(
-    web_test_fixture: WebTestFixture,
-    console_error_checker: ConsoleErrorCollector,
+    web_test_with_console_check: WebTestFixture,
 ) -> None:
     """
     Test that all UI endpoints are accessible via Playwright and render without errors.
     Uses parallel execution to speed up testing of multiple endpoints.
     """
-    browser = web_test_fixture.page.context.browser
-    base_url = web_test_fixture.base_url
+    browser = web_test_with_console_check.page.context.browser
+    base_url = web_test_with_console_check.base_url
 
     # Split endpoints into batches for parallel processing
     # Process 5 endpoints at a time to avoid overwhelming the server
@@ -144,20 +143,19 @@ async def test_ui_endpoint_accessibility_playwright(
 @pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_navigation_links_work(
-    web_test_fixture: WebTestFixture,
-    console_error_checker: ConsoleErrorCollector,
+    web_test_with_console_check: WebTestFixture,
 ) -> None:
     """Test that all navigation links in the UI work correctly.
 
     This is a smoke test that discovers all nav links dynamically and tests each one
     in isolation to avoid stale element references and ensure proper testing.
     """
-    browser = web_test_fixture.page.context.browser
+    browser = web_test_with_console_check.page.context.browser
     assert browser is not None, "Browser not available"
-    base_url = web_test_fixture.base_url
+    base_url = web_test_with_console_check.base_url
 
     # Discover all navigation links using the existing page
-    page = web_test_fixture.page
+    page = web_test_with_console_check.page
     base_page = BasePage(page, base_url)
 
     await base_page.navigate_to("/notes")
@@ -236,19 +234,15 @@ async def test_navigation_links_work(
             + "\n".join(f"  - {f}" for f in failures)
         )
 
-    # Check console errors from original page
-    console_error_checker.assert_no_errors()
-
 
 @pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_responsive_design_mobile(
-    web_test_fixture: WebTestFixture,
-    console_error_checker: ConsoleErrorCollector,
+    web_test_with_console_check: WebTestFixture,
 ) -> None:
     """Test that pages work on mobile viewport sizes."""
-    page = web_test_fixture.page
-    base_url = web_test_fixture.base_url
+    page = web_test_with_console_check.page
+    base_url = web_test_with_console_check.base_url
     base_page = BasePage(page, base_url)
 
     # Set mobile viewport
@@ -273,20 +267,16 @@ async def test_responsive_design_mobile(
             f"body width {body_width}px > viewport {viewport_width}px"
         )
 
-    # Assert no console errors
-    console_error_checker.assert_no_errors()
-
 
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_form_interactions(
-    web_test_fixture: WebTestFixture,
-    console_error_checker: ConsoleErrorCollector,
+    web_test_with_console_check: WebTestFixture,
 ) -> None:
     """Test basic form interactions work without errors."""
-    page = web_test_fixture.page
-    base_url = web_test_fixture.base_url
+    page = web_test_with_console_check.page
+    base_url = web_test_with_console_check.base_url
     base_page = BasePage(page, base_url)
 
     # Navigate to vector search page (has a simple search form)
@@ -317,19 +307,15 @@ async def test_form_interactions(
         await search_button.first.click()
         # No need to wait - this test only checks that the button click doesn't cause errors
 
-    # Assert no console errors
-    console_error_checker.assert_no_errors()
-
 
 @pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_loading_states(
-    web_test_fixture_readonly: WebTestFixture,
-    console_error_checker: ConsoleErrorCollector,
+    web_test_readonly_with_console_check: WebTestFixture,
 ) -> None:
     """Test that pages show appropriate loading states."""
-    page = web_test_fixture_readonly.page
-    base_url = web_test_fixture_readonly.base_url
+    page = web_test_readonly_with_console_check.page
+    base_url = web_test_readonly_with_console_check.base_url
     base_page = BasePage(page, base_url)
 
     # Navigate to tasks page (likely to have loading states)
@@ -348,6 +334,3 @@ async def test_loading_states(
 
     # Wait for final load
     await base_page.wait_for_load()
-
-    # Assert no console errors
-    console_error_checker.assert_no_errors()


### PR DESCRIPTION
## Summary

This PR fixes multiple flaky Playwright test issues and improves overall test reliability by addressing race conditions and test infrastructure improvements.

## Key Fixes

### 1. ElementHandle Race Condition
- **Issue**: `test_conversation_loading_with_tool_calls` failing with "Element is not attached to the DOM"
- **Fix**: Replaced ElementHandle pattern with Playwright's locator API in `select_conversation()` which auto-retries and handles detached elements during React re-renders

### 2. SSE Connection Cleanup Sequencing
- **Issue**: `test_image_upload_basic_functionality` failing with "[SSE] Connection error" in postgres tests
- **Root Cause**: Test teardown checked console errors before page was closed, while SSE notification connection was still active
- **Fix**: Created new fixtures `web_test_with_console_check` and `web_test_readonly_with_console_check` that use pytest's fixture dependency system to ensure proper sequencing: test completes → page closes (SSE terminates) → console errors checked

### 3. Condition-Based Waits
- Replaced arbitrary time-based waits with condition-based waits throughout test suite
- Removed networkidle waits that were incompatible with persistent SSE connections
- Added proper wait helpers for React app readiness

### 4. CI/CD Improvements
- Updated GitHub Actions workflows with better caching and timeouts
- Added Dockerfile build verification to CI
- Optimized container builds with CPU-only torch to reduce image size
- Skip test requirements for Dockerfile-only changes

## Test Updates

Systematically updated 5 test files using ast-grep:
- `test_file_upload_functionality.py`
- `test_ui_endpoints_playwright.py`
- `test_history_ui.py`
- `test_live_message_updates.py`
- `test_chat_ui_attachment_response.py`

## Verification

- ✅ Full test suite passes: 1270+ tests in ~10 minutes
- ✅ All linters pass
- ✅ Both SQLite and PostgreSQL test runs successful
- ✅ Previously flaky tests now reliable

🤖 Generated with [Claude Code](https://claude.com/claude-code)