### PR TITLE
fix: Add escaping workaround for telegramify_markdown bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,12 +402,13 @@ When evaluating input trust levels:
   - Any content from unauthenticated sources
 
 - This approach requires enforcing strong authentication and authorization at the interface
-  boundaries
-The current architecture primarily operates in **[BC]** mode:
+  boundaries The current architecture primarily operates in **[BC]** mode:
 
 - Input filtering and authentication ensure only authorized users can interact with the system
+
 - The agent can access sensitive data (notes, calendar, contacts) and take actions (creating tasks,
   sending notifications)
+
 - This approach requires maintaining strong authentication and authorization at the interface
   boundaries
 

--- a/README.md
+++ b/README.md
@@ -1,65 +1,78 @@
 # Family Assistant
 
-Family Assistant is an LLM-powered application designed for family information management and task automation. It provides multiple interfaces (Telegram, Web UI, Email webhooks) and uses a modular architecture built with Python, FastAPI, and SQLAlchemy. The goal of this project is to create a centralized, intelligent assistant that can help with a variety of tasks, from scheduling and reminders to answering questions based on your personal documents.
+Family Assistant is an LLM-powered application designed for family information management and task
+automation. It provides multiple interfaces (Telegram, Web UI, Email webhooks) and uses a modular
+architecture built with Python, FastAPI, and SQLAlchemy. The goal of this project is to create a
+centralized, intelligent assistant that can help with a variety of tasks, from scheduling and
+reminders to answering questions based on your personal documents.
 
 ## Features
 
--   **Multiple Interfaces**: Interact with the assistant via Telegram, a responsive web UI, or by forwarding emails.
--   **LLM-Powered**: Leverages the power of Large Language Models for natural language understanding and generation. You can configure different models for different tasks.
--   **Task Automation**: Automate repetitive tasks with a powerful scheduling and callback system.
--   **Document Indexing**: Ingest and search through your documents, including PDFs, text files, and web pages. The assistant can use this information to answer questions.
--   **Calendar Integration**: Connects with CalDAV and iCal calendars to manage your family's schedule.
--   **Extensible**: Add new tools and capabilities to the assistant. The project is designed to be modular and easy to extend.
--   **Configurable**: Fine-tune the assistant's behavior with a flexible configuration system using `config.yaml` and environment variables.
+- **Multiple Interfaces**: Interact with the assistant via Telegram, a responsive web UI, or by
+  forwarding emails.
+- **LLM-Powered**: Leverages the power of Large Language Models for natural language understanding
+  and generation. You can configure different models for different tasks.
+- **Task Automation**: Automate repetitive tasks with a powerful scheduling and callback system.
+- **Document Indexing**: Ingest and search through your documents, including PDFs, text files, and
+  web pages. The assistant can use this information to answer questions.
+- **Calendar Integration**: Connects with CalDAV and iCal calendars to manage your family's
+  schedule.
+- **Extensible**: Add new tools and capabilities to the assistant. The project is designed to be
+  modular and easy to extend.
+- **Configurable**: Fine-tune the assistant's behavior with a flexible configuration system using
+  `config.yaml` and environment variables.
 
 ## Architecture
 
 Family Assistant is built with a modern Python stack, featuring:
 
--   **Backend**: FastAPI for the web server, SQLAlchemy for database interactions, and `uv` for dependency management.
--   **Frontend**: A React application built with Vite, TypeScript, and Tailwind CSS.
--   **Asynchronous**: Fully asynchronous architecture using `asyncio` for high performance.
--   **Dependency Injection**: Promotes modular and testable code.
--   **Repository Pattern**: Encapsulates data access logic for clean and maintainable code.
--   **Event-Driven**: Loosely coupled components communicate via events.
+- **Backend**: FastAPI for the web server, SQLAlchemy for database interactions, and `uv` for
+  dependency management.
+- **Frontend**: A React application built with Vite, TypeScript, and Tailwind CSS.
+- **Asynchronous**: Fully asynchronous architecture using `asyncio` for high performance.
+- **Dependency Injection**: Promotes modular and testable code.
+- **Repository Pattern**: Encapsulates data access logic for clean and maintainable code.
+- **Event-Driven**: Loosely coupled components communicate via events.
 
