### PR TITLE
Fix flaky test_conversation_persistence_and_switching by avoiding stale element references

### DIFF
--- a/tests/functional/web/pages/chat_page.py
+++ b/tests/functional/web/pages/chat_page.py
@@ -429,12 +429,12 @@ class ChatPage(BasePage):
         if not await self.is_sidebar_open():
             await self.toggle_sidebar()
 
-        # Use locator instead of ElementHandle to avoid race conditions
-        # Locators automatically retry and handle element detachment during React re-renders
+        # Use locator's click with timeout to atomically wait and click
+        # This avoids stale element references that can happen if React re-renders
+        # between a separate wait_for() and click() call
         selector = f'[data-conversation-id="{conversation_id}"]'
         conv_item = self.page.locator(selector)
-        await conv_item.wait_for(state="visible", timeout=10000)
-        await conv_item.click()
+        await conv_item.click(timeout=10000)
 
         # Wait for the conversation to load
         await self.wait_for_load()


### PR DESCRIPTION
## Summary

Fixes the flaky `test_conversation_persistence_and_switching` test that was failing with "Element is not attached to the DOM" errors in CI.

## Problem

The test was failing intermittently with:
```
playwright._impl._errors.Error: ElementHandle.click: Element is not attached to the DOM
```

This occurred in the `select_conversation` method when clicking conversation items in the sidebar.

## Root Cause

Race condition where React re-renders could update the conversation list between the `wait_for(state="visible")` and `click()` calls, making the element reference stale.

## Solution

Following the same pattern as #329 (commit 62a2628a) for `test_mobile_chat_input_visibility`, replaced separate wait and click operations with a single atomic operation:

**Before:**
```python
await conv_item.wait_for(state="visible", timeout=10000)
await conv_item.click()
```

**After:**
```python
await conv_item.click(timeout=10000)
```

Playwright's `locator.click(timeout)` automatically:
- Waits for the element to be visible
- Waits for it to be enabled and stable
- Retries if the element becomes stale during React re-renders
- All within a single atomic operation

This eliminates the race condition window where React can re-render between waiting for visibility and clicking.

## Test Plan

- ✅ Full test suite passed: 1403 tests passed, 2 skipped
- ✅ All linters passed
- ✅ Verified the specific test no longer has stale element issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)