### PR TITLE
Add structured TypedDict types for tool definitions

### DIFF
--- a/src/family_assistant/processing.py
+++ b/src/family_assistant/processing.py
@@ -15,6 +15,7 @@ from datetime import (  # Added timezone
 from typing import (
     TYPE_CHECKING,
     Any,
+    cast,
 )
 
 if TYPE_CHECKING:
@@ -529,7 +530,9 @@ class ProcessingService:
             try:
                 async for event in self.llm_client.generate_response_stream(
                     messages=messages,
-                    tools=tools_to_offer,
+                    # cast needed because ToolDefinition is a TypedDict which
+                    # the type checker doesn't recognize as assignable to dict[str, Any]
+                    tools=cast("list[dict[str, Any]] | None", tools_to_offer),
                     tool_choice=tool_choice_mode,
                 ):
                     # Yield content events as they come

--- a/src/family_assistant/scripting/apis/tools.py
+++ b/src/family_assistant/scripting/apis/tools.py
@@ -28,7 +28,11 @@ from family_assistant.tools.infrastructure import (
     CompositeToolsProvider,
     LocalToolsProvider,
 )
-from family_assistant.tools.types import ToolResult
+from family_assistant.tools.types import (
+    ToolDefinition,
+    ToolParametersSchema,
+    ToolResult,
+)
 
 T = TypeVar("T")
 
@@ -45,8 +49,7 @@ class ToolInfo:
 
     name: str
     description: str
-    # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    parameters: dict[str, Any]
+    parameters: ToolParametersSchema
 
 
 @dataclass
@@ -121,10 +124,8 @@ class ToolsAPI:
         self._executor = ThreadPoolExecutor(max_workers=1)
 
         # Cache tool definitions
-        # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-        self._tool_definitions: list[dict[str, Any]] | None = None
-        # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-        self._raw_tool_definitions: list[dict[str, Any]] | None = None
+        self._tool_definitions: list[ToolDefinition] | None = None
+        self._raw_tool_definitions: list[ToolDefinition] | None = None
 
         logger.info(
             "Initialized ToolsAPI bridge for Starlark scripts (deny_all_tools=%s, allowed_tools=%s, main_loop=%s)",
@@ -251,8 +252,7 @@ class ToolsAPI:
 
         return await fetch_attachment_object(attachment_id, self.execution_context)
 
-    # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    async def _get_raw_tool_definitions(self) -> list[dict[str, Any]]:
+    async def _get_raw_tool_definitions(self) -> list[ToolDefinition]:
         """Get raw tool definitions for internal schema analysis.
 
         Uses the raw definitions (without LLM translation) to detect attachment types.

--- a/src/family_assistant/tools/CLAUDE.md
+++ b/src/family_assistant/tools/CLAUDE.md
@@ -44,7 +44,9 @@ Create a new file in `src/family_assistant/tools/` (e.g., `something.py`) with:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from family_assistant.tools.types import ToolDefinition
 
 if TYPE_CHECKING:
     from family_assistant.tools.types import ToolExecutionContext
@@ -52,7 +54,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Tool Definitions
-SOMETHING_TOOLS_DEFINITION: list[dict[str, Any]] = [
+SOMETHING_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {
@@ -129,7 +131,7 @@ AVAILABLE_FUNCTIONS: dict[str, Callable] = {
 }
 
 # Add to TOOLS_DEFINITION list
-TOOLS_DEFINITION: list[dict[str, Any]] = (
+TOOLS_DEFINITION: list[ToolDefinition] = (
     # ... existing definitions ...
     + SOMETHING_TOOLS_DEFINITION
     # ... rest ...

--- a/src/family_assistant/tools/README.md
+++ b/src/family_assistant/tools/README.md
@@ -25,7 +25,9 @@ Create a new file in `src/family_assistant/tools/` (e.g., `something.py`) with:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from family_assistant.tools.types import ToolDefinition
 
 if TYPE_CHECKING:
     from family_assistant.tools.types import ToolExecutionContext
@@ -33,7 +35,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Tool Definitions
-SOMETHING_TOOLS_DEFINITION: list[dict[str, Any]] = [
+SOMETHING_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {
@@ -111,7 +113,7 @@ AVAILABLE_FUNCTIONS: dict[str, Callable] = {
 }
 
 # Add to TOOLS_DEFINITION list
-TOOLS_DEFINITION: list[dict[str, Any]] = (
+TOOLS_DEFINITION: list[ToolDefinition] = (
     # ... existing definitions ...
 
     + SOMETHING_TOOLS_DEFINITION

--- a/src/family_assistant/tools/__init__.py
+++ b/src/family_assistant/tools/__init__.py
@@ -7,7 +7,7 @@ The tools are organized into thematic submodules for better maintainability.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from family_assistant import storage
 from family_assistant.tools.attachments import (
@@ -152,7 +152,7 @@ from family_assistant.tools.tasks import (
     schedule_recurring_task_tool,
     schedule_reminder_tool,
 )
-from family_assistant.tools.types import ToolExecutionContext
+from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 from family_assistant.tools.video_generation import (
     VIDEO_GENERATION_TOOLS_DEFINITION,
     generate_video_tool,
@@ -414,8 +414,7 @@ AVAILABLE_FUNCTIONS: dict[str, Callable] = {
 
 
 # Combine all tool definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-TOOLS_DEFINITION: list[dict[str, Any]] = (
+TOOLS_DEFINITION: list[ToolDefinition] = (
     NOTE_TOOLS_DEFINITION
     + SERVICE_TOOLS_DEFINITION
     + TASK_TOOLS_DEFINITION

--- a/src/family_assistant/tools/attachment_utils.py
+++ b/src/family_assistant/tools/attachment_utils.py
@@ -14,7 +14,7 @@ from family_assistant.scripting.apis.attachments import ScriptAttachment
 
 if TYPE_CHECKING:
     from family_assistant.storage.context import DatabaseContext
-    from family_assistant.tools.types import ToolExecutionContext
+    from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 logger = logging.getLogger(__name__)
 
@@ -95,12 +95,11 @@ async def fetch_attachment_object(
 
 
 async def process_attachment_arguments(
-    # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
+    # ast-grep-ignore: no-dict-any - Tool arguments are dynamic JSON from LLM
     arguments: dict[str, Any],
     context: ToolExecutionContext,
-    # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    tool_definition: dict[str, Any] | None = None,
-    # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
+    tool_definition: ToolDefinition | None = None,
+    # ast-grep-ignore: no-dict-any - Tool arguments are dynamic JSON
 ) -> dict[str, Any]:
     """
     Process arguments and convert attachment IDs to ScriptAttachment objects.

--- a/src/family_assistant/tools/attachments.py
+++ b/src/family_assistant/tools/attachments.py
@@ -4,18 +4,17 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from family_assistant.scripting.apis.attachments import ScriptAttachment
-    from family_assistant.tools.types import ToolExecutionContext
+    from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 logger = logging.getLogger(__name__)
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-ATTACHMENT_TOOLS_DEFINITION: list[dict[str, Any]] = [
+ATTACHMENT_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/automations.py
+++ b/src/family_assistant/tools/automations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from family_assistant.tools.types import ToolResult
+from family_assistant.tools.types import ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -49,8 +49,7 @@ def _to_isoformat(dt: datetime | None) -> str | None:
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-AUTOMATIONS_TOOLS_DEFINITION: list[dict[str, Any]] = [
+AUTOMATIONS_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/calendar.py
+++ b/src/family_assistant/tools/calendar.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from family_assistant.tools.types import (
         CalendarConfig,
         CalendarEvent,
+        ToolDefinition,
         ToolExecutionContext,
     )
 
@@ -271,7 +272,7 @@ async def _check_for_duplicate_events(
         return None
 
 
-CALENDAR_TOOLS_DEFINITION = [
+CALENDAR_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/camera.py
+++ b/src/family_assistant/tools/camera.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
-from family_assistant.tools.types import ToolAttachment, ToolResult
+from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 
 # Threshold for warning about old dates (likely model confusion about current date)
 OLD_DATE_THRESHOLD = timedelta(days=30)
@@ -23,8 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Tool definitions require dict[str, Any] for JSON schema
-CAMERA_TOOLS_DEFINITION: list[dict[str, Any]] = [
+CAMERA_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/communication.py
+++ b/src/family_assistant/tools/communication.py
@@ -9,19 +9,18 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from family_assistant.scripting.apis.attachments import ScriptAttachment
 
 if TYPE_CHECKING:
-    from family_assistant.tools.types import ToolExecutionContext
+    from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 logger = logging.getLogger(__name__)
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-COMMUNICATION_TOOLS_DEFINITION: list[dict[str, Any]] = [
+COMMUNICATION_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/computer_use.py
+++ b/src/family_assistant/tools/computer_use.py
@@ -20,7 +20,7 @@ from playwright.async_api import (
     async_playwright,
 )
 
-from family_assistant.tools.types import ToolAttachment, ToolResult
+from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 from family_assistant.utils.stealth_browser import (
     create_stealth_context,
     launch_stealth_browser,
@@ -507,7 +507,7 @@ async def computer_use_scroll_document(
 
 
 # Tools Definition
-COMPUTER_USE_TOOLS_DEFINITION = [
+COMPUTER_USE_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/data_manipulation.py
+++ b/src/family_assistant/tools/data_manipulation.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 import jq
 
 from family_assistant.scripting.apis.attachments import ScriptAttachment
-from family_assistant.tools.types import ToolResult
+from family_assistant.tools.types import ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
     from family_assistant.tools.types import ToolExecutionContext
@@ -22,8 +22,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-DATA_MANIPULATION_TOOLS_DEFINITION: list[dict[str, Any]] = [
+DATA_MANIPULATION_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/data_visualization.py
+++ b/src/family_assistant/tools/data_visualization.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import vl_convert as vlc
 
-from family_assistant.tools.types import ToolAttachment, ToolResult
+from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
     from family_assistant.scripting.apis.attachments import ScriptAttachment
@@ -23,8 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-DATA_VISUALIZATION_TOOLS_DEFINITION: list[dict[str, Any]] = [
+DATA_VISUALIZATION_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/documents.py
+++ b/src/family_assistant/tools/documents.py
@@ -24,6 +24,7 @@ from family_assistant.storage.vector_search import (
 )
 from family_assistant.tools.types import (
     ToolAttachment,
+    ToolDefinition,
     ToolResult,
     get_attachment_limits,
 )
@@ -38,8 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-DOCUMENT_TOOLS_DEFINITION: list[dict[str, Any]] = [
+DOCUMENT_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/events.py
+++ b/src/family_assistant/tools/events.py
@@ -11,14 +11,13 @@ from sqlalchemy import text
 
 # get_db_context import removed - using exec_context.db_context for dependency injection
 from family_assistant.events.validation import format_validation_errors
-from family_assistant.tools.types import ToolExecutionContext
+from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 logger = logging.getLogger(__name__)
 
 
 # Tool definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-EVENT_TOOLS_DEFINITION: list[dict[str, Any]] = [
+EVENT_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/execute_script.py
+++ b/src/family_assistant/tools/execute_script.py
@@ -18,7 +18,7 @@ from family_assistant.scripting.errors import (
     ScriptSyntaxError,
     ScriptTimeoutError,
 )
-from family_assistant.tools.types import ToolAttachment, ToolResult
+from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
     from family_assistant.tools.types import ToolExecutionContext
@@ -321,8 +321,7 @@ async def execute_script_tool(
 
 
 # Tool Definition
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-SCRIPT_TOOLS_DEFINITION: list[dict[str, Any]] = [
+SCRIPT_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/home_assistant.py
+++ b/src/family_assistant/tools/home_assistant.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from family_assistant.tools.types import (
     ToolAttachment,
+    ToolDefinition,
     ToolResult,
     get_attachment_limits,
 )
@@ -46,8 +47,7 @@ def detect_image_mime_type(content: bytes) -> str:
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-HOME_ASSISTANT_TOOLS_DEFINITION: list[dict[str, Any]] = [
+HOME_ASSISTANT_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/image_generation.py
+++ b/src/family_assistant/tools/image_generation.py
@@ -11,7 +11,7 @@ implementations (mock, Gemini API, fallback).
 
 import io
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from PIL import Image
 
@@ -20,7 +20,7 @@ from family_assistant.tools.image_backends import (
     ImageGenerationBackend,
     MockImageBackend,
 )
-from family_assistant.tools.types import ToolAttachment, ToolResult
+from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
     from family_assistant.config_models import AppConfig
@@ -30,8 +30,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-IMAGE_GENERATION_TOOLS_DEFINITION: list[dict[str, Any]] = [
+IMAGE_GENERATION_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/image_tools.py
+++ b/src/family_assistant/tools/image_tools.py
@@ -13,15 +13,14 @@ from typing import TYPE_CHECKING, Any
 
 from PIL import Image, ImageDraw
 
-from family_assistant.tools.types import ToolAttachment, ToolResult
+from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
     from family_assistant.scripting.apis.attachments import ScriptAttachment
     from family_assistant.tools.types import ToolExecutionContext
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-IMAGE_TOOLS_DEFINITION: list[dict[str, Any]] = [
+IMAGE_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/mcp.py
+++ b/src/family_assistant/tools/mcp.py
@@ -13,7 +13,7 @@ from mcp.types import TextContent  # Import TextContent from mcp.types
 
 # Import storage functions needed by local tools
 # Import the context from the new types file
-from .types import ToolExecutionContext, ToolNotFoundError
+from .types import ToolDefinition, ToolExecutionContext, ToolNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +43,7 @@ class MCPToolsProvider:
         self._health_check_interval_seconds = health_check_interval_seconds
         self._sessions: dict[str, ClientSession] = {}
         self._tool_map: dict[str, str] = {}  # Map tool name -> server_id
-        # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-        self._definitions: list[dict[str, Any]] = []
+        self._definitions: list[ToolDefinition] = []
         self._initialized = False
         self._connection_contexts: dict[str, contextlib.AsyncExitStack] = {}
         self._server_statuses: dict[str, str] = {
@@ -106,13 +105,11 @@ class MCPToolsProvider:
             logger.debug("MCP initialization logging task finished.")
 
     async def _connect_and_discover_mcp(
-        # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
         self,
         server_id: str,
-        # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
+        # ast-grep-ignore: no-dict-any - MCP server config can have varied structure
         server_conf: dict[str, Any],
-        # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    ) -> tuple["ClientSession | None", list[dict[str, Any]], dict[str, str]]:
+    ) -> tuple["ClientSession | None", list[ToolDefinition], dict[str, str]]:
         """Connects to a single MCP server, discovers tools, and returns results."""
         self._server_statuses[server_id] = MCP_SERVER_STATUS_CONNECTING
         discovered_tools = []
@@ -482,8 +479,7 @@ class MCPToolsProvider:
         # self, definitions: List[Dict[str, Any]] # Original signature
         self,
         definitions: list[Any],  # MCP list_tools returns list of Tool objects
-        # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    ) -> list[dict[str, Any]]:
+    ) -> list[ToolDefinition]:
         """
         Accepts a list of MCP Tool objects.
         Converts MCP Tool objects to OpenAI-like dictionary format.
@@ -519,8 +515,7 @@ class MCPToolsProvider:
 
     async def get_tool_definitions(
         self,
-        # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    ) -> list[dict[str, Any]]:  # Return type is still dict
+    ) -> list[ToolDefinition]:
         """Returns the aggregated and sanitized tool definitions from all connected servers."""
         if not self._initialized:
             await self.initialize()

--- a/src/family_assistant/tools/media_download.py
+++ b/src/family_assistant/tools/media_download.py
@@ -7,7 +7,7 @@ import logging
 import re
 import tempfile
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import TypedDict
 from urllib.parse import urlparse
 
 import yt_dlp
@@ -15,6 +15,7 @@ from yt_dlp.utils import DownloadError, sanitize_filename
 
 from family_assistant.tools.types import (
     ToolAttachment,
+    ToolDefinition,
     ToolExecutionContext,
     ToolResult,
     get_attachment_limits,
@@ -109,8 +110,7 @@ class MediaMetadata(TypedDict, total=False):
     extractor: str | None
 
 
-# ast-grep-ignore: no-dict-any - OpenAI function calling spec requires untyped dict for JSON schema
-MEDIA_DOWNLOAD_TOOLS_DEFINITION: list[dict[str, Any]] = [
+MEDIA_DOWNLOAD_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/mock_image_tools.py
+++ b/src/family_assistant/tools/mock_image_tools.py
@@ -7,9 +7,9 @@ without requiring actual image processing dependencies.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from family_assistant.tools.types import ToolAttachment, ToolResult
+from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
     from family_assistant.scripting.apis.attachments import ScriptAttachment
@@ -17,8 +17,7 @@ if TYPE_CHECKING:
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-MOCK_IMAGE_TOOLS_DEFINITION: list[dict[str, Any]] = [
+MOCK_IMAGE_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/notes.py
+++ b/src/family_assistant/tools/notes.py
@@ -10,7 +10,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from family_assistant.tools.types import ToolAttachment, ToolResult
+from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
     from family_assistant.tools.types import ToolExecutionContext
@@ -87,8 +87,7 @@ async def add_or_update_note_tool(
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-NOTE_TOOLS_DEFINITION: list[dict[str, Any]] = [
+NOTE_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/services.py
+++ b/src/family_assistant/tools/services.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, cast
 import telegramify_markdown
 
 from family_assistant.llm.content_parts import text_content
-from family_assistant.tools.types import ToolAttachment, ToolResult
+from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
     from family_assistant.llm.content_parts import ContentPartDict
@@ -31,8 +31,7 @@ ConfirmationCallbackSignature = Callable[
 ]
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-SERVICE_TOOLS_DEFINITION: list[dict[str, Any]] = [
+SERVICE_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/tasks.py
+++ b/src/family_assistant/tools/tasks.py
@@ -23,15 +23,14 @@ from family_assistant.utils.clock import SystemClock
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from family_assistant.tools.types import ToolExecutionContext
+    from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 
 logger = logging.getLogger(__name__)
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-TASK_TOOLS_DEFINITION: list[dict[str, Any]] = [
+TASK_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/video_generation.py
+++ b/src/family_assistant/tools/video_generation.py
@@ -14,14 +14,14 @@ from google.genai import types
 from family_assistant.scripting.apis.attachments import ScriptAttachment
 from family_assistant.tools.types import (
     ToolAttachment,
+    ToolDefinition,
     ToolExecutionContext,
     ToolResult,
 )
 
 logger = logging.getLogger(__name__)
 
-# ast-grep-ignore: no-dict-any - Tool definition schema uses dict structure
-VIDEO_GENERATION_TOOLS_DEFINITION: list[dict[str, Any]] = [
+VIDEO_GENERATION_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/worker.py
+++ b/src/family_assistant/tools/worker.py
@@ -19,14 +19,13 @@ from family_assistant.tools.types import ToolResult
 from family_assistant.utils.workspace import get_workspace_root, validate_workspace_path
 
 if TYPE_CHECKING:
-    from family_assistant.tools.types import ToolExecutionContext
+    from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 logger = logging.getLogger(__name__)
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Tool definitions follow OpenAI schema format
-WORKER_TOOLS_DEFINITION: list[dict[str, Any]] = [
+WORKER_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {

--- a/src/family_assistant/tools/workspace_files.py
+++ b/src/family_assistant/tools/workspace_files.py
@@ -20,14 +20,13 @@ from family_assistant.tools.types import ToolResult
 from family_assistant.utils.workspace import get_workspace_root, validate_workspace_path
 
 if TYPE_CHECKING:
-    from family_assistant.tools.types import ToolExecutionContext
+    from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 logger = logging.getLogger(__name__)
 
 
 # Tool Definitions
-# ast-grep-ignore: no-dict-any - Tool definitions follow OpenAI schema format
-_WORKSPACE_FILE_TOOLS: list[dict[str, Any]] = [
+_WORKSPACE_FILE_TOOLS: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {
@@ -507,8 +506,7 @@ async def workspace_mkdir_tool(
 
 
 # Notes Integration Tool Definitions
-# ast-grep-ignore: no-dict-any - Tool definitions follow OpenAI schema format
-NOTES_INTEGRATION_TOOLS_DEFINITION: list[dict[str, Any]] = [
+NOTES_INTEGRATION_TOOLS_DEFINITION: list[ToolDefinition] = [
     {
         "type": "function",
         "function": {
@@ -796,4 +794,6 @@ async def workspace_import_note_tool(
 
 
 # Combined tool definitions for export
-WORKSPACE_TOOLS_DEFINITION = _WORKSPACE_FILE_TOOLS + NOTES_INTEGRATION_TOOLS_DEFINITION
+WORKSPACE_TOOLS_DEFINITION: list[ToolDefinition] = (
+    _WORKSPACE_FILE_TOOLS + NOTES_INTEGRATION_TOOLS_DEFINITION
+)

--- a/tests/functional/attachments/test_attachment_tools.py
+++ b/tests/functional/attachments/test_attachment_tools.py
@@ -6,7 +6,7 @@ import io
 import json
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock
 
 import aiofiles
@@ -371,8 +371,8 @@ class TestToolRegistration:
             in function_def["description"].lower()
         )
 
-        # Verify parameters
-        params = function_def["parameters"]
+        # Verify parameters (cast to dict for test assertions on optional TypedDict keys)
+        params = cast("dict[str, Any]", function_def["parameters"])
         assert params["type"] == "object"
         assert "attachment_ids" in params["properties"]
         assert params["properties"]["attachment_ids"]["type"] == "array"

--- a/tests/functional/scripting/example_direct_tools.py
+++ b/tests/functional/scripting/example_direct_tools.py
@@ -14,7 +14,7 @@ from family_assistant.scripting.engine import StarlarkEngine
 from family_assistant.storage import init_db
 from family_assistant.storage.base import create_engine_with_sqlite_optimizations
 from family_assistant.storage.context import DatabaseContext
-from family_assistant.tools.types import ToolExecutionContext
+from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -24,8 +24,7 @@ logger = logging.getLogger(__name__)
 class SimpleToolsProvider:
     """Simple tools provider with a few example tools."""
 
-    # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    async def get_tool_definitions(self) -> list[dict[str, Any]]:
+    async def get_tool_definitions(self) -> list[ToolDefinition]:
         """Return tool definitions."""
         return [
             {

--- a/tests/functional/scripting/test_direct_tool_callables.py
+++ b/tests/functional/scripting/test_direct_tool_callables.py
@@ -12,14 +12,13 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from family_assistant.scripting.engine import StarlarkConfig, StarlarkEngine
 from family_assistant.storage.context import DatabaseContext
-from family_assistant.tools.types import ToolExecutionContext
+from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 
 class MockToolsProvider:
     """Mock tools provider for testing direct callables."""
 
-    # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    async def get_tool_definitions(self) -> list[dict[str, Any]]:
+    async def get_tool_definitions(self) -> list[ToolDefinition]:
         """Return mock tool definitions."""
         return [
             {

--- a/tests/functional/scripting/test_tools_api.py
+++ b/tests/functional/scripting/test_tools_api.py
@@ -9,14 +9,13 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from family_assistant.scripting.engine import StarlarkEngine
 from family_assistant.storage.context import DatabaseContext
-from family_assistant.tools.types import ToolExecutionContext
+from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 
 class MockToolsProvider:
     """Mock tools provider for testing."""
 
-    # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    async def get_tool_definitions(self) -> list[dict[str, Any]]:
+    async def get_tool_definitions(self) -> list[ToolDefinition]:
         """Return mock tool definitions."""
         return [
             {

--- a/tests/functional/tools/test_execute_script.py
+++ b/tests/functional/tools/test_execute_script.py
@@ -16,6 +16,7 @@ from family_assistant.tools.infrastructure import (
 )
 from family_assistant.tools.types import (
     ToolAttachment,
+    ToolDefinition,
     ToolExecutionContext,
     ToolResult,
 )
@@ -102,7 +103,7 @@ async def test_execute_script_with_tools(db_engine: AsyncEngine) -> None:
             return f"Echo: {message}"
 
         # Create tools provider
-        tool_definitions = [
+        tool_definitions: list[ToolDefinition] = [
             {
                 "type": "function",
                 "function": {
@@ -386,7 +387,7 @@ async def test_script_attachment_composition_dict_format(
             )
 
         # Create tools provider with both tools
-        tool_definitions = [
+        tool_definitions: list[ToolDefinition] = [
             {
                 "type": "function",
                 "function": {

--- a/tests/functional/tools/test_execute_script_attachments.py
+++ b/tests/functional/tools/test_execute_script_attachments.py
@@ -18,6 +18,7 @@ from family_assistant.tools.infrastructure import (
 )
 from family_assistant.tools.types import (
     ToolAttachment,
+    ToolDefinition,
     ToolExecutionContext,
     ToolResult,
 )
@@ -158,7 +159,7 @@ async def test_execute_script_return_attachment_from_tool(
             )
 
         # Register tool
-        tool_definitions = [
+        tool_definitions: list[ToolDefinition] = [
             {
                 "type": "function",
                 "function": {
@@ -269,7 +270,7 @@ async def test_execute_script_functional_composition(
             )
 
         # Register tools
-        tool_definitions = [
+        tool_definitions: list[ToolDefinition] = [
             {
                 "type": "function",
                 "function": {
@@ -378,7 +379,7 @@ async def test_execute_script_mixed_attachment_sources(
                 ],
             )
 
-        tool_definitions = [
+        tool_definitions: list[ToolDefinition] = [
             {
                 "type": "function",
                 "function": {

--- a/tests/unit/processing/test_processing_history_formatting.py
+++ b/tests/unit/processing/test_processing_history_formatting.py
@@ -13,7 +13,7 @@ import pytest
 from PIL import Image
 
 if TYPE_CHECKING:
-    from family_assistant.tools.types import ToolAttachment
+    from family_assistant.tools.types import ToolAttachment, ToolDefinition
 
 from family_assistant.config_models import AppConfig
 from family_assistant.llm import LLMStreamEvent
@@ -78,8 +78,7 @@ class MockToolsProvider:
         self,
         *args: Any,  # noqa: ANN401  # Mock needs flexibility
         **kwargs: Any,  # noqa: ANN401 # Mock needs flexibility
-        # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
-    ) -> list[dict[str, Any]]:
+    ) -> "list[ToolDefinition]":
         return []  # Not used
 
     async def execute_tool(

--- a/tests/unit/tools/test_media_download_tools.py
+++ b/tests/unit/tools/test_media_download_tools.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -48,7 +48,8 @@ def test_tool_definition_structure() -> None:
     assert tool_def["function"]["name"] == "download_media"
     assert "description" in tool_def["function"]
 
-    params = tool_def["function"]["parameters"]
+    # Cast to dict for test assertions on optional TypedDict keys
+    params = cast("dict[str, Any]", tool_def["function"]["parameters"])
     assert params["type"] == "object"
     assert "url" in params["properties"]
     assert "audio_only" in params["properties"]


### PR DESCRIPTION
## Summary
Introduce proper TypedDict types for LLM tool definitions to replace generic `dict[str, Any]` usage throughout the codebase. This improves type safety and IDE support while maintaining compatibility with the OpenAI function calling schema format.

## Key Changes

- **New type definitions in `tools/types.py`**: Added `ToolDefinition`, `ToolFunctionSchema`, `ToolParametersSchema`, `ToolPropertySchema`, and `ToolPropertyItems` TypedDicts that follow the OpenAI function calling schema format (camelCase JSON Schema)

- **Updated tool definition declarations**: Changed all tool definition lists from `list[dict[str, Any]]` to `list[ToolDefinition]` across 30+ tool modules (notes, tasks, calendar, camera, communication, etc.)

- **Updated infrastructure and provider types**: Modified `ToolsProvider` protocol, `LocalToolsProvider`, `CompositeToolsProvider`, `FilteringToolsProvider`, and `ConfirmingToolsProvider` to use `ToolDefinition` in their signatures

- **Updated scripting APIs**: Changed `ToolsAPI` and related classes to use `ToolDefinition` for tool definition caching and retrieval

- **Added type cast in processing**: Added `cast()` in `process_message_stream()` to handle TypedDict assignability to `dict[str, Any]` for LLM client compatibility

- **Updated test files**: Modified test files to use `ToolDefinition` type and added appropriate casts for test assertions on optional TypedDict keys

- **Updated documentation**: Modified README and CLAUDE.md examples to show `ToolDefinition` usage instead of generic dicts

## Implementation Details

- **Design rationale**: Used strict TypedDict typing for top-level tool definition structures while allowing `dict[str, Any]` for deeply nested JSON Schema properties, since JSON Schema's recursive flexibility exceeds what TypedDict can practically express

- **Backward compatibility**: The changes are fully backward compatible - TypedDicts are structurally compatible with dicts at runtime

- **Tool arguments remain dynamic**: Tool execution arguments remain typed as `dict[str, Any]` since they come from LLM responses and are inherently dynamic

- **Updated ast-grep ignores**: Clarified ignore comments to distinguish between "dynamic JSON from LLM" (tool arguments) and "tool definitions follow schema format" (definitions)

https://claude.ai/code/session_01ATa1KPSqmPFJPDJNY2bx4t