### PR TITLE
feat: add claude-code-plugins marketplace via local clone

### DIFF
--- a/.devcontainer/claude-wrapper.sh
+++ b/.devcontainer/claude-wrapper.sh
@@ -98,9 +98,10 @@ fi
 # Update Claude plugin marketplaces
 echo "🔄 Updating Claude plugin marketplaces..."
 # Pull latest changes from local plugin marketplace clone
-PLUGINS_DIR="/home/claude/claude-code-plugins"
+PLUGINS_DIR="$HOME/claude-code-plugins"
 if [ -d "$PLUGINS_DIR/.git" ]; then
-    (cd "$PLUGINS_DIR" && git pull --quiet 2>/dev/null) || {
+    # GIT_TERMINAL_PROMPT=0 prevents hanging if credentials are needed
+    (cd "$PLUGINS_DIR" && GIT_TERMINAL_PROMPT=0 git pull --quiet 2>/dev/null) || {
         echo "⚠️  Warning: Failed to pull plugin marketplace updates"
     }
 fi

--- a/.devcontainer/setup-workspace.sh
+++ b/.devcontainer/setup-workspace.sh
@@ -315,14 +315,17 @@ $CLAUDE_BIN mcp add --scope user playwright $(which npx) -- -y -q @playwright/mc
 
 # Configure Claude plugin marketplace from local clone
 # Note: Using local path because Claude Code's git auth handler doesn't work with GitHub URLs
-PLUGINS_DIR="/home/claude/claude-code-plugins"
+# Use /home/claude explicitly since this script runs as root (not as claude user)
+CLAUDE_HOME="/home/claude"
+PLUGINS_DIR="$CLAUDE_HOME/claude-code-plugins"
 echo "Setting up Claude plugin marketplace..."
 if [ ! -d "$PLUGINS_DIR" ]; then
     echo "Cloning claude-code-plugins repository..."
+    # GIT_TERMINAL_PROMPT=0 prevents hanging if credentials are needed
     if [ -n "$GITHUB_TOKEN" ]; then
-        git clone "https://${GITHUB_TOKEN}@github.com/werdnum/claude-code-plugins.git" "$PLUGINS_DIR"
+        GIT_TERMINAL_PROMPT=0 git clone "https://${GITHUB_TOKEN}@github.com/werdnum/claude-code-plugins.git" "$PLUGINS_DIR"
     else
-        git clone "https://github.com/werdnum/claude-code-plugins.git" "$PLUGINS_DIR"
+        GIT_TERMINAL_PROMPT=0 git clone "https://github.com/werdnum/claude-code-plugins.git" "$PLUGINS_DIR"
     fi
     if [ "$RUNNING_AS_ROOT" = "true" ]; then
         chown -R claude:claude "$PLUGINS_DIR"


### PR DESCRIPTION
Clone werdnum/claude-code-plugins to /home/claude/claude-code-plugins
and add it as a marketplace by file path. This works around an issue
where Claude Code's custom git auth handler doesn't work when adding
marketplaces via GitHub URL directly.

- setup-workspace.sh: Clone repo on initial setup, add as marketplace
- claude-wrapper.sh: Pull latest changes before marketplace update