### PR TITLE
fix: Make lint hook silent when all checks pass

### DIFF
--- a/.claude/lint-hook.py
+++ b/.claude/lint-hook.py
@@ -326,13 +326,11 @@ async def main() -> None:
 
         # Format and output results
         if all_results:
-            combined_output = []
-            for file_path, results in all_results.items():
-                formatted = format_results(file_path, results)
-                if formatted is not None:
-                    combined_output.append(
-                        formatted["hookSpecificOutput"]["additionalContext"]
-                    )
+            combined_output = [
+                formatted["hookSpecificOutput"]["additionalContext"]
+                for file_path, results in all_results.items()
+                if (formatted := format_results(file_path, results)) is not None
+            ]
 
             if combined_output:
                 output = {


### PR DESCRIPTION
## Summary

Modified the lint hook to only provide feedback when there are actual lint issues, reducing noise during normal development when all checks pass.

## Changes

- Updated `format_results()` to return `None` when all checks pass (instead of showing a success message)
- Removed the success message that was displayed when all linters passed
- Added `None` check in `main()` before accessing formatted results to prevent type errors
- Updated return type annotation to `dict[str, Any] | None`

## Rationale

The previous behavior showed a success message like "✅ file.py: ruff check, basedpyright, code-conformance (2.37s)" every time linters passed. This added visual noise without providing actionable information. The new behavior follows the Unix philosophy of "silence is golden" - only speak up when there's something to report.

## Test Plan

- [x] Verified lint hook passes basedpyright type checking
- [x] Tested with a file that has no lint issues (should be silent)
- [x] Tested with a file that has lint issues (should show detailed feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)