### PR TITLE
Fix ScriptAttachment type handling in jq_query and improve structured data support

### DIFF
--- a/src/family_assistant/scripting/engine.py
+++ b/src/family_assistant/scripting/engine.py
@@ -242,13 +242,16 @@ class StarlarkEngine:
                     # Create a closure to capture the tool name
                     def make_tool_wrapper(
                         name: str,
+                    ) -> Callable[
+                        ...,
                         # ast-grep-ignore: no-dict-any - Return dict for Starlark JSON compatibility
-                    ) -> Callable[..., str | dict[str, Any]]:
+                        str | dict[str, Any] | list[Any] | int | float | bool,
+                    ]:
                         def tool_wrapper(
                             *args: Any,  # noqa: ANN401 # Tool args can be any type
                             **kwargs: Any,  # noqa: ANN401
                             # ast-grep-ignore: no-dict-any - Return dict for Starlark JSON compatibility
-                        ) -> str | dict[str, Any]:
+                        ) -> str | dict[str, Any] | list[Any] | int | float | bool:
                             """Execute the tool with the given arguments."""
                             # If positional args are provided, we need to map them to kwargs
                             # This requires knowing the parameter names of the tool

--- a/src/family_assistant/tools/execute_script.py
+++ b/src/family_assistant/tools/execute_script.py
@@ -279,11 +279,17 @@ async def execute_script_tool(
                     )
                 )
 
-        # Prepare data field (typed as dict or list or None)
+        # Prepare data field - preserve structured data for programmatic access
         # ast-grep-ignore: no-dict-any - Script results can be arbitrary structures
-        result_data: dict[str, Any] | str | None = None
-        if isinstance(result, (dict, list)):
+        result_data: dict[str, Any] | list[Any] | str | int | float | bool | None = None
+        if isinstance(result, (dict, list, int, float, bool, str)):
+            # Preserve structured data for programmatic access
             result_data = result  # type: ignore[assignment]
+        elif result is not None and not isinstance(
+            result, (ScriptAttachment, ScriptToolResult)
+        ):
+            # For other types, convert to string
+            result_data = str(result)
 
         return ToolResult(
             text=response_text,

--- a/src/family_assistant/tools/types.py
+++ b/src/family_assistant/tools/types.py
@@ -171,7 +171,9 @@ class ToolResult:
         None  # List of attachments (can be references or new content)
     )
     # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    data: dict[str, Any] | str | None = None  # Structured data for tests/scripts
+    data: dict[str, Any] | list[Any] | str | int | float | bool | None = (
+        None  # Structured data for tests/scripts
+    )
 
     def __post_init__(self) -> None:
         """Ensure at least one of text or data is populated"""
@@ -197,7 +199,7 @@ class ToolResult:
         return ""
 
     # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    def get_data(self) -> dict[str, Any] | str | None:
+    def get_data(self) -> dict[str, Any] | list[Any] | str | int | float | bool | None:
         """
         Get data, parsing from text if needed.
 


### PR DESCRIPTION
## Summary
Fixes three interconnected bugs that prevented `jq_query` from working correctly when called from Starlark scripts, and improves structured data handling throughout the tool execution pipeline.

## Root Cause
The original error occurred when `jq_query` was called from a Starlark script:
```
sqlalchemy.exc.StatementError: (builtins.TypeError) Could not locate a bind processor for type 'ScriptAttachment'
```

This happened because:
1. The `jq_query` tool definition incorrectly declared `attachment_id` with `type: "string"`
2. The ToolsAPI wasn't passing the tool definition to the argument processor
3. Without the tool definition, the system couldn't detect that the parameter should be converted from string to ScriptAttachment

## Bug Fixes

### 1. jq_query tool definition (src/family_assistant/tools/data_manipulation.py)
- **Before**: `"type": "string"`
- **After**: `"type": "attachment"`
- This enables automatic conversion to ScriptAttachment objects

### 2. jq_query_tool signature (src/family_assistant/tools/data_manipulation.py)
- Updated to accept both `ScriptAttachment` and `str`
- Added logic to extract ID from ScriptAttachment objects
- Maintains backward compatibility with direct string UUID calls

### 3. ToolsAPI argument processing (src/family_assistant/scripting/apis/tools.py)
- `_process_attachment_arguments` now retrieves and passes tool definition
- Enables proper attachment type detection based on tool schema
- Falls back to heuristic detection when definition unavailable

### 4. ToolsAPI return value handling (src/family_assistant/scripting/apis/tools.py)
- Tools returning ToolResult with data but no attachments now return data directly
- Previously converted everything to text, losing structured types
- Scripts can now receive and manipulate native Python objects

### 5. execute_script_tool data preservation (src/family_assistant/tools/execute_script.py)
- Now preserves `int`, `float`, `bool`, `str`, `dict`, and `list` types in `ToolResult.data`
- Previously only preserved dict and list, converting others to text
- Enables programmatic access to all JSON-compatible types

### 6. ToolResult type annotations (src/family_assistant/tools/types.py)
- Updated data field: `dict | list | str | int | float | bool | None`
- Updated `get_data()` return type to match
- Maintains backward compatibility

### 7. Type annotations throughout pipeline
- Updated `ToolsAPI.execute()` and `execute_json()` return types
- Updated `StarlarkEngine` tool wrapper return types
- Ensures type safety across the entire execution chain

## Test Improvements

### Converted to Realistic Integration Tests
All tests in `test_data_manipulation_tools.py` now:
- Use realistic script-based execution (not direct Python calls)
- Use real `ProcessingService` with full dependency injection
- Test the complete flow from script → ToolsAPI → tool execution

### Added Workflow Test
`test_tool_chaining_json_query_workflow` in `test_execute_script_attachments.py`:
- Creates JSON attachment via `attachment_create()`
- Queries it with `jq_query()` passing ScriptAttachment object
- Verifies structured data is returned correctly
- **This test would have caught the original bug**

## Testing
- ✅ All 22 tests in test_data_manipulation_tools.py pass
- ✅ Workflow test demonstrates end-to-end attachment creation and querying
- ✅ Linter checks pass (ruff, basedpyright, pylint, code conformance)

## Impact
- Fixes broken `jq_query` functionality when called from scripts
- Improves structured data handling across all tools
- Better type safety throughout the tool execution pipeline
- More realistic tests that catch integration issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)