### PR TITLE
Add debug flag to chart creation tool

### DIFF
--- a/src/family_assistant/tools/data_visualization.py
+++ b/src/family_assistant/tools/data_visualization.py
@@ -190,7 +190,7 @@ async def create_vega_chart_tool(
 
         # If debug mode, return the spec as structured data instead of rendering
         if debug:
-            return ToolResult(text=f"Debug: Generated spec for {title}", data=spec_dict)
+            return ToolResult(data=spec_dict)
 
         # Determine if this is Vega or Vega-Lite based on schema
         is_vega_lite = False

--- a/tests/unit/tools/test_data_visualization_tools.py
+++ b/tests/unit/tools/test_data_visualization_tools.py
@@ -599,7 +599,6 @@ March,200"""
         )
 
         assert isinstance(result, ToolResult)
-        assert "Debug: Generated spec for Debug Test" in result.get_text()
         # Should not have PNG attachments in debug mode
         assert not result.attachments or len(result.attachments) == 0
 
@@ -609,6 +608,12 @@ March,200"""
         assert isinstance(returned_spec, dict)
         assert "$schema" in returned_spec
         assert "data" in returned_spec
+
+        # Verify get_text() auto-generates JSON from data
+        text = result.get_text()
+        assert text  # Should not be empty
+        parsed = json.loads(text)  # Should be valid JSON
+        assert parsed == returned_spec  # Should match the data
 
     @pytest.mark.asyncio
     async def test_debug_mode_with_data_attachments(
@@ -627,7 +632,6 @@ March,200"""
         )
 
         assert isinstance(result, ToolResult)
-        assert "Debug: Generated spec for Debug with CSV" in result.get_text()
         assert not result.attachments or len(result.attachments) == 0
 
         # Get the returned spec as structured data
@@ -643,6 +647,12 @@ March,200"""
         assert len(values) == 3
         assert values[0]["month"] == "January"
         assert values[0]["sales"] == "100"
+
+        # Verify get_text() auto-generates JSON from data
+        text = result.get_text()
+        assert text  # Should not be empty
+        parsed = json.loads(text)  # Should be valid JSON
+        assert parsed == returned_spec  # Should match the data
 
     @pytest.mark.asyncio
     async def test_debug_mode_with_direct_data(self, mock_exec_context: Mock) -> None:
@@ -669,7 +679,6 @@ March,200"""
         )
 
         assert isinstance(result, ToolResult)
-        assert "Debug: Generated spec for Debug with Data" in result.get_text()
         assert not result.attachments or len(result.attachments) == 0
 
         # Get the returned spec as structured data
@@ -681,3 +690,9 @@ March,200"""
         assert "data" in returned_spec
         assert "values" in returned_spec["data"]
         assert returned_spec["data"]["values"] == data["mydata"]
+
+        # Verify get_text() auto-generates JSON from data
+        text = result.get_text()
+        assert text  # Should not be empty
+        parsed = json.loads(text)  # Should be valid JSON
+        assert parsed == returned_spec  # Should match the data


### PR DESCRIPTION
Add a debug parameter to the create_vega_chart tool that returns the generated Vega/Vega-Lite spec as JSON instead of rendering it to PNG. This is useful for debugging and inspecting the spec with data merged in.

Changes:
- Add debug boolean parameter to tool definition (default: false)
- Return formatted JSON spec when debug=true instead of PNG
- Fix data merging logic to work with direct data parameter (was only working when data_attachments were provided)
- Add comprehensive tests for debug mode with different data sources

The debug mode returns the spec after all data processing and merging, so it shows exactly what would be sent to the Vega renderer.