### PR TITLE
Fix Tools API endpoint method error

### DIFF
--- a/frontend/src/tools/ToolsApp.jsx
+++ b/frontend/src/tools/ToolsApp.jsx
@@ -149,14 +149,13 @@ const ToolsApp = () => {
       const parameters = editorInstanceRef.current.getValue();
 
       // Execute the tool
-      const response = await fetch('/api/tools/execute', {
+      const response = await fetch(`/api/tools/execute/${selectedTool}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          tool_name: selectedTool,
-          parameters: parameters,
+          arguments: parameters,
         }),
       });
 


### PR DESCRIPTION
The backend expects:
- URL: /api/tools/execute/{tool_name} (tool_name as path parameter)
- Body: {arguments: {...}}

Frontend was incorrectly sending:
- URL: /api/tools/execute
- Body: {tool_name: ..., parameters: ...}

This change fixes the 405 Method Not Allowed error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)