### PR TITLE
Publish string payloads as raw strings over MQTT

### DIFF
--- a/src/family_assistant/tools/mqtt.py
+++ b/src/family_assistant/tools/mqtt.py
@@ -99,7 +99,9 @@ async def mqtt_publish_tool(
     """Publish a JSON message to an MQTT topic."""
     host, port, username, password = _get_mqtt_config(exec_context)
 
-    payload_bytes = json.dumps(payload).encode()
+    payload_bytes = (
+        payload.encode() if isinstance(payload, str) else json.dumps(payload).encode()
+    )
 
     logger.info(
         "Publishing to MQTT topic %s (retain=%s, %d bytes)",

--- a/tests/unit/tools/test_mqtt_tools.py
+++ b/tests/unit/tools/test_mqtt_tools.py
@@ -133,10 +133,10 @@ async def test_mqtt_publish_string_payload(exec_context: ToolExecutionContext) -
 
     data = result.get_data()
     assert isinstance(data, dict)
-    assert data["payload_size"] == 4  # "ON" with quotes
+    assert data["payload_size"] == 2  # "ON" without JSON quotes
 
     call_args = mock_client.publish.call_args
-    assert call_args.kwargs["payload"] == b'"ON"'
+    assert call_args.kwargs["payload"] == b"ON"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When the MQTT publish payload is a string, encode it directly as UTF-8
instead of JSON-encoding it (which wraps it in quotes). This matches
the convention expected by most MQTT consumers like Home Assistant
and ESPHome, where e.g. "ON" should arrive as `ON` not `"ON"`.

https://claude.ai/code/session_012zZkzEqdFnLmfKUoPAicyu