-For a detailed architecture overview, see [docs/architecture-diagram.md](docs/architecture-diagram.md).
+For a detailed architecture overview, see
+[docs/architecture-diagram.md](docs/architecture-diagram.md).
 
 ## Getting Started
 
 ### Prerequisites
 
--   Python 3.10+
--   Node.js and npm
--   Docker (recommended for the development environment)
+- Python 3.10+
+- Node.js and npm
+- Docker (recommended for the development environment)
 
 ### Installation
 
-1.  **Clone the repository:**
+1. **Clone the repository:**
 
-    ```bash
-    git clone https://github.com/your-username/family-assistant.git
-    cd family-assistant
-    ```
+   ```bash
+   git clone https://github.com/your-username/family-assistant.git
+   cd family-assistant
+   ```
 
-    git clone https://github.com/werdnum/family-assistant.git
-    The easiest way to set up your development environment is to use the setup script:
+   git clone https://github.com/werdnum/family-assistant.git The easiest way to set up your
+   development environment is to use the setup script:
 
-    ```bash
-    ./scripts/setup-workspace.sh
-    ```
+   ```bash
+   ./scripts/setup-workspace.sh
+   ```
 
-    This script will:
-    -   Create a virtual environment (`.venv`)
-    -   Install Python dependencies
-    -   Install frontend dependencies
-    -   Set up pre-commit hooks
+   This script will:
 
-3.  **Activate the virtual environment:**
+   - Create a virtual environment (`.venv`)
+   - Install Python dependencies
+   - Install frontend dependencies
+   - Set up pre-commit hooks
 
-    ```bash
-    source .venv/bin/activate
-    ```
+2. **Activate the virtual environment:**
+
+   ```bash
+   source .venv/bin/activate
+   ```
 
 For manual installation instructions, see `AGENTS.md`.
 
@@ -67,21 +80,27 @@ For manual installation instructions, see `AGENTS.md`.
 
 The application is configured through `config.yaml` and environment variables.
 
--   **`config.yaml`**: The main configuration file for the application. It defines service profiles, tool configurations, LLM parameters, and the document indexing pipeline.
--   **`prompts.yaml`**: This file contains the prompts used by the LLM, allowing you to customize the assistant's personality and behavior.
--   **`.env`**: Create a `.env` file in the root of the project to store your secrets, such as API keys and database URLs. You can use `.env.example` as a template.
+- **`config.yaml`**: The main configuration file for the application. It defines service profiles,
+  tool configurations, LLM parameters, and the document indexing pipeline.
+- **`prompts.yaml`**: This file contains the prompts used by the LLM, allowing you to customize the
+  assistant's personality and behavior.
+- **`.env`**: Create a `.env` file in the root of the project to store your secrets, such as API
+  keys and database URLs. You can use `.env.example` as a template.
 
 ### Environment Variables
 
 The following environment variables are the most important for getting started:
 
--   `TELEGRAM_BOT_TOKEN`: Your Telegram bot token.
--   `OPENROUTER_API_KEY`: Your OpenRouter API key.
--   `GEMINI_API_KEY`: Your Google Gemini API key.
--   `DATABASE_URL`: The URL for your database (e.g., `sqlite+aiosqlite:///family_assistant.db` or `postgresql+asyncpg://user:password@host/dbname`).
--   `ALLOWED_USER_IDS`: A comma-separated list of Telegram user IDs that are allowed to interact with the bot.
+- `TELEGRAM_BOT_TOKEN`: Your Telegram bot token.
+- `OPENROUTER_API_KEY`: Your OpenRouter API key.
+- `GEMINI_API_KEY`: Your Google Gemini API key.
+- `DATABASE_URL`: The URL for your database (e.g., `sqlite+aiosqlite:///family_assistant.db` or
+  `postgresql+asyncpg://user:password@host/dbname`).
+- `ALLOWED_USER_IDS`: A comma-separated list of Telegram user IDs that are allowed to interact with
+  the bot.
 
-For a full list of environment variables, see the `load_config` function in `src/family_assistant/__main__.py`.
+For a full list of environment variables, see the `load_config` function in
+`src/family_assistant/__main__.py`.
 
 ## Usage
 
