### PR TITLE
Make service_profiles in config.yaml additive instead of replacing defaults

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -54,10 +54,18 @@
 #       - delete_calendar_event
 #       - modify_calendar_event
 
-# --- Camera Configuration ---
-# Configure Reolink cameras for the camera_analyst profile
-# Or use REOLINK_CAMERAS environment variable (JSON format)
+# --- Service Profiles ---
+# Profiles defined here are merged with defaults.yaml by ID:
+#   - New IDs are added alongside the built-in profiles.
+#   - Matching IDs override the corresponding default profile.
+# You do NOT need to re-list all default profiles to add a new one.
+#
+# Example: add a custom profile and configure an existing one
 # service_profiles:
+#   - id: "my_custom_profile"
+#     description: "A custom profile for my use case"
+#     processing_config:
+#       llm_model: "claude-sonnet-4-6"
 #   - id: "camera_analyst"
 #     processing_config:
 #       camera_config:

--- a/docs/operations/CONFIGURATION_REFERENCE.md
+++ b/docs/operations/CONFIGURATION_REFERENCE.md
@@ -679,6 +679,13 @@ The main configuration file (`config.yaml`) supports:
 - **attachment_config**: Attachment handling settings
 - **event_system**: Event system configuration
 
+Operator merge note for service profiles:
+
+- `service_profiles` in `config.yaml` are **merged by ID** with `defaults.yaml`.
+- Profiles with new IDs are added alongside the built-in defaults.
+- Profiles whose ID matches a default override that default.
+- You do not need to re-list all default profiles to add a new one.
+
 Operator merge note for tool policy:
 
 - `default_profile_settings.tools_policy.rules` in `config.yaml` are additive.

