### PR TITLE
Switch to gemini-3-pro-preview as primary model

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -118,7 +118,7 @@ default_profile_settings:
     retry_config:
       primary:
         provider: "google"
-        model: "gemini-2.5-pro"
+        model: "gemini-3-pro-preview"
       fallback:
         provider: "openai"
         model: "gpt-5"


### PR DESCRIPTION
## Summary

This PR switches the default primary model from gemini-2.5-pro to gemini-3-pro-preview, deploying support for the new Gemini 3.0 Pro preview model with thought signatures.

## Changes

- Updated `config.yaml` to use `google/gemini-3-pro-preview` as the primary model

## Context

The thought signature implementation was completed and merged to main. This change deploys the model switch to take advantage of Gemini 3.0 Pro preview's thought signature capabilities in production.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>