### PR TITLE
Fix SessionStart hook script issue

### DIFF
--- a/.claude/session-start-hook.sh
+++ b/.claude/session-start-hook.sh
@@ -18,13 +18,10 @@ if [ -f "scripts/setup-workspace.sh" ]; then
     bash scripts/setup-workspace.sh
 fi
 
-# Ensure pgserver extra is installed on amd64 architectures
-ARCH=$(uname -m)
-if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
-    echo "🔍 Ensuring pgserver extra is installed..." >&2
-    source .venv/bin/activate
-    uv sync --extra dev --extra pgserver
-fi
+# Ensure pgserver extra is installed
+echo "🔍 Ensuring pgserver extra is installed..." >&2
+source .venv/bin/activate
+uv sync --extra dev --extra pgserver
 
 # Set environment variables for the activated virtual environment
 VENV_PATH="$(pwd)/.venv"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ poe test
 The setup script will:
 
 - Create a virtual environment (`.venv`)
-- Install all Python dependencies using `uv sync --extra dev` (includes all dev tools)
+- Install all Python dependencies using `uv sync --extra dev --extra pgserver` (includes all dev
+  tools and PostgreSQL test server)
 - Install pre-commit hooks
 - Install frontend dependencies (`npm ci --prefix frontend`)
 - Install Playwright browsers
@@ -71,8 +72,8 @@ If you prefer to set up manually:
 uv venv .venv
 source .venv/bin/activate
 
-# Install Python dependencies (includes dev dependencies)
-uv sync --extra dev
+# Install Python dependencies (includes dev dependencies and pgserver)
+uv sync --extra dev --extra pgserver
 
 # Install pre-commit hooks
 .venv/bin/pre-commit install
@@ -86,11 +87,6 @@ npm ci --prefix frontend
 # Optional: Install local embedding model support (adds ~450MB of dependencies)
 # Only needed if you want to use local sentence transformer models instead of cloud APIs
 uv sync --extra dev --extra local-embeddings
-
-# Optional: Install pgserver for PostgreSQL testing
-# Only needed if TEST_DATABASE_URL is unset (e.g., cloud coding environments)
-# Not needed if you have access to an external PostgreSQL database
-uv sync --extra dev --extra pgserver
 ```
 
 ## Dependency Management
@@ -402,12 +398,13 @@ When evaluating input trust levels:
   - Any content from unauthenticated sources
 
 - This approach requires enforcing strong authentication and authorization at the interface
-  boundaries
-The current architecture primarily operates in **[BC]** mode:
+  boundaries The current architecture primarily operates in **[BC]** mode:
 
 - Input filtering and authentication ensure only authorized users can interact with the system
+
 - The agent can access sensitive data (notes, calendar, contacts) and take actions (creating tasks,
   sending notifications)
+
 - This approach requires maintaining strong authentication and authorization at the interface
   boundaries
 

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -34,16 +34,7 @@ source .venv/bin/activate
 
 # Step 3: Install Python dependencies
 echo "📥 Installing Python dependencies..."
-
-# Detect architecture for pgserver extra
-ARCH=$(uname -m)
-if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
-    echo "🔍 Detected amd64 architecture, installing pgserver extra..."
-    uv sync --extra dev --extra pgserver
-else
-    echo "🔍 Detected non-amd64 architecture ($ARCH), skipping pgserver extra..."
-    uv sync --extra dev
-fi
+uv sync --extra dev --extra pgserver
 
 # Install additional dev tools that might not be in pyproject.toml
 echo "📥 Installing additional development tools..."


### PR DESCRIPTION
Summary of Changes
I've updated the project to install pgserver unconditionally for all architectures (since arm64 wheels are now available):

Files Modified:
scripts/setup-workspace.sh

Removed architecture detection logic
Now runs uv sync --extra dev --extra pgserver unconditionally
Simplified from 11 lines to 2 lines
.claude/session-start-hook.sh

Removed architecture detection logic
Always installs pgserver extra in remote Claude Code sessions
Updated message to remove "on amd64 architectures" qualifier
AGENTS.md

Updated Quick Setup section to mention pgserver is installed by default
Updated Manual Installation section to show pgserver as part of the standard install
Removed the "Optional" section for pgserver (now it's standard)