### PR TITLE
Remove uv cache from dev container build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -65,8 +65,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 # User setup
 RUN useradd -m -s /bin/bash -u 1001 claude && \
-    mkdir -p /home/claude/.cache/uv \
-             /home/claude/.npm-global \
+    mkdir -p /home/claude/.npm-global \
              /home/claude/.cache/deno \
              /home/claude/.deno \
              /home/claude/.cache/playwright-browsers \

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - TEST_DATABASE_URL=postgresql+asyncpg://test:test@postgres:5432/test
       - DEV_MODE=true
       - HOME=/home/claude
+      - UV_CACHE_DIR=/workspace/.cache/uv
       # Pass through any additional environment variables
       - CLAUDE_PROJECT_REPO=${CLAUDE_PROJECT_REPO:-https://github.com/werdnum/family-assistant.git}
       - CLAUDE_PROJECT_BRANCH=${CLAUDE_PROJECT_BRANCH:-}
@@ -90,6 +91,7 @@ services:
       - TEST_DATABASE_URL=postgresql+asyncpg://test:test@postgres:5432/test
       - DEV_MODE=true
       - HOME=/home/claude
+      - UV_CACHE_DIR=/workspace/.cache/uv
       - PYTEST_PARALLELISM=auto
       # Oneshot mode environment variables
       - ONESHOT_MODE=${ONESHOT_MODE:-}
@@ -127,6 +129,7 @@ services:
     environment:
       - CLAUDE_PROJECT_REPO=${CLAUDE_PROJECT_REPO:-https://github.com/werdnum/family-assistant.git}
       - GITHUB_TOKEN=${GITHUB_TOKEN:-}
+      - UV_CACHE_DIR=/workspace/.cache/uv
     volumes:
       - ${WORKSPACE_DIR:-./workspace}:/workspace
       - ${CLAUDE_HOME_DIR:-./claude-home}:/home/claude


### PR DESCRIPTION
Problem:
- uv cache was in /home/claude/.cache/uv (claude-home volume)
- .venv is in /workspace/main (workspace volume)
- Different volumes = different filesystems
- uv falls back to copying instead of hardlinking
- Result: wasted disk space with duplicate dependencies

Solution:
- Set UV_CACHE_DIR=/workspace/.cache/uv in docker-compose
- Both cache and .venv now on same volume → hardlinking works
- Removed /home/claude/.cache/uv directory creation from Dockerfile

CI remains optimized:
- CI containers still use /opt/uv-cache (pre-populated at build time)
- CI workflow explicitly sets UV_CACHE_DIR=/opt/uv-cache
- Fast CI builds unchanged

Benefits:
- Disk space savings: hardlinks instead of copies
- Single shared cache per workspace instead of per-container
- Slightly slower first startup (cache not pre-populated) but significant long-term savings