### PR TITLE
Simplify plugin marketplace setup to use public GitHub repo

### DIFF
--- a/.devcontainer/claude-wrapper.sh
+++ b/.devcontainer/claude-wrapper.sh
@@ -95,16 +95,8 @@ if [ -f "frontend/package.json" ] && [ ! -d "frontend/node_modules" ]; then
     npm install --prefix frontend
 fi
 
-# Update Claude plugin marketplaces
+# Update Claude plugin marketplaces (fetches latest from GitHub)
 echo "🔄 Updating Claude plugin marketplaces..."
-# Pull latest changes from local plugin marketplace clone
-PLUGINS_DIR="$HOME/werdnum-plugins"
-if [ -d "$PLUGINS_DIR/.git" ]; then
-    # GIT_TERMINAL_PROMPT=0 prevents hanging if credentials are needed
-    (cd "$PLUGINS_DIR" && GIT_TERMINAL_PROMPT=0 git pull --quiet 2>/dev/null) || {
-        echo "⚠️  Warning: Failed to pull plugin marketplace updates"
-    }
-fi
 /home/claude/.npm-global/bin/claude plugin marketplace update >/dev/null 2>&1 || {
     echo "⚠️  Warning: Failed to update plugin marketplaces"
 }

--- a/.devcontainer/setup-workspace.sh
+++ b/.devcontainer/setup-workspace.sh
@@ -364,30 +364,14 @@ $CLAUDE_BIN mcp add --scope user serena -- sh -c "$(which uvx) -q --from git+htt
 $CLAUDE_BIN mcp add --scope user playwright $(which npx) -- -y -q @playwright/mcp@latest --no-sandbox --allowed-origins "localhost:8000;localhost:5173;localhost:8001;unpkg.com;cdn.jsdelivr.net;cdnjs.cloudflare.com;cdn.simplecss.org;devcontainer-backend-1" --headless --isolated --browser chromium
 # $CLAUDE_BIN mcp add --scope user github -t http https://api.githubcopilot.com/mcp/ -H "Authorization: Bearer $GITHUB_TOKEN"
 
-# Configure Claude plugin marketplace from local clone
-# Note: Using local path because Claude Code's git auth handler doesn't work with GitHub URLs
-# Use /home/claude explicitly since this script runs as root (not as claude user)
-CLAUDE_HOME="/home/claude"
-PLUGINS_DIR="$CLAUDE_HOME/werdnum-plugins"
+# Configure Claude plugin marketplace from public GitHub repo
 echo "Setting up Claude plugin marketplace..."
-if [ ! -d "$PLUGINS_DIR" ]; then
-    echo "Cloning claude-code-plugins repository..."
-    # GIT_TERMINAL_PROMPT=0 prevents hanging if credentials are needed
-    if [ -n "$GITHUB_TOKEN" ]; then
-        GIT_TERMINAL_PROMPT=0 git clone "https://${GITHUB_TOKEN}@github.com/werdnum/claude-code-plugins.git" "$PLUGINS_DIR"
-    else
-        GIT_TERMINAL_PROMPT=0 git clone "https://github.com/werdnum/claude-code-plugins.git" "$PLUGINS_DIR"
-    fi
-    if [ "$RUNNING_AS_ROOT" = "true" ]; then
-        chown -R claude:claude "$PLUGINS_DIR"
-    fi
-fi
-
-# Add the marketplace by file path (remove first to avoid duplicates)
+# Remove old marketplaces to avoid duplicates
 $CLAUDE_BIN plugin marketplace remove claude-code-plugins 2>/dev/null || true
 $CLAUDE_BIN plugin marketplace remove werdnum-plugins 2>/dev/null || true
-$CLAUDE_BIN plugin marketplace add "$PLUGINS_DIR"
-echo "Claude plugin marketplace configured from local path"
+# Add the marketplace directly from GitHub (repo is now public)
+$CLAUDE_BIN plugin marketplace add werdnum/claude-code-plugins
+echo "Claude plugin marketplace configured from GitHub"
 
 # Ensure proper ownership if running as root
 if [ "$RUNNING_AS_ROOT" = "true" ]; then


### PR DESCRIPTION
## Summary
Refactored the Claude plugin marketplace configuration to use the public GitHub repository directly instead of maintaining a local clone. This simplifies the setup process and removes unnecessary git operations.

## Key Changes
- **Removed local plugin marketplace cloning**: Eliminated the logic that cloned `werdnum/claude-code-plugins` to a local directory (`~/werdnum-plugins`)
- **Simplified marketplace registration**: Changed from adding marketplace by local file path to adding it directly from the public GitHub repository using `werdnum/claude-code-plugins`
- **Removed git pull operations**: Eliminated the periodic git pull in `claude-wrapper.sh` that attempted to keep the local clone updated
- **Removed authentication complexity**: Removed conditional logic for `GITHUB_TOKEN` authentication and `GIT_TERMINAL_PROMPT` handling since the repository is now public

## Implementation Details
- The marketplace is now added directly via `$CLAUDE_BIN plugin marketplace add werdnum/claude-code-plugins` instead of a local path
- Kept the cleanup logic to remove old marketplace entries to prevent duplicates
- Updated comments to reflect that the repository is now public and fetched directly from GitHub
- This change reduces setup time and eliminates potential git authentication issues during container initialization

https://claude.ai/code/session_0192ccF4TFnxutexx9DDx1FF