### PR TITLE
fix: accept bytes|None in base64_encode for attachment_read_bytes compat

### DIFF
--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -352,8 +352,8 @@ def _apply_default_profile_tools_policy_layers(
     if isinstance(operator_tools_config, dict):
         operator_mcp_ids = operator_tools_config.get("enable_mcp_server_ids", [])
         if operator_mcp_ids:
-            config_data["default_profile_settings"]["operator_mcp_server_ids"] = (
-                list(operator_mcp_ids)
+            config_data["default_profile_settings"]["operator_mcp_server_ids"] = list(
+                operator_mcp_ids
             )
 
     operator_policy_data = operator_default_settings.get("tools_policy")
@@ -667,9 +667,12 @@ def resolve_service_profile(
         # regardless of what the profile ships with.
         operator_mcp_ids = default_settings.get("operator_mcp_server_ids") or []
         if operator_mcp_ids:
-            profile_mcp_ids = resolved["tools_config"].get(
-                "enable_mcp_server_ids",
-            ) or []
+            profile_mcp_ids = (
+                resolved["tools_config"].get(
+                    "enable_mcp_server_ids",
+                )
+                or []
+            )
             # Deduplicate by string ID, preserving order. Entries can be
             # plain strings, MCPServerLoadingEntry dicts (from YAML), or
             # MCPServerLoadingEntry model instances (from validated config).

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -282,7 +282,9 @@ class ServiceProfile(BaseModel):
     tools_config: ToolsConfig = Field(default_factory=ToolsConfig)
     tools_policy: ToolPolicyConfig | None = None
     operator_tools_policy: ToolPolicyConfig | None = Field(default=None, exclude=True)
-    operator_mcp_server_ids: list[str | MCPServerLoadingEntry] = Field(default_factory=list, exclude=True)
+    operator_mcp_server_ids: list[str | MCPServerLoadingEntry] = Field(
+        default_factory=list, exclude=True
+    )
     chat_id_to_name_map: dict[int, str] = Field(default_factory=dict)
     slash_commands: list[str] = Field(default_factory=list)
     visibility_grants: list[str] = Field(default_factory=list)
@@ -298,7 +300,9 @@ class DefaultProfileSettings(BaseModel):
     tools_config: ToolsConfig = Field(default_factory=ToolsConfig)
     tools_policy: ToolPolicyConfig | None = None
     operator_tools_policy: ToolPolicyConfig | None = Field(default=None, exclude=True)
-    operator_mcp_server_ids: list[str | MCPServerLoadingEntry] = Field(default_factory=list, exclude=True)
+    operator_mcp_server_ids: list[str | MCPServerLoadingEntry] = Field(
+        default_factory=list, exclude=True
+    )
     chat_id_to_name_map: dict[int, str] = Field(default_factory=dict)
     slash_commands: list[str] = Field(default_factory=list)
     visibility_grants: list[str] = Field(default_factory=list)

--- a/src/family_assistant/scripting/monty_engine.py
+++ b/src/family_assistant/scripting/monty_engine.py
@@ -87,8 +87,10 @@ def _safe_json_decode(value: Any) -> Any:  # noqa: ANN401 - JSON decode returns 
     return value
 
 
-def _base64_encode(data: str | bytes) -> str:
+def _base64_encode(data: str | bytes | None) -> str:
     """Encode a string or bytes to a base64 string."""
+    if data is None:
+        raise TypeError("base64_encode: data must not be None")
     if isinstance(data, str):
         data = data.encode("utf-8")
     return base64.b64encode(data).decode("ascii")

--- a/src/family_assistant/scripting/validator.py
+++ b/src/family_assistant/scripting/validator.py
@@ -157,7 +157,7 @@ def _generate_builtin_api_stubs(
         lines.append("")
 
     # Base64 API (always available)
-    lines.append("def base64_encode(data: str | bytes) -> str: ...")
+    lines.append("def base64_encode(data: str | bytes | None) -> str: ...")
     lines.append("def base64_decode(data: str) -> str: ...")
     lines.append("def base64_decode_bytes(data: str) -> bytes: ...")
     lines.append("")

--- a/tests/functional/tools/test_execute_script.py
+++ b/tests/functional/tools/test_execute_script.py
@@ -491,3 +491,111 @@ chart
         )
         # Should contain indication of success
         assert "Error:" not in result.text or "Script result:" in result.text
+
+
+@pytest.mark.asyncio
+async def test_execute_script_base64_encode_bytes(db_engine: AsyncEngine) -> None:
+    """Test base64_encode with bytes argument through the full execute_script tool path.
+
+    This exercises both validation (type checker) and runtime to ensure bytes
+    are properly supported as an argument to base64_encode.
+    """
+    async with DatabaseContext(engine=db_engine) as db:
+        ctx = ToolExecutionContext(
+            interface_type="test",
+            conversation_id="test-conv",
+            user_name="test",
+            turn_id=None,
+            db_context=db,
+            clock=None,
+            home_assistant_client=None,
+            event_sources=None,
+            attachment_registry=None,
+            processing_service=None,
+            camera_backend=None,
+            timezone=ZoneInfo("UTC"),
+        )
+
+        # Test 1: bytes literal
+        result = await execute_script_tool(ctx, 'base64_encode(b"hello")')
+        assert result.text is not None
+        assert "aGVsbG8=" in result.text, f"Unexpected result: {result.text}"
+
+        # Test 2: bytes from base64_decode_bytes round-trip
+        result = await execute_script_tool(
+            ctx,
+            """
+data = base64_decode_bytes("aGVsbG8=")
+base64_encode(data)
+""",
+        )
+        assert result.text is not None
+        assert "aGVsbG8=" in result.text, f"Unexpected result: {result.text}"
+
+        # Test 3: bytes via globals
+        result = await execute_script_tool(
+            ctx,
+            "base64_encode(raw_data)",
+            globals={"raw_data": b"binary content"},
+        )
+        assert result.text is not None
+        assert "Error" not in result.text, f"Unexpected error: {result.text}"
+
+
+@pytest.mark.asyncio
+async def test_execute_script_base64_encode_bytes_from_optional(
+    db_engine: AsyncEngine,
+    tmp_path: Path,
+) -> None:
+    """Test base64_encode with bytes|None from attachment_read_bytes.
+
+    This reproduces the real-world issue: attachment_read_bytes returns
+    bytes | None, and passing that directly to base64_encode(str | bytes)
+    fails validation because None is not in the union.
+    """
+    async with DatabaseContext(engine=db_engine) as db:
+        test_storage = tmp_path / "test_attachments"
+        test_storage.mkdir(exist_ok=True)
+        attachment_registry = AttachmentRegistry(
+            storage_path=str(test_storage), db_engine=db_engine, config=None
+        )
+
+        mock_service = Mock()
+        mock_service.tools_provider = CompositeToolsProvider([])
+
+        ctx = ToolExecutionContext(
+            interface_type="test",
+            conversation_id="test-conv",
+            user_name="test",
+            turn_id=None,
+            db_context=db,
+            clock=None,
+            home_assistant_client=None,
+            event_sources=None,
+            attachment_registry=attachment_registry,
+            processing_service=mock_service,
+            camera_backend=None,
+            timezone=ZoneInfo("UTC"),
+        )
+
+        # Store a test attachment so attachment_read_bytes returns real bytes
+        metadata = await attachment_registry.store_and_register_tool_attachment(
+            file_content=b"binary content",
+            filename="test.png",
+            content_type="image/png",
+            tool_name="test",
+            description="test data",
+            conversation_id="test-conv",
+        )
+
+        # This is the pattern that fails: attachment_read_bytes returns bytes|None,
+        # and the type checker rejects passing bytes|None to base64_encode(str|bytes)
+        result = await execute_script_tool(
+            ctx,
+            f"""
+data = attachment_read_bytes("{metadata.attachment_id}")
+base64_encode(data)
+""",
+        )
+        assert result.text is not None
+        assert "Error" not in result.text, f"Unexpected error: {result.text}"


### PR DESCRIPTION
attachment_read_bytes returns bytes|None, so passing its result directly
to base64_encode(str|bytes) was rejected by the Monty type checker
because None is not in the union. Widen the validator stub to accept
str|bytes|None and add a clear runtime TypeError for None.

https://claude.ai/code/session_01XoyHhz21xcnBcCHUFLrPTU