### PR TITLE
Fix flaky conversation list tests by using fixed timestamps

### DIFF
--- a/tests/functional/web/ui/test_conversations_list.py
+++ b/tests/functional/web/ui/test_conversations_list.py
@@ -284,7 +284,8 @@ async def test_get_conversations_date_filters(
     """Test filtering conversations by date range."""
 
     # Create test conversations with different timestamps
-    base_time = datetime.now(UTC)
+    # Use a fixed date to avoid flakiness at day boundaries
+    base_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
     async with get_db_context(db_engine) as db_context:
         # Old conversation (3 days ago)
         await db_context.message_history.add_message(
@@ -387,7 +388,8 @@ async def test_get_conversations_combined_filters(
 ) -> None:
     """Test using multiple filters together."""
 
-    base_time = datetime.now(UTC)
+    # Use a fixed date to avoid flakiness at day boundaries
+    base_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
 
     # Create test data
     async with get_db_context(db_engine) as db_context:


### PR DESCRIPTION
Fixes flaky tests in `tests/functional/web/ui/test_conversations_list.py` by replacing `datetime.now(UTC)` with a fixed timestamp. This prevents test failures that could occur when running tests near midnight or due to other timing inconsistencies.

---
*PR created automatically by Jules for task [3187483325122696967](https://jules.google.com/task/3187483325122696967) started by @werdnum*