--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -844,11 +844,16 @@ def _merge_service_profiles_by_id(
     Returns:
         List of profile dicts ready for ``resolve_all_service_profiles()``.
     """
-    operator_profile_defs = operator_config_data.get("service_profiles")
-    if not operator_profile_defs:
-        # Operator did not define any profiles — use the merged result as-is
-        # (which equals the defaults since no replacement happened).
+    if "service_profiles" not in operator_config_data:
+        # Operator did not mention service_profiles at all — use the merged
+        # result as-is (which equals the defaults since no replacement happened).
         return [p.model_dump(exclude_unset=True) for p in merged_profiles]
+
+    operator_profile_defs = operator_config_data["service_profiles"]
+    if not operator_profile_defs:
+        # Operator explicitly set an empty list — return nothing so
+        # resolve_all_service_profiles() creates a single default profile.
+        return []
 
     operator_profile_ids = {
         p["id"] for p in operator_profile_defs if isinstance(p, dict) and "id" in p

--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -352,8 +352,8 @@ def _apply_default_profile_tools_policy_layers(
     if isinstance(operator_tools_config, dict):
         operator_mcp_ids = operator_tools_config.get("enable_mcp_server_ids", [])
         if operator_mcp_ids:
-            config_data["default_profile_settings"]["operator_mcp_server_ids"] = (
-                list(operator_mcp_ids)
+            config_data["default_profile_settings"]["operator_mcp_server_ids"] = list(
+                operator_mcp_ids
             )
 
     operator_policy_data = operator_default_settings.get("tools_policy")
@@ -667,9 +667,12 @@ def resolve_service_profile(
         # regardless of what the profile ships with.
         operator_mcp_ids = default_settings.get("operator_mcp_server_ids") or []
         if operator_mcp_ids:
-            profile_mcp_ids = resolved["tools_config"].get(
-                "enable_mcp_server_ids",
-            ) or []
+            profile_mcp_ids = (
+                resolved["tools_config"].get(
+                    "enable_mcp_server_ids",
+                )
+                or []
+            )
             # Deduplicate by string ID, preserving order. Entries can be
             # plain strings, MCPServerLoadingEntry dicts (from YAML), or
             # MCPServerLoadingEntry model instances (from validated config).
@@ -813,6 +816,66 @@ def load_indexing_pipeline_config(
             logger.error(f"Error parsing INDEXING_PIPELINE_CONFIG_JSON: {e}")
 
 
+def _merge_service_profiles_by_id(
+    defaults_profiles: list[Any],  # noqa: ANN401
+    merged_profiles: list[Any],  # noqa: ANN401
+    operator_config_data: dict[str, Any],  # noqa: ANN401
+) -> list[dict[str, Any]]:  # noqa: ANN401
+    """Merge service profile lists by ID so config.yaml is additive.
+
+    When the operator's config.yaml defines ``service_profiles``, profiles are
+    merged with the defaults by ID rather than replacing the whole list:
+
+    * Default profiles whose ID does not appear in config.yaml are preserved.
+    * Operator profiles whose ID matches a default override that default.
+    * Operator profiles with new IDs are appended.
+
+    ``exclude_unset=True`` is used so that ``resolve_service_profile()`` can
+    later distinguish explicitly-set YAML values from Pydantic defaults.
+
+    Args:
+        defaults_profiles: ServiceProfile instances from defaults.yaml only.
+        merged_profiles: ServiceProfile instances from the deep-merged config
+            (defaults.yaml + config.yaml).  When the operator defines
+            ``service_profiles``, the deep-merge *replaces* the list, so this
+            contains only the operator's profiles.
+        operator_config_data: Raw dict loaded from config.yaml (may be empty).
+
+    Returns:
+        List of profile dicts ready for ``resolve_all_service_profiles()``.
+    """
+    operator_profile_defs = operator_config_data.get("service_profiles")
+    if not operator_profile_defs:
+        # Operator did not define any profiles — use the merged result as-is
+        # (which equals the defaults since no replacement happened).
+        return [p.model_dump(exclude_unset=True) for p in merged_profiles]
+
+    operator_profile_ids = {
+        p["id"] for p in operator_profile_defs if isinstance(p, dict) and "id" in p
+    }
+
+    # Operator profiles from the validated (deep-merged) config, keyed by ID.
+    operator_by_id = {p.id: p.model_dump(exclude_unset=True) for p in merged_profiles}
+
+    result: list[dict[str, Any]] = []
+
+    # 1. Preserve default profiles not overridden by the operator.
+    for dp in defaults_profiles:
+        if dp.id not in operator_profile_ids:
+            result.append(dp.model_dump(exclude_unset=True))
+
+    # 2. Append all operator profiles (overrides + new).
+    for prof_def in operator_profile_defs:
+        if isinstance(prof_def, dict) and "id" in prof_def:
+            pid = prof_def["id"]
+            if pid in operator_by_id:
+                result.append(operator_by_id[pid])
+            else:
+                result.append(prof_def)
+
+    return result
+
+
 def load_config(
     defaults_file_path: str = DEFAULT_DEFAULTS_FILE,
     config_file_path: str = DEFAULT_CONFIG_FILE,
@@ -869,13 +932,16 @@ def load_config(
         operator_config_data,
     )
 
-    # Use exclude_unset=True for service_profiles so resolve_service_profile()
-    # can distinguish YAML-specified values from Pydantic defaults.
-    # Without this, ProcessingConfig defaults (e.g. timezone="UTC") overwrite
-    # the correct values from default_profile_settings during profile merging.
-    config_data["service_profiles"] = [
-        p.model_dump(exclude_unset=True) for p in base_config.service_profiles
-    ]
+    # Merge service profiles by ID so config.yaml can add new profiles
+    # without re-listing all defaults.  Profiles in config.yaml with the same
+    # ID as a default override it; new IDs are appended.
+    # exclude_unset=True lets resolve_service_profile() distinguish
+    # YAML-specified values from Pydantic defaults.
+    config_data["service_profiles"] = _merge_service_profiles_by_id(
+        defaults_only_config.service_profiles,
+        base_config.service_profiles,
+        operator_config_data,
+    )
 
     if load_dotenv_file:
         load_dotenv()

--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -862,6 +862,11 @@ def _merge_service_profiles_by_id(
     # Operator profiles from the validated (deep-merged) config, keyed by ID.
     operator_by_id = {p.id: p.model_dump(exclude_unset=True) for p in merged_profiles}
 
+    # Default profiles keyed by ID for merging with overrides.
+    defaults_by_id = {
+        dp.id: dp.model_dump(exclude_unset=True) for dp in defaults_profiles
+    }
+
     result: list[dict[str, Any]] = []
 
     # 1. Preserve default profiles not overridden by the operator.
@@ -874,7 +879,14 @@ def _merge_service_profiles_by_id(
         if isinstance(prof_def, dict) and "id" in prof_def:
             pid = prof_def["id"]
             if pid in operator_by_id:
-                result.append(operator_by_id[pid])
+                if pid in defaults_by_id:
+                    # Override: deep-merge operator's partial definition on
+                    # top of the default so unmentioned fields are preserved.
+                    result.append(
+                        deep_merge_dicts(defaults_by_id[pid], operator_by_id[pid])
+                    )
+                else:
+                    result.append(operator_by_id[pid])
             else:
                 result.append(prof_def)
 

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -282,7 +282,9 @@ class ServiceProfile(BaseModel):
     tools_config: ToolsConfig = Field(default_factory=ToolsConfig)
     tools_policy: ToolPolicyConfig | None = None
     operator_tools_policy: ToolPolicyConfig | None = Field(default=None, exclude=True)
-    operator_mcp_server_ids: list[str | MCPServerLoadingEntry] = Field(default_factory=list, exclude=True)
+    operator_mcp_server_ids: list[str | MCPServerLoadingEntry] = Field(
+        default_factory=list, exclude=True
+    )
     chat_id_to_name_map: dict[int, str] = Field(default_factory=dict)
     slash_commands: list[str] = Field(default_factory=list)
     visibility_grants: list[str] = Field(default_factory=list)
@@ -298,7 +300,9 @@ class DefaultProfileSettings(BaseModel):
     tools_config: ToolsConfig = Field(default_factory=ToolsConfig)
     tools_policy: ToolPolicyConfig | None = None
     operator_tools_policy: ToolPolicyConfig | None = Field(default=None, exclude=True)
-    operator_mcp_server_ids: list[str | MCPServerLoadingEntry] = Field(default_factory=list, exclude=True)
+    operator_mcp_server_ids: list[str | MCPServerLoadingEntry] = Field(
+        default_factory=list, exclude=True
+    )
     chat_id_to_name_map: dict[int, str] = Field(default_factory=dict)
     slash_commands: list[str] = Field(default_factory=list)
     visibility_grants: list[str] = Field(default_factory=list)

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1698,6 +1698,46 @@ class TestLoadConfig:
         assert shared.description == "Overridden"
         assert shared.processing_config.max_iterations == 42
 
+    def test_empty_service_profiles_in_config_yaml_wipes_defaults(
+        self, tmp_path: Path
+    ) -> None:
+        """Explicitly empty service_profiles in config.yaml removes all defaults."""
+        defaults_file = tmp_path / "defaults.yaml"
+        defaults_file.write_text(
+            yaml.dump({
+                "service_profiles": [
+                    {"id": "default_a", "description": "Default A"},
+                ],
+            })
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump({"service_profiles": []}))
+        prompts_file = tmp_path / "prompts.yaml"
+        prompts_file.write_text(yaml.dump({"system_prompt": "test"}))
+
+        env_to_clear = [m.env_var for m in ENV_VAR_MAPPINGS]
+        env_to_clear.extend([
+            "CALDAV_USERNAME",
+            "CALDAV_PASSWORD",
+            "CALDAV_CALENDAR_URLS",
+            "ICAL_URLS",
+            "MCP_CONFIG_PATH",
+            "INDEXING_PIPELINE_CONFIG_JSON",
+        ])
+        clean_env = {k: v for k, v in os.environ.items() if k not in env_to_clear}
+
+        with mock.patch.dict(os.environ, clean_env, clear=True):
+            config = load_config(
+                defaults_file_path=str(defaults_file),
+                config_file_path=str(config_file),
+                prompts_file_path=str(prompts_file),
+                load_dotenv_file=False,
+            )
+
+        # Empty list triggers resolve_all_service_profiles to create a
+        # single fallback profile, but the defaults are NOT preserved.
+        assert "default_a" not in {p.id for p in config.service_profiles}
+
     def test_invalid_config_raises_validation_error(self, tmp_path: Path) -> None:
         """Test that invalid config raises ValidationError."""
         config_file = tmp_path / "config.yaml"

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1450,9 +1450,15 @@ class TestLoadConfig:
                 load_dotenv_file=False,
             )
 
-        assert len(config.service_profiles) == 1
-        assert config.service_profiles[0].id == "test_profile"
-        assert config.service_profiles[0].processing_config.max_iterations == 25
+        profile_ids = {p.id for p in config.service_profiles}
+        # test_profile from config.yaml is added alongside defaults
+        assert "test_profile" in profile_ids
+        # Default profiles from defaults.yaml are preserved
+        assert "default_assistant" in profile_ids
+        test_profile = next(
+            p for p in config.service_profiles if p.id == "test_profile"
+        )
+        assert test_profile.processing_config.max_iterations == 25
 
     def test_profile_inherits_timezone_from_defaults(self, tmp_path: Path) -> None:
         """Regression: profile without explicit timezone inherits from defaults.
@@ -1596,6 +1602,101 @@ class TestLoadConfig:
         assert (
             config.service_profiles[0].processing_config.timezone == "America/New_York"
         )
+
+    def test_config_yaml_adds_profiles_to_defaults(self, tmp_path: Path) -> None:
+        """config.yaml profiles are additive — defaults are preserved."""
+        defaults_file = tmp_path / "defaults.yaml"
+        defaults_file.write_text(
+            yaml.dump({
+                "service_profiles": [
+                    {"id": "default_a", "description": "Default A"},
+                    {"id": "default_b", "description": "Default B"},
+                ],
+            })
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump({
+                "service_profiles": [
+                    {"id": "custom_c", "description": "Custom C"},
+                ],
+            })
+        )
+        prompts_file = tmp_path / "prompts.yaml"
+        prompts_file.write_text(yaml.dump({"system_prompt": "test"}))
+
+        env_to_clear = [m.env_var for m in ENV_VAR_MAPPINGS]
+        env_to_clear.extend([
+            "CALDAV_USERNAME",
+            "CALDAV_PASSWORD",
+            "CALDAV_CALENDAR_URLS",
+            "ICAL_URLS",
+            "MCP_CONFIG_PATH",
+            "INDEXING_PIPELINE_CONFIG_JSON",
+        ])
+        clean_env = {k: v for k, v in os.environ.items() if k not in env_to_clear}
+
+        with mock.patch.dict(os.environ, clean_env, clear=True):
+            config = load_config(
+                defaults_file_path=str(defaults_file),
+                config_file_path=str(config_file),
+                prompts_file_path=str(prompts_file),
+                load_dotenv_file=False,
+            )
+
+        profile_ids = {p.id for p in config.service_profiles}
+        assert profile_ids == {"default_a", "default_b", "custom_c"}
+
+    def test_config_yaml_overrides_default_profile_by_id(self, tmp_path: Path) -> None:
+        """config.yaml profile with same ID as default overrides it."""
+        defaults_file = tmp_path / "defaults.yaml"
+        defaults_file.write_text(
+            yaml.dump({
+                "service_profiles": [
+                    {"id": "shared", "description": "Original"},
+                    {"id": "other", "description": "Other"},
+                ],
+            })
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump({
+                "service_profiles": [
+                    {
+                        "id": "shared",
+                        "description": "Overridden",
+                        "processing_config": {"max_iterations": 42},
+                    },
+                ],
+            })
+        )
+        prompts_file = tmp_path / "prompts.yaml"
+        prompts_file.write_text(yaml.dump({"system_prompt": "test"}))
+
+        env_to_clear = [m.env_var for m in ENV_VAR_MAPPINGS]
+        env_to_clear.extend([
+            "CALDAV_USERNAME",
+            "CALDAV_PASSWORD",
+            "CALDAV_CALENDAR_URLS",
+            "ICAL_URLS",
+            "MCP_CONFIG_PATH",
+            "INDEXING_PIPELINE_CONFIG_JSON",
+        ])
+        clean_env = {k: v for k, v in os.environ.items() if k not in env_to_clear}
+
+        with mock.patch.dict(os.environ, clean_env, clear=True):
+            config = load_config(
+                defaults_file_path=str(defaults_file),
+                config_file_path=str(config_file),
+                prompts_file_path=str(prompts_file),
+                load_dotenv_file=False,
+            )
+
+        profile_ids = {p.id for p in config.service_profiles}
+        assert profile_ids == {"shared", "other"}
+        shared = next(p for p in config.service_profiles if p.id == "shared")
+        assert shared.description == "Overridden"
+        assert shared.processing_config.max_iterations == 42
 
     def test_invalid_config_raises_validation_error(self, tmp_path: Path) -> None:
         """Test that invalid config raises ValidationError."""

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1698,6 +1698,80 @@ class TestLoadConfig:
         assert shared.description == "Overridden"
         assert shared.processing_config.max_iterations == 42
 
+    def test_partial_profile_override_preserves_default_attributes(
+        self, tmp_path: Path
+    ) -> None:
+        """Overriding an existing profile preserves attributes from defaults.yaml."""
+        defaults_file = tmp_path / "defaults.yaml"
+        defaults_file.write_text(
+            yaml.dump({
+                "service_profiles": [
+                    {
+                        "id": "reminder",
+                        "description": "Reminder profile",
+                        "processing_config": {
+                            "prompts": {"system_prompt": "You are a reminder bot."},
+                        },
+                        "tools_config": {
+                            "enable_local_tools": ["get_note", "list_notes"],
+                            "enable_mcp_server_ids": [],
+                        },
+                    },
+                ],
+            })
+        )
+        config_file = tmp_path / "config.yaml"
+        # Operator only wants to change the timezone — everything else
+        # from defaults.yaml should be preserved.
+        config_file.write_text(
+            yaml.dump({
+                "service_profiles": [
+                    {
+                        "id": "reminder",
+                        "processing_config": {"timezone": "US/Eastern"},
+                    },
+                ],
+            })
+        )
+        prompts_file = tmp_path / "prompts.yaml"
+        prompts_file.write_text(yaml.dump({"system_prompt": "test"}))
+
+        env_to_clear = [m.env_var for m in ENV_VAR_MAPPINGS]
+        env_to_clear.extend([
+            "CALDAV_USERNAME",
+            "CALDAV_PASSWORD",
+            "CALDAV_CALENDAR_URLS",
+            "ICAL_URLS",
+            "MCP_CONFIG_PATH",
+            "INDEXING_PIPELINE_CONFIG_JSON",
+        ])
+        clean_env = {k: v for k, v in os.environ.items() if k not in env_to_clear}
+
+        with mock.patch.dict(os.environ, clean_env, clear=True):
+            config = load_config(
+                defaults_file_path=str(defaults_file),
+                config_file_path=str(config_file),
+                prompts_file_path=str(prompts_file),
+                load_dotenv_file=False,
+            )
+
+        reminder = next(p for p in config.service_profiles if p.id == "reminder")
+        # Operator override applied
+        assert reminder.processing_config.timezone == "US/Eastern"
+        # Defaults preserved
+        assert reminder.description == "Reminder profile"
+        assert (
+            reminder.processing_config.prompts["system_prompt"]
+            == "You are a reminder bot."
+        )
+        assert reminder.tools_config.enable_local_tools is not None
+        local_tool_names = [
+            t if isinstance(t, str) else t.name
+            for t in reminder.tools_config.enable_local_tools
+        ]
+        assert "get_note" in local_tool_names
+        assert "list_notes" in local_tool_names
+
     def test_empty_service_profiles_in_config_yaml_wipes_defaults(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Previously, defining service_profiles in config.yaml replaced the entire
list from defaults.yaml due to how deep_merge_dicts handles lists. Now
profiles are merged by ID: new IDs are appended, matching IDs override
the corresponding default, and unmentioned defaults are preserved.

https://claude.ai/code/session_013iYztYFJhUBSYnykXUbV1t