### PR TITLE
Fix devcontainer setup and add Reolink support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -153,4 +153,4 @@ RUN chmod +x /usr/local/bin/setup-workspace.sh \
 # Final user and entrypoint
 USER claude
 ENTRYPOINT ["/usr/local/bin/setup-workspace.sh"]
-CMD ["happy", "daemon", "start-sync"]
+CMD ["sh", "-c", "happy daemon start-sync"]

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - HOMEASSISTANT_API_KEY=${HOMEASSISTANT_API_KEY:-}
       - GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY:-}
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
+      - REOLINK_CAMERAS=${REOLINK_CAMERAS:-}
       - DEBUG_LLM_MESSAGES=true
     volumes:
       # Mount workspace - you can change this to your desired host directory

--- a/.devcontainer/setup-workspace.sh
+++ b/.devcontainer/setup-workspace.sh
@@ -181,7 +181,7 @@ if [ -f "pyproject.toml" ]; then
     
     # Install dependencies using uv sync to respect lock file
     echo "Installing Python dependencies..."
-    uv sync --extra dev
+    uv sync --extra dev --extra reolink
 
     uv pip install poethepoet pytest-xdist pre-commit
     
@@ -320,6 +320,8 @@ if [ "$RUNNING_AS_ROOT" = "true" ]; then
 fi
 
 echo "Workspace setup complete!"
+
+happy doctor clean
 
 # Execute the command passed to the container
 exec "$@"


### PR DESCRIPTION
## Summary

- Wrap `happy daemon start-sync` command in `sh -c` for proper shell processing in Dockerfile CMD
- Add `REOLINK_CAMERAS` environment variable to docker-compose.yml for camera support
- Install `--extra reolink` dependencies during workspace setup
- Run `happy doctor clean` before starting to ensure clean daemon state

## Test plan

- [ ] Verify devcontainer builds and starts correctly
- [ ] Confirm happy daemon starts properly with the new CMD format
- [ ] Check that Reolink dependencies are installed when workspace is set up

🤖 Generated with [Claude Code](https://claude.com/claude-code)