### PR TITLE
feat: Add automatic Claude plugin marketplace updates

### DIFF
--- a/.devcontainer/claude-wrapper.sh
+++ b/.devcontainer/claude-wrapper.sh
@@ -95,6 +95,12 @@ if [ -f "frontend/package.json" ] && [ ! -d "frontend/node_modules" ]; then
     npm install --prefix frontend
 fi
 
+# Update Claude plugin marketplaces
+echo "🔄 Updating Claude plugin marketplaces..."
+/home/claude/.npm-global/bin/claude plugin marketplace update >/dev/null 2>&1 || {
+    echo "⚠️  Warning: Failed to update plugin marketplaces"
+}
+
 export BASH_DEFAULT_TIMEOUT_MS=300000
 export BASH_MAX_TIMEOUT_MS=3600000
 export CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -75,7 +75,18 @@ if grep -q "playwright" pyproject.toml 2>/dev/null; then
     }
 fi
 
-# Step 8: Verify setup
+# Step 8: Update Claude plugin marketplaces
+if command -v claude >/dev/null 2>&1; then
+    echo "🔄 Updating Claude plugin marketplaces..."
+    claude plugin marketplace update || {
+        echo "⚠️  Warning: Failed to update Claude plugin marketplaces"
+        echo "   You may need to run: claude plugin marketplace update manually"
+    }
+else
+    echo "⚠️  Claude CLI not found, skipping plugin marketplace update"
+fi
+
+# Step 9: Verify setup
 echo ""
 echo "✅ Workspace setup complete!"
 echo ""


### PR DESCRIPTION
## Summary

- Adds automatic updates of Claude plugin marketplaces to keep plugins up-to-date
- Updates run during Claude startup (via `claude-wrapper.sh`)
- Updates run during workspace setup (via `setup-workspace.sh`)

## Changes

### `.devcontainer/claude-wrapper.sh`
- Added `claude plugin marketplace update` before starting Claude
- Suppresses output to avoid noise
- Includes error handling to prevent startup failures

### `scripts/setup-workspace.sh`
- Added marketplace update as Step 8 in workspace setup
- Checks if Claude CLI is available before attempting update
- Provides helpful error messages if update fails

## Benefits

- Ensures developers always have access to the latest plugin versions
- Automatically syncs both `anthropic-agent-skills` and `claude-code-plugins` marketplaces
- No manual intervention required

## Test Plan

- [x] Verified `claude plugin marketplace update` is the correct command
- [x] Validated bash syntax for both scripts
- [x] Tested command execution successfully updates 2 marketplaces
- [x] Confirmed error handling works properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)