### PR TITLE
Fix flaky test_mobile_chat_input_visibility

### DIFF
--- a/tests/functional/web/test_chat_ui_flow.py
+++ b/tests/functional/web/test_chat_ui_flow.py
@@ -913,8 +913,7 @@ async def test_mobile_chat_input_visibility(
     # Test that last message is not obscured by input
     # Send multiple messages to fill the viewport
     for i in range(3):
-        await chat_input.type(f"Additional test message {i + 1}")
-        await chat_input.press("Enter")
+        await chat_page.send_message(f"Additional test message {i + 1}")
         await chat_page.wait_for_assistant_response(timeout=15000)
 
     # Get all message elements


### PR DESCRIPTION
## Summary
Fixes the flaky `test_mobile_chat_input_visibility` test that was failing intermittently in CI.

## Problem
The test was caching a reference to the chat input element and reusing it in a loop. React re-renders can make the cached element reference stale, causing message sends to silently fail.

**CI Failure:**
- Expected: 8 messages (4 user + 4 assistant)
- Actual: Only 6 messages (3 user + 3 assistant)
- Error: `assert 6 >= 8` at line 924

## Solution
Changed lines 916-917 to use `chat_page.send_message()` instead of direct element manipulation:

**Before:**
```python
for i in range(3):
    await chat_input.type(f"Additional test message {i + 1}")
    await chat_input.press("Enter")
    await chat_page.wait_for_assistant_response(timeout=15000)
```

**After:**
```python
for i in range(3):
    await chat_page.send_message(f"Additional test message {i + 1}")
    await chat_page.wait_for_assistant_response(timeout=15000)
```

## Benefits
- ✅ Re-fetches the input element each time (no stale references)
- ✅ Waits for the input to be visible and enabled
- ✅ Properly handles React re-renders
- ✅ Consistent with how the rest of the test sends messages

## Verification
- ✅ 100 consecutive test runs with `--flake-finder` (all passed)
- ✅ Full test suite: 736 tests passed
- ✅ All linters and type checks passed

## Test Plan
CI will run the full test suite including this test multiple times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)