### PR TITLE
style: apply updated ruff formatting rules

### DIFF
--- a/src/family_assistant/__main__.py
+++ b/src/family_assistant/__main__.py
@@ -976,8 +976,9 @@ def main() -> int:
     for sig_num, sig_name in signal_map.items():
         loop.add_signal_handler(
             sig_num,
-            lambda name=sig_name,
-            app_instance=assistant_app: app_instance.initiate_shutdown(name),
+            lambda name=sig_name, app_instance=assistant_app: (
+                app_instance.initiate_shutdown(name)
+            ),
         )
 
     if hasattr(signal, "SIGHUP"):

--- a/src/family_assistant/context_providers.py
+++ b/src/family_assistant/context_providers.py
@@ -587,7 +587,8 @@ class WeatherContextProvider(ContextProvider):
         current_temp = obs.get("temperature", {}).get("temperature", "N/A")
         apparent_temp = obs.get("temperature", {}).get("apparentTemperature", "N/A")
         current_precis = (
-            forecasts.get("weather", {})
+            forecasts
+            .get("weather", {})
             .get("days", [{}])[0]
             .get("entries", [{}])[0]
             .get("precis", "N/A")
@@ -635,7 +636,8 @@ class WeatherContextProvider(ContextProvider):
 
         # Rain Timing
         rain_prob_graph = (
-            graphs.get("rainfallprobability", {})
+            graphs
+            .get("rainfallprobability", {})
             .get("dataConfig", {})
             .get("series", {})
         )

--- a/src/family_assistant/processing.py
+++ b/src/family_assistant/processing.py
@@ -1974,7 +1974,8 @@ Call attach_to_response with your selected attachment IDs."""
                 local_tz = pytz.timezone(self.timezone_str)
                 # Use the injected clock's now() method
                 current_time_str = (
-                    self.clock.now()
+                    self.clock
+                    .now()
                     .astimezone(local_tz)
                     .strftime("%Y-%m-%d %H:%M:%S %Z")
                 )
@@ -2392,7 +2393,8 @@ Call attach_to_response with your selected attachment IDs."""
             try:
                 local_tz = pytz.timezone(self.timezone_str)
                 current_time_str = (
-                    self.clock.now()
+                    self.clock
+                    .now()
                     .astimezone(local_tz)
                     .strftime("%Y-%m-%d %H:%M:%S %Z")
                 )

--- a/src/family_assistant/storage/repositories/email.py
+++ b/src/family_assistant/storage/repositories/email.py
@@ -147,7 +147,8 @@ class EmailRepository(BaseRepository):
             stmt = stmt.where(received_emails_table.c.received_at >= since)
 
         stmt = (
-            stmt.order_by(received_emails_table.c.received_at.desc())
+            stmt
+            .order_by(received_emails_table.c.received_at.desc())
             .limit(limit)
             .offset(offset)
         )

--- a/src/family_assistant/storage/vector.py
+++ b/src/family_assistant/storage/vector.py
@@ -266,7 +266,8 @@ async def add_document(
                 doc_id = existing_doc_row["id"]
                 # 2. If exists, update it
                 update_stmt = (
-                    sa.update(DocumentRecord)
+                    sa
+                    .update(DocumentRecord)
                     .where(DocumentRecord.id == doc_id)
                     .values(**values_to_insert)
                 )
@@ -515,7 +516,8 @@ async def add_embedding(
                     if k not in {"document_id", "chunk_index", "embedding_type"}
                 }
                 update_stmt = (
-                    sa.update(DocumentEmbeddingRecord)
+                    sa
+                    .update(DocumentEmbeddingRecord)
                     .where(DocumentEmbeddingRecord.id == embedding_id)
                     .values(**update_values_for_embedding)
                 )
@@ -692,7 +694,8 @@ async def query_vectors(
         vector_subquery.c.embedding_id,
         vector_subquery.c.document_id,
         vector_subquery.c.distance,
-        func.row_number()
+        func
+        .row_number()
         .over(order_by=vector_subquery.c.distance.asc())
         .label("vec_rank"),
     ).cte("vector_results")
@@ -722,7 +725,8 @@ async def query_vectors(
             fts_subquery.c.embedding_id,
             fts_subquery.c.document_id,
             fts_subquery.c.score,
-            func.row_number()
+            func
+            .row_number()
             .over(order_by=fts_subquery.c.score.desc())
             .label("fts_rank"),
         ).cte("fts_results")
@@ -827,7 +831,8 @@ async def update_document_title_in_db(
         return
 
     stmt = (
-        sa.update(DocumentRecord)
+        sa
+        .update(DocumentRecord)
         .where(DocumentRecord.id == document_id)
         .values(title=new_title.strip())
     )

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -312,7 +312,8 @@ async def handle_llm_callback(
         f"Handling LLM callback for conversation {interface_type}:{conversation_id} (scheduled at {scheduling_timestamp_str})"
     )
     current_time_str = (
-        clock.now()
+        clock
+        .now()
         .astimezone(zoneinfo.ZoneInfo(exec_context.timezone_str))
         .strftime("%Y-%m-%d %H:%M:%S %Z")
     )  # Use timezone from context

--- a/src/family_assistant/tools/attachment_utils.py
+++ b/src/family_assistant/tools/attachment_utils.py
@@ -122,7 +122,8 @@ async def process_attachment_arguments(
 
         # Get the parameter definition from the tool schema
         properties = (
-            tool_definition.get("function", {})
+            tool_definition
+            .get("function", {})
             .get("parameters", {})
             .get("properties", {})
         )

--- a/tests/functional/telegram/test_telegram_handler.py
+++ b/tests/functional/telegram/test_telegram_handler.py
@@ -582,8 +582,11 @@ async def test_telegram_photo_persistence_and_llm_context(
         ),
         # Second message - LLM should still have access to historical image
         (
-            lambda args: has_image_content(args)
-            and "remember" in get_last_message_text(args.get("messages", [])).lower(),
+            lambda args: (
+                has_image_content(args)
+                and "remember"
+                in get_last_message_text(args.get("messages", [])).lower()
+            ),
             LLMOutput(
                 content="Yes, I still have access to the image you sent earlier. It's a test image."
             ),

--- a/tests/functional/web/ui/test_settings_ui.py
+++ b/tests/functional/web/ui/test_settings_ui.py
@@ -27,7 +27,8 @@ async def test_token_management_page_loads(
 
     # Check for token list or empty state using more specific selectors
     token_cards = (
-        page.locator("div")
+        page
+        .locator("div")
         .filter(has=page.locator("h3"))
         .filter(has=page.locator("code"))
     )  # Token cards have h3 and code elements
@@ -108,7 +109,8 @@ async def test_token_list_display(
 
     # Check for token items or empty state
     token_cards = (
-        page.locator("div")
+        page
+        .locator("div")
         .filter(has=page.locator("h3"))
         .filter(has=page.locator("code"))
     )  # Token cards have h3 and code elements


### PR DESCRIPTION
Ruff now prefers breaking before the `.` for chained method calls
that start with a parenthesized expression. Applied to 9 files.