### PR TITLE
feat(scripting): Add attachment_create() function for Starlark scripts

### DIFF
--- a/src/family_assistant/scripting/engine.py
+++ b/src/family_assistant/scripting/engine.py
@@ -197,6 +197,7 @@ class StarlarkEngine:
 
                     # Add attachment functions (excluding list and send for security/architecture)
                     module.add_callable("attachment_get", attachment_api.get)
+                    module.add_callable("attachment_create", attachment_api.create)
                     # NOTE: attachment_list intentionally excluded to prevent ID enumeration
                     # NOTE: attachment_send removed - scripts should use LLM tools:
                     #   - attach_to_response (for current user)


### PR DESCRIPTION
Enable scripts to create attachments from generated content, making it possible to manipulate JSON data and save results as attachments.

Changes:
- Add AttachmentAPI.create() method to create attachments from scripts
- Accept both string and bytes content, auto-encoding strings to UTF-8
- Store attachments with source_type="script" for tracking
- Expose attachment_create() to Starlark environment
- Add comprehensive tests for creation with text, bytes, and JSON content
- Test conversation scoping and create/retrieve workflows

Scripts can now create attachments like:
  attachment_id = attachment_create( content=json_encode(data), filename="output.json", description="Script output", mime_type="text/plain" )

🤖 Generated with [Claude Code](https://claude.com/claude-code)