### PR TITLE
Switch Claude Code installation to native installer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -119,9 +119,12 @@ FROM base
 # Switch to claude user for dev tool installations
 USER claude
 
+# Install Claude Code using native installer (recommended over deprecated npm install)
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
 # Install development Node.js packages
 RUN --mount=type=cache,target=/home/claude/.npm,sharing=locked,uid=1001,gid=1001 \
-    npm install -g @anthropic-ai/claude-code @google/gemini-cli@nightly
+    npm install -g @google/gemini-cli@nightly
 
 # Install Python development tools
 RUN --mount=type=cache,target=/home/claude/.cache/uv,sharing=locked,uid=1001,gid=1001 \


### PR DESCRIPTION
## Summary
Updated the dev container to install Claude Code using its native installer script instead of the deprecated npm package, improving installation reliability and following the recommended installation method.

## Changes
- Added installation of Claude Code via native installer (`https://claude.ai/install.sh`)
- Removed `@anthropic-ai/claude-code` from npm global packages (deprecated installation method)
- Kept `@google/gemini-cli@nightly` in npm installations

## Details
The native installer is now the recommended approach for Claude Code installation. This change:
- Uses the official installation script rather than relying on npm package distribution
- Simplifies dependency management by removing a deprecated npm package
- Maintains all other development tools and their installation methods

https://claude.ai/code/session_01VuReUYoiB3kP2V3YqLo1fQ