@@ -93,19 +112,20 @@ To run the application in development mode with hot-reloading:
 poe dev
 ```
 
-This will start both the backend and frontend servers. You can access the web UI at `http://localhost:5173`.
+This will start both the backend and frontend servers. You can access the web UI at
+`http://localhost:5173`.
 
 ### Development Commands
 
 The project uses `poethepoet` as a task runner. Here are some of the most common commands:
 
--   **`poe lint`**: Run the full linting suite.
--   **`poe test`**: Run the test suite.
--   **`poe format`**: Format the code.
--   **`poe serve`**: Run the backend server only.
--   **`poe serve-reload`**: Run the backend server with auto-reloading.
--   **`poe ui-dev`**: Run the frontend development server.
--   **`poe ui-build`**: Build the production frontend assets.
+- **`poe lint`**: Run the full linting suite.
+- **`poe test`**: Run the test suite.
+- **`poe format`**: Format the code.
+- **`poe serve`**: Run the backend server only.
+- **`poe serve-reload`**: Run the backend server with auto-reloading.
+- **`poe ui-dev`**: Run the frontend development server.
+- **`poe ui-build`**: Build the production frontend assets.
 
 For a full list of commands, see the `[tool.poe.tasks]` section in `pyproject.toml`.
 
@@ -123,36 +143,38 @@ You can also run specific tests:
 pytest tests/functional/test_specific.py
 ```
 
-The test suite includes unit tests, functional tests, and integration tests. It uses `pytest` for the backend and `vitest` for the frontend.
+The test suite includes unit tests, functional tests, and integration tests. It uses `pytest` for
+the backend and `vitest` for the frontend.
 
 ## Frontend Development
 
-The frontend is a React application located in the `frontend/` directory. It uses Vite for the build tooling, TypeScript for type safety, and Tailwind CSS for styling.
+The frontend is a React application located in the `frontend/` directory. It uses Vite for the build
+tooling, TypeScript for type safety, and Tailwind CSS for styling.
 
 ### Frontend Scripts
 
--   **`npm run dev`**: Start the Vite development server.
--   **`npm run build`**: Build the production assets.
--   **`npm run lint`**: Lint the frontend code.
--   **`npm run test`**: Run the frontend tests with `vitest`.
--   **`npm run format`**: Format the frontend code with `biome`.
+- **`npm run dev`**: Start the Vite development server.
+- **`npm run build`**: Build the production assets.
+- **`npm run lint`**: Lint the frontend code.
+- **`npm run test`**: Run the frontend tests with `vitest`.
+- **`npm run format`**: Format the frontend code with `biome`.
 
 ## Database Migrations
 
 The project uses Alembic for database migrations.
 
--   **Create a new migration:**
+- **Create a new migration:**
 
-    When you make changes to the SQLAlchemy models, you'll need to generate a new migration script:
+  When you make changes to the SQLAlchemy models, you'll need to generate a new migration script:
 
-    ```bash
-    alembic revision --autogenerate -m "Your migration message"
-    ```
+  ```bash
+  alembic revision --autogenerate -m "Your migration message"
+  ```
 
--   **Apply migrations:**
+- **Apply migrations:**
 
-    To apply the latest migrations to your database:
+  To apply the latest migrations to your database:
 
-    ```bash
-    alembic upgrade head
-    ```
+  ```bash
+  alembic upgrade head
+  ```


### PR DESCRIPTION
The telegramify_markdown library has bugs where it doesn't properly
escape '<' and '>' characters in certain contexts:
1. '<' characters are never escaped
2. '>' at the start of lines (blockquotes) are not escaped

This causes Telegram's MarkdownV2 parser to fail with errors like:
"Can't parse entities: character '>' is reserved and must be escaped
with the preceding '\'"

This commit adds a post-processing function that fixes these escaping
bugs by ensuring all unescaped '<' and '>' characters are properly
escaped.

Changes:
- Add fix_telegramify_markdown_escaping() utility function in
  telegram/markdown_utils.py
- Apply the fix in all locations that call telegramify_markdown.markdownify():
  - telegram/interface.py (send_message)
  - telegram/handler.py (process_batch, handle_generic_slash_command)
  - telegram/ui.py (request_confirmation)
- Add comprehensive unit tests for the escaping fix

The fix detects unescaped '<' and '>' characters and adds the necessary
backslash escape, while avoiding double-escaping already-escaped characters.

Issue: #011CUqp7qEvcMyj2nqUg96R4