### PR TITLE
Add Render one-click deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Family Assistant
 
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/werdnum/family-assistant)
+
 Family Assistant is an LLM-powered application designed for family information management and task
 automation. It provides multiple interfaces (Telegram, Web UI, Email webhooks) and uses a modular
 architecture built with Python, FastAPI, and SQLAlchemy. The goal of this project is to create a
@@ -204,6 +206,7 @@ The project uses Alembic for database migrations.
 ### For Operators
 
 - **[Operator Getting Started](docs/operations/GETTING_STARTED.md)** - **Start here for deployment**
+- **[Render Deployment](docs/deployment/RENDER_DEPLOYMENT.md)** - One-click cloud deployment
 - **[Production Deployment](docs/deployment/PRODUCTION_DEPLOYMENT.md)** - Advanced Kubernetes
   deployment
 - **[Configuration Reference](docs/operations/CONFIGURATION_REFERENCE.md)** - All config options

--- a/docs/deployment/RENDER_DEPLOYMENT.md
+++ b/docs/deployment/RENDER_DEPLOYMENT.md
@@ -1,0 +1,196 @@
+# Render Deployment Guide
+
+This guide explains how to deploy Family Assistant to [Render](https://render.com) using their
+one-click deployment feature.
+
+## One-Click Deployment
+
+The easiest way to deploy Family Assistant is using the "Deploy to Render" button:
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/werdnum/family-assistant)
+
+This will:
+
+1. Create a PostgreSQL database with pgvector extension
+2. Create a web service running the Family Assistant application
+3. Set up a persistent disk for document and attachment storage
+4. Prompt you to enter required environment variables
+
+## Prerequisites
+
+Before deploying, you'll need:
+
+1. **A Render account**: Sign up at [render.com](https://render.com)
+2. **Telegram Bot Token**: Create a bot via [@BotFather](https://t.me/botfather)
+3. **LLM API Key**: At least one of:
+   - [Google Gemini](https://aistudio.google.com/) (recommended)
+   - [OpenRouter](https://openrouter.ai/)
+   - [OpenAI](https://platform.openai.com/)
+4. **Your Telegram User ID**: Message [@userinfobot](https://t.me/userinfobot) to get your ID
+
+## Required Environment Variables
+
+During deployment, you'll be prompted to enter these values:
+
+| Variable             | Required | Description                                      |
+| -------------------- | -------- | ------------------------------------------------ |
+| `TELEGRAM_BOT_TOKEN` | Yes      | Your Telegram bot token from @BotFather          |
+| `ALLOWED_USER_IDS`   | Yes      | Comma-separated Telegram user IDs allowed access |
+| `GEMINI_API_KEY`     | \*       | Google Gemini API key                            |
+| `OPENROUTER_API_KEY` | \*       | OpenRouter API key                               |
+| `OPENAI_API_KEY`     | \*       | OpenAI API key                                   |
+| `DEVELOPER_CHAT_ID`  | No       | Telegram user ID for error notifications         |
+
+\* At least one LLM API key is required.
+
+## Optional Configuration
+
+### Web UI Authentication (OIDC)
+
+To secure the web interface with OpenID Connect:
+
+| Variable              | Description                        |
+| --------------------- | ---------------------------------- |
+| `OIDC_CLIENT_ID`      | OIDC provider client ID            |
+| `OIDC_CLIENT_SECRET`  | OIDC provider client secret        |
+| `OIDC_DISCOVERY_URL`  | OIDC discovery endpoint URL        |
+| `ALLOWED_OIDC_EMAILS` | Comma-separated allowed email list |
+
+### Calendar Integration
+
+| Variable               | Description                                    |
+| ---------------------- | ---------------------------------------------- |
+| `CALDAV_URL`           | CalDAV server URL (e.g., caldav.icloud.com)    |
+| `CALDAV_USERNAME`      | CalDAV username                                |
+| `CALDAV_PASSWORD`      | CalDAV app-specific password                   |
+| `CALDAV_CALENDAR_URLS` | Direct calendar URLs                           |
+| `ICAL_URLS`            | Comma-separated iCalendar URLs for read access |
+
+### Push Notifications
+
+| Variable              | Description                                    |
+| --------------------- | ---------------------------------------------- |
+| `VAPID_PRIVATE_KEY`   | VAPID private key (URL-safe base64)            |
+| `VAPID_CONTACT_EMAIL` | Admin contact email (mailto:admin@example.com) |
+
+Generate VAPID keys locally:
+
+```bash
+python scripts/generate_vapid_keys.py
+```
+
+### Additional Integrations
+
+| Variable                | Description            |
+| ----------------------- | ---------------------- |
+| `BRAVE_API_KEY`         | Brave Search API key   |
+| `HOMEASSISTANT_API_KEY` | Home Assistant API key |
+| `GOOGLE_MAPS_API_KEY`   | Google Maps API key    |
+
+## Post-Deployment Setup
+
+### 1. Enable pgvector Extension
+
+After deployment, connect to your database and enable the vector extension:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+```
+
+You can do this via Render's database shell or using `psql` with the external connection string.
+
+### 2. Access Your Application
+
+Once deployed, your application will be available at:
+
+- **Web UI**: `https://family-assistant-xxxx.onrender.com`
+- **Telegram**: Message your bot to start chatting
+
+### 3. Configure Your Domain (Optional)
+
+To use a custom domain:
+
+1. Go to your service's Settings in Render
+2. Add your custom domain under "Custom Domains"
+3. Configure DNS as instructed by Render
+
+## Scaling Considerations
+
+The default blueprint uses Render's "Starter" plan for both the web service and database. For
+production use, consider upgrading:
+
+### Web Service
+
+- **Starter**: Good for testing and light use
+- **Standard**: Recommended for production (includes zero-downtime deploys)
+- **Pro**: For higher traffic and performance needs
+
+### Database
+
+- **Starter**: 1GB storage, good for testing
+- **Standard**: 10GB storage, daily backups
+- **Pro**: Higher performance and storage
+
+To upgrade, edit the `plan` field in `render.yaml` or change it in the Render dashboard.
+
+## Limitations
+
+1. **Cold Starts**: Starter plan services may experience cold starts after periods of inactivity.
+   Upgrade to Standard plan for always-on behavior.
+
+2. **Disk Size**: The default persistent disk is 10GB. Increase `sizeGB` in `render.yaml` if you
+   need more storage for documents and attachments.
+
+3. **Region**: The default region is Oregon (`oregon`). Change the `region` field in `render.yaml`
+   to deploy closer to your users.
+
+## Troubleshooting
+
+### Service Not Starting
+
+Check the logs in the Render dashboard:
+
+1. Go to your service → "Logs"
+2. Look for error messages during startup
+3. Common issues:
+   - Missing required environment variables
+   - Database connection errors (wait for database to be ready)
+
+### Database Connection Issues
+
+1. Verify the `DATABASE_URL` is correctly set (should be automatic from the blueprint)
+2. Check that the database is in the same region as the web service
+3. Ensure the pgvector extension is enabled
+
+### Telegram Bot Not Responding
+
+1. Verify `TELEGRAM_BOT_TOKEN` is correct
+2. Check that `ALLOWED_USER_IDS` includes your Telegram user ID
+3. Review logs for Telegram-related errors
+
+## Updating Your Deployment
+
+When you push changes to your repository:
+
+1. Render will automatically rebuild and deploy (if auto-deploy is enabled)
+2. Database migrations run automatically on startup
+3. Zero-downtime deploys are available on Standard plan and above
+
+## Cost Estimation
+
+Approximate monthly costs on Render (as of 2024):
+
+| Component              | Starter | Standard |
+| ---------------------- | ------- | -------- |
+| Web Service            | $7      | $25      |
+| PostgreSQL Database    | $7      | $20      |
+| Persistent Disk (10GB) | $2.50   | $2.50    |
+| **Total**              | ~$17    | ~$48     |
+
+Check [Render's pricing page](https://render.com/pricing) for current rates.
+
+## Further Reading
+
+- [Render Blueprint Specification](https://render.com/docs/blueprint-spec)
+- [Render PostgreSQL Documentation](https://render.com/docs/databases)
+- [Family Assistant Configuration Reference](../operations/CONFIGURATION_REFERENCE.md)

--- a/docs/operations/GETTING_STARTED.md
+++ b/docs/operations/GETTING_STARTED.md
@@ -65,7 +65,26 @@ To enable secure authentication for the Web UI, you must configure OpenID Connec
 
 ______________________________________________________________________
 
-### Option 2: Native Deployment (Kubernetes)
+### Option 2: One-Click Cloud Deployment (Render)
+
+For a quick, hassle-free cloud deployment, use Render's one-click deploy:
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/werdnum/family-assistant)
+
+This automatically provisions:
+
+- A web service running Family Assistant
+- A PostgreSQL database with pgvector extension
+- A persistent disk for document storage
+
+You'll be prompted to enter your Telegram bot token, LLM API keys, and allowed user IDs during
+setup.
+
+For detailed instructions, see the [Render Deployment Guide](../deployment/RENDER_DEPLOYMENT.md).
+
+______________________________________________________________________
+
+### Option 3: Native Deployment (Kubernetes)
 
 Family Assistant is natively designed to run on Kubernetes. This is the most robust deployment
 method, suitable for high availability and advanced scaling.
@@ -85,7 +104,7 @@ The Kubernetes manifests are located in the `deploy/` directory:
 
 ______________________________________________________________________
 
-### Option 3: Development/Testing (SQLite)
+### Option 4: Development/Testing (SQLite)
 
 For quick testing or development, you can run the application with SQLite.
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,100 @@
+# Render Blueprint for Family Assistant
+# https://render.com/docs/blueprint-spec
+#
+# Deploy with one click: https://render.com/deploy?repo=https://github.com/werdnum/family-assistant
+#
+# This blueprint creates:
+# - A web service running the Family Assistant application
+# - A PostgreSQL database with pgvector extension for vector storage
+# - A persistent disk for document and attachment storage
+
+databases:
+  - name: family-assistant-db
+    plan: starter # Upgrade to standard or higher for production
+    databaseName: family_assistant
+    user: assistant
+    postgresMajorVersion: "16" # PostgreSQL 16 supports pgvector
+
+services:
+  - type: web
+    name: family-assistant
+    runtime: docker
+    plan: starter # Upgrade to standard or higher for production
+    region: oregon # Change to your preferred region
+    healthCheckPath: /health
+    envVars:
+      # Database connection (automatically configured from the database)
+      - key: DATABASE_URL
+        fromDatabase:
+          name: family-assistant-db
+          property: connectionString
+      # Session secret (auto-generated)
+      - key: SESSION_SECRET_KEY
+        generateValue: true
+      # Timezone configuration
+      - key: TIMEZONE
+        value: UTC
+      # LLM API Keys - at least one is required
+      # Users will be prompted to enter these during deployment
+      - key: GEMINI_API_KEY
+        sync: false
+      - key: OPENROUTER_API_KEY
+        sync: false
+      - key: OPENAI_API_KEY
+        sync: false
+      # Telegram Bot Configuration
+      # Get your token from https://t.me/BotFather
+      - key: TELEGRAM_BOT_TOKEN
+        sync: false
+      # Comma-separated list of Telegram user IDs allowed to use the bot
+      # Find your ID by messaging @userinfobot on Telegram
+      - key: ALLOWED_USER_IDS
+        sync: false
+      # Telegram user ID for error notifications
+      - key: DEVELOPER_CHAT_ID
+        sync: false
+      # OIDC Authentication (optional)
+      # Configure these if you want to use OIDC for web UI authentication
+      - key: OIDC_CLIENT_ID
+        sync: false
+      - key: OIDC_CLIENT_SECRET
+        sync: false
+      - key: OIDC_DISCOVERY_URL
+        sync: false
+      - key: ALLOWED_OIDC_EMAILS
+        sync: false
+      # Push Notifications (optional)
+      # Generate with: python scripts/generate_vapid_keys.py
+      - key: VAPID_PRIVATE_KEY
+        sync: false
+      - key: VAPID_CONTACT_EMAIL
+        sync: false
+      # Calendar Integration (optional)
+      - key: CALDAV_URL
+        sync: false
+      - key: CALDAV_USERNAME
+        sync: false
+      - key: CALDAV_PASSWORD
+        sync: false
+      - key: CALDAV_CALENDAR_URLS
+        sync: false
+      - key: ICAL_URLS
+        sync: false
+      # Optional Integrations
+      - key: BRAVE_API_KEY
+        sync: false
+      - key: HOMEASSISTANT_API_KEY
+        sync: false
+      - key: GOOGLE_MAPS_API_KEY
+        sync: false
+      # Storage paths (using persistent disk)
+      - key: DOCUMENT_STORAGE_PATH
+        value: /data/documents
+      - key: ATTACHMENT_STORAGE_PATH
+        value: /data/attachments
+      - key: CHAT_ATTACHMENT_STORAGE_PATH
+        value: /data/chat_attachments
+    disk:
+      name: family-assistant-data
+      mountPath: /data
+      sizeGB: 10 # Adjust based on your needs


### PR DESCRIPTION
- Add render.yaml blueprint for automated deployment to Render
- Create comprehensive RENDER_DEPLOYMENT.md documentation
- Add "Deploy to Render" button to README
- Update GETTING_STARTED.md with Render as deployment option

The render.yaml configures:
- Web service using Docker with health checks
- PostgreSQL database with pgvector support
- Persistent disk for document/attachment storage
- Environment variables with prompts for secrets

https://claude.ai/code/session_01ML5gprumhDANpTXdo9yCrn