### PR TITLE
Fix automation script truncation in get_automation_tool

### DIFF
--- a/src/family_assistant/tools/automations.py
+++ b/src/family_assistant/tools/automations.py
@@ -665,7 +665,7 @@ async def get_automation_tool(
             if action_type == "wake_llm" and config.get("context"):
                 lines.append(f"Context: {config['context']}")
             elif action_type == "script" and config.get("script_code"):
-                lines.append(f"Script: {config['script_code'][:100]}...")
+                lines.append(f"Script:\n{config['script_code']}")
 
         # Build structured data
         result_data = {


### PR DESCRIPTION
The text output sent to the LLM was truncating script_code to 100
characters, causing the assistant to see incomplete automation scripts
when retrieving them. Now includes the full script content.

https://claude.ai/code/session_01LLKovMPX1KGwdPNJZEMQ7P