### PR TITLE
Debug bash-guard hooks not triggering

### DIFF
--- a/.claude/README_HOOKS.md
+++ b/.claude/README_HOOKS.md
@@ -23,8 +23,9 @@ Prevents dangerous shell commands and enforces best practices through PreToolUse
 
 - Container URL rewrites (localhost → devcontainer-backend-1)
 - Dev server blocking (prevents duplicate instances)
-- Test timeout requirements (pytest: 5min, poe test: 15min)
 - Command optimizations (npm --prefix, llm -f)
+- Test timeout requirements (pytest: 5min, poe test: 15min)
+- Background restrictions (poe test must run in foreground)
 
 ### 2. **format-and-lint** - Code Quality
 
@@ -60,9 +61,16 @@ Ensures code quality through test verification, pre-commit workflows, and stop v
 
 **Project Configuration**:
 
-- Code review enabled using `scripts/review-changes.py`
-- Test verification for pytest and poe test
-- Excludes documentation files from test requirements
+- **Code review**: Enabled using `scripts/review-changes.py`
+- **Test verification**: Checks that tests have been run before commits
+  - Triggers on `git commit`
+  - Excludes documentation and config files
+  - Accepts `poe test` and `.venv/bin/poe test` as valid test commands
+  - Checks `.report.json` for test results (max age: 5 minutes)
+- **Stop validation**: Validates completeness before stopping session
+  - Checks for clean working directory
+  - Verifies tests have been run
+  - Allows failure acknowledgment via `.claude/FAILURE_REASON`
 
 ### 4. **development-agents** - Specialized Agents
 

--- a/.claude/bash-guard.json
+++ b/.claude/bash-guard.json
@@ -88,6 +88,24 @@
       "action": "block",
       "explanation": "DATABASE_URL is already correctly set in the environment. Do not override it when running alembic commands. Simply run 'alembic revision --autogenerate -m \"Description\"' without DATABASE_URL prefix."
     }
+  ],
+  "timeout_requirements": [
+    {
+      "regexp": "^pytest\\b",
+      "minimum_timeout_ms": 300000,
+      "explanation": "pytest requires at least 5 minutes for comprehensive test execution"
+    },
+    {
+      "regexp": "^poe\\s+test\\b",
+      "minimum_timeout_ms": 900000,
+      "explanation": "poe test requires at least 15 minutes for full test suite including integration tests"
+    }
+  ],
+  "background_restrictions": [
+    {
+      "regexp": "^poe\\s+test\\b",
+      "explanation": "poe test must run in foreground to ensure proper output capture and test result visibility"
+    }
   ]
 }
 

--- a/.claude/guardian.json
+++ b/.claude/guardian.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Project-specific guardian configuration for family-assistant. Enables code review workflow.",
+  "comment": "Project-specific guardian configuration for family-assistant. Enables code review, test verification, and completion validation.",
   "preCommitReview": {
     "workflow": {
       "runCodeReview": {
@@ -7,6 +7,46 @@
         "scriptPath": "scripts/review-changes.py"
       }
     }
+  },
+  "testVerification": {
+    "enabled": true,
+    "triggers": ["git commit"],
+    "excludePatterns": [
+      "^docs/",
+      "^\\.claude/",
+      "^\\.github/",
+      "^\\.devcontainer/",
+      "^deploy/",
+      "^contrib/",
+      "^scripts/review-changes\\.(py|sh)$",
+      "^scripts/format-and-lint\\.sh$",
+      "^\\.pre-commit-config\\.yaml$",
+      "^\\.gitignore$",
+      "^\\.dockerignore$",
+      "\\.(md|txt)$",
+      "^scratch/",
+      "^tmp/",
+      "^README",
+      "^LICENSE",
+      "^CHANGELOG",
+      "^Dockerfile$",
+      "^\\.devcontainer/Dockerfile",
+      "^\\.devcontainer/Dockerfile\\.ci$"
+    ],
+    "acceptableCommands": [
+      "poe test",
+      ".venv/bin/poe test",
+      "./\\.venv/bin/poe test"
+    ],
+    "reportFile": ".report.json",
+    "maxTestAge": 300
+  },
+  "stopValidation": {
+    "enabled": true,
+    "checkCleanWorkingDirectory": true,
+    "checkTestsRun": true,
+    "allowFailureAcknowledgment": true,
+    "failureReasonFile": ".claude/FAILURE_REASON"
   }
 }
 


### PR DESCRIPTION
…dian

Complete the plugin migration from commit 1a4b6d9 by adding missing configuration sections that were present in the old custom hooks.

**bash-guard.json changes:**
- Add timeout_requirements: enforce 5min for pytest, 15min for poe test
- Add background_restrictions: prevent poe test from running in background

**guardian.json changes:**
- Add testVerification: verify tests run before commits
  - Triggers on git commit
  - Excludes docs/config files
  - Checks .report.json (max age 5min)
- Add stopValidation: validate completeness before stopping
  - Checks clean working directory
  - Verifies tests have been run
  - Allows failure acknowledgment via .claude/FAILURE_REASON

**Documentation:**
- Update README_HOOKS.md with complete configuration details

These configurations replicate the behavior of the old custom hooks (test-verification-hook.sh, banned_commands.json) that were removed in the original migration but whose functionality was not fully configured in the new plugin configuration files.

Fixes enforcement of:
- Test timeout requirements
- Test verification before commits
- Code review workflow
- Stop validation checks