### PR TITLE
Ensure mobile chat test waits for all messages

### DIFF
--- a/tests/functional/web/test_chat_ui_flow.py
+++ b/tests/functional/web/test_chat_ui_flow.py
@@ -917,7 +917,7 @@ async def test_mobile_chat_input_visibility(
         await chat_page.wait_for_assistant_response(timeout=15000)
 
     # Wait until all user/assistant message pairs have rendered to avoid race conditions
-    await chat_page.wait_for_message_count(8, timeout=20000)
+    await chat_page.wait_for_message_count(2 + (3 * 2), timeout=20000)
 
     # Get all message elements
     message_elements = await page.query_selector_all(


### PR DESCRIPTION
## Summary
- wait for the expected number of messages before asserting in the mobile chat visibility test

## Testing
- pytest tests/functional/web/test_chat_ui_flow.py::test_mobile_chat_input_visibility -k sqlite -q

------
https://chatgpt.com/codex/tasks/task_e_6904a742b1308330af4d61a578d93272