### PR TITLE
Fix: Add disk cleanup to devcontainer build jobs

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -45,6 +45,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - name: Free up disk space
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "After cleanup:"
+          df -h
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Set up QEMU

--- a/.github/workflows/ci-with-devcontainer.yml
+++ b/.github/workflows/ci-with-devcontainer.yml
@@ -110,6 +110,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Free up disk space
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "After cleanup:"
+          df -h
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Set up Docker Buildx
@@ -140,6 +151,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
+      - name: Free up disk space
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          echo "After cleanup:"
+          df -h
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Set up Docker Buildx


### PR DESCRIPTION
This PR adds a 'Free up disk space' step to the devcontainer build jobs in the GitHub Actions workflows. This is necessary to prevent disk space exhaustion on the GHA runners when building the large development image, mirroring the existing cleanup step in the main build job.