### PR TITLE
Install pgserver extra on amd64 architecture in setup script

### DIFF
--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -34,7 +34,16 @@ source .venv/bin/activate
 
 # Step 3: Install Python dependencies
 echo "📥 Installing Python dependencies..."
-uv sync --extra dev
+
+# Detect architecture for pgserver extra
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
+    echo "🔍 Detected amd64 architecture, installing pgserver extra..."
+    uv sync --extra dev --extra pgserver
+else
+    echo "🔍 Detected non-amd64 architecture ($ARCH), skipping pgserver extra..."
+    uv sync --extra dev
+fi
 
 # Install additional dev tools that might not be in pyproject.toml
 echo "📥 Installing additional development tools..."


### PR DESCRIPTION
Modified setup-workspace.sh to detect system architecture and automatically install the pgserver extra when running on amd64/x86_64 systems. This ensures PostgreSQL testing capabilities are available in remote Claude Code sessions on compatible architectures.

Changes:
- Added architecture detection using uname -m
- Conditionally install pgserver extra on amd64/x86_64 systems
- Skip pgserver on other architectures (e.g., ARM) to avoid compatibility issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)