### PR TITLE
Fix pytest warnings in email storage module

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,4 +27,5 @@ filterwarnings =
     ignore:websockets.server.WebSocketServerProtocol is deprecated:DeprecationWarning:uvicorn
     ignore:The `name` is not the first parameter anymore:DeprecationWarning:starlette
     ignore:No path_separator found in configuration:DeprecationWarning:alembic
+    ignore:Inheritance class AiohttpClientSession from ClientSession is discouraged:DeprecationWarning:google.genai
 

--- a/src/family_assistant/storage/email.py
+++ b/src/family_assistant/storage/email.py
@@ -7,7 +7,7 @@ import uuid  # Add uuid import
 from datetime import datetime  # Added for Pydantic models
 
 import sqlalchemy as sa
-from pydantic import BaseModel, Field  # Added for Pydantic models
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import JSON  # Import generic JSON type
 from sqlalchemy.dialects.postgresql import JSONB  # Import PostgreSQL specific JSONB
 from sqlalchemy.exc import SQLAlchemyError  # Use broader exception
@@ -51,8 +51,7 @@ class ParsedEmailData(BaseModel):
     mailgun_timestamp: str | None = Field(default=None, alias="timestamp")
     mailgun_token: str | None = Field(default=None, alias="token")
 
-    class Config:
-        allow_population_by_field_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 logger = logging.getLogger(__name__)

--- a/src/family_assistant/storage/models.py
+++ b/src/family_assistant/storage/models.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Automation(BaseModel):
@@ -41,7 +41,4 @@ class Automation(BaseModel):
     next_scheduled_at: datetime | None = None
     execution_count: int | None = None
 
-    class Config:
-        """Pydantic model configuration."""
-
-        frozen = True
+    model_config = ConfigDict(frozen=True)

--- a/src/family_assistant/web/models.py
+++ b/src/family_assistant/web/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
     from starlette.datastructures import State
@@ -174,8 +174,7 @@ class SearchResultItem(BaseModel):
     fts_score: float | None = None
     rrf_score: float | None = None
 
-    class Config:
-        orm_mode = True  # Allows creating from ORM-like objects (dict-like rows)
+    model_config = ConfigDict(from_attributes=True)
 
 
 # --- Pydantic model for API response ---


### PR DESCRIPTION
…onfig class

Migrate from deprecated class-based Config to ConfigDict as required by Pydantic V2. This fixes pytest warnings about PydanticDeprecatedSince20.

- ParsedEmailData: allow_population_by_field_name -> populate_by_name
- SearchResultItem: orm_mode -> from_attributes
- Automation: frozen=True via ConfigDict

Also filter third-party google.genai aiohttp deprecation warning in pytest.ini.