### PR TITLE
fix: Change SSE connection errors from console.error to console.warn

### DIFF
--- a/frontend/src/chat/useLiveMessageUpdates.ts
+++ b/frontend/src/chat/useLiveMessageUpdates.ts
@@ -88,7 +88,9 @@ export function useLiveMessageUpdates({
       });
 
       eventSource.onerror = (error) => {
-        console.error('[SSE] Connection error:', error);
+        // Log as warning since SSE disconnections are expected during normal operation
+        // (server restarts, network issues, etc.) and we handle reconnection automatically
+        console.warn('[SSE] Connection error, will attempt to reconnect:', error);
         eventSource.close();
 
         // Attempt reconnection after 5 seconds by triggering useEffect


### PR DESCRIPTION
SSE disconnections are expected during normal operation (server restarts,
network issues, test teardown) and are automatically handled with reconnection
logic. Logging these as errors causes Playwright console error checkers to fail.

By logging as warnings instead, we:
- Still inform developers about SSE connection issues
- Don't trigger test failures for expected disconnections
- Maintain visibility into connection state for debugging

Fixes the flake in:
- test_base_page_console_errors
- test_automations_filters_interaction