### PR TITLE
fix: Resolve jq_query() deadlock when called from Starlark scripts

### DIFF
--- a/src/family_assistant/scripting/apis/tools.py
+++ b/src/family_assistant/scripting/apis/tools.py
@@ -252,7 +252,7 @@ class ToolsAPI:
         return await fetch_attachment_object(attachment_id, self.execution_context)
 
     # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    def _get_raw_tool_definitions(self) -> list[dict[str, Any]]:
+    async def _get_raw_tool_definitions(self) -> list[dict[str, Any]]:
         """Get raw tool definitions for internal schema analysis.
 
         Uses the raw definitions (without LLM translation) to detect attachment types.
@@ -289,8 +289,9 @@ class ToolsAPI:
                     f"Cannot get raw tool definitions from {type(self.tools_provider).__name__}, "
                     "using translated definitions - attachment detection may not work properly"
                 )
-                self._raw_tool_definitions = self._run_async(
-                    self.tools_provider.get_tool_definitions()
+                # Use await instead of _run_async since we're already in async context
+                self._raw_tool_definitions = (
+                    await self.tools_provider.get_tool_definitions()
                 )
 
         return self._raw_tool_definitions or []
@@ -315,7 +316,7 @@ class ToolsAPI:
         """
         # Get tool definition to properly detect attachment parameters
         tool_definition = None
-        raw_definitions = self._get_raw_tool_definitions()
+        raw_definitions = await self._get_raw_tool_definitions()
         for definition in raw_definitions:
             # Tool definitions have a 'function' key with the function name
             func_def = definition.get("function", {})

--- a/tests/unit/scripting/test_jq_query_deadlock.py
+++ b/tests/unit/scripting/test_jq_query_deadlock.py
@@ -1,0 +1,111 @@
+"""Test for jq_query() deadlock when called from scripts.
+
+This test reproduces the deadlock that occurs when jq_query() is called from within
+a Starlark script with a ConfirmingToolsProvider (which doesn't have get_raw_tool_definitions).
+"""
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from family_assistant.services.attachment_registry import AttachmentRegistry
+from family_assistant.storage.context import DatabaseContext
+from family_assistant.tools import AVAILABLE_FUNCTIONS, TOOLS_DEFINITION
+from family_assistant.tools.execute_script import execute_script_tool
+from family_assistant.tools.infrastructure import (
+    ConfirmingToolsProvider,
+    LocalToolsProvider,
+)
+from family_assistant.tools.types import ToolExecutionContext
+
+
+@pytest.fixture
+async def attachment_registry(
+    tmp_path: Path,
+    db_engine: AsyncEngine,
+) -> AttachmentRegistry:
+    """Create an AttachmentRegistry for testing."""
+    test_storage = tmp_path / "test_attachments"
+    test_storage.mkdir(exist_ok=True)
+    return AttachmentRegistry(
+        storage_path=str(test_storage), db_engine=db_engine, config=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_jq_query_from_script_no_deadlock(
+    db_engine: AsyncEngine,
+    attachment_registry: AttachmentRegistry,
+) -> None:
+    """Test that jq_query() doesn't deadlock when called from a script.
+
+    This test reproduces the deadlock issue where calling jq_query() from within
+    a Starlark script causes a 30-second timeout. The deadlock occurs because:
+
+    1. _process_attachment_arguments() (async coroutine on main loop)
+    2. → calls _get_raw_tool_definitions() (sync method)
+    3. → which calls _run_async(get_tool_definitions()) with ConfirmingToolsProvider
+    4. → creates nested _run_async() call while already in async context
+    5. → deadlock: main loop blocked, can't process the new coroutine
+    """
+    async with DatabaseContext(engine=db_engine) as db:
+        # Create a basic LocalToolsProvider
+        local_provider = LocalToolsProvider(
+            definitions=TOOLS_DEFINITION,
+            implementations=AVAILABLE_FUNCTIONS,
+        )
+
+        # Wrap it in ConfirmingToolsProvider
+        # This doesn't have get_raw_tool_definitions(), triggering the deadlock
+        confirming_provider = ConfirmingToolsProvider(
+            wrapped_provider=local_provider,
+            tools_requiring_confirmation=set(),  # No tools need confirmation, we just need the wrapper
+        )
+
+        ctx = ToolExecutionContext(
+            interface_type="test",
+            conversation_id="test-conv",
+            user_name="test",
+            turn_id=None,
+            db_context=db,
+            clock=None,
+            home_assistant_client=None,
+            event_sources=None,
+            attachment_registry=attachment_registry,
+            processing_service=None,
+            tools_provider=confirming_provider,  # Use confirming provider
+        )
+
+        # Script that creates an attachment and then calls jq_query() on it
+        # This will trigger the deadlock in _process_attachment_arguments
+        script = """
+# Create a JSON attachment (use text/plain since application/json isn't in allowed list)
+test_data = [
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+    {"name": "Charlie", "age": 35}
+]
+attachment = attachment_create(
+    content=json_encode(test_data),
+    filename="test_data.json",
+    description="Test data",
+    mime_type="text/plain"
+)
+
+# Query the attachment to filter people over 30
+# This is where the deadlock occurs
+result = jq_query(
+    attachment_id=attachment["id"],
+    jq_program="[.[] | select(.age > 30)]"
+)
+result
+"""
+
+        # This should complete without timeout
+        # Currently it will timeout after 30s due to the deadlock
+        result = await execute_script_tool(ctx, script)
+
+        # Verify the script executed successfully
+        assert result.text is not None
+        assert "Charlie" in result.text or "35" in result.text


### PR DESCRIPTION
## Summary
Fixes a 30-second timeout issue when `jq_query()` is called from within a Starlark script.

## Root Cause
The deadlock occurred due to nested `_run_async()` calls creating a circular dependency:

1. Script execution runs in thread, calls `jq_query()`
2. `ToolsAPI.execute()` calls `_run_async(_process_attachment_arguments())`
3. `_process_attachment_arguments()` (async coroutine on main loop) calls `_get_raw_tool_definitions()` (sync method)
4. `_get_raw_tool_definitions()` calls `_run_async(get_tool_definitions())` when using `ConfirmingToolsProvider`
5. **DEADLOCK**: Main loop blocked in sync method waiting for `_get_raw_tool_definitions()` to return, can't process the newly scheduled coroutine → 30-second timeout

## Solution
Made `_get_raw_tool_definitions()` async to eliminate the nested `_run_async()` call:

- Changed signature: `async def _get_raw_tool_definitions()`
- Replaced `self._run_async(self.tools_provider.get_tool_definitions())` with `await self.tools_provider.get_tool_definitions()`
- Updated caller to: `await self._get_raw_tool_definitions()`

This eliminates the sync-to-async bridge since both caller and callee are now async, allowing normal await flow instead of problematic thread coordination.

## Changes
- `src/family_assistant/scripting/apis/tools.py`: Made `_get_raw_tool_definitions()` async
- `tests/unit/scripting/test_jq_query_deadlock.py`: Added regression test

## Testing
- ✅ New test passes (reproduces and verifies fix)
- ✅ All scripting tests pass (150 tests)
- ✅ All execute_script attachment tests pass (14 tests)
- ✅ All data manipulation tests pass (20 tests)
- ✅ Full test suite passes (`poe test`)
- ✅ Linting passes

## Note
This is separate from commit 512a60e0 which added `asyncio.to_thread()` to prevent blocking in `jq_query_tool()`. That commit addressed blocking operations when tools are called directly from async code, while this commit fixes the deadlock when tools are called from scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)