### PR TITLE
Improve type error messages to show expected vs actual types

### DIFF
--- a/src/family_assistant/scripting/monty_engine.py
+++ b/src/family_assistant/scripting/monty_engine.py
@@ -444,7 +444,9 @@ class MontyEngine:
         ) -> Any:  # noqa: ANN401
             parsed_args = json.loads(args_json)
             if not isinstance(parsed_args, dict):
-                raise ValueError("Arguments must be a JSON object")
+                raise ValueError(
+                    f"Arguments: expected JSON object, got {type(parsed_args).__name__}"
+                )
             return await execute_tool_async(tool_name, **parsed_args)
 
         names.append("tools_execute_json")
@@ -893,16 +895,22 @@ class MontyEngine:
             elif isinstance(context, dict):
                 context_dict = dict(context)
             else:
-                raise TypeError("wake_llm context must be a dictionary or string")
+                raise TypeError(
+                    f"wake_llm context: expected dict or str, got {type(context).__name__}"
+                )
 
             if "attachments" in context_dict:
                 attachments = context_dict["attachments"]
                 if not isinstance(attachments, list):
-                    raise TypeError("attachments must be a list of attachment IDs")
+                    raise TypeError(
+                        f"attachments: expected list, got {type(attachments).__name__}"
+                    )
 
                 for attachment_id in attachments:
                     if not isinstance(attachment_id, str):
-                        raise TypeError("attachment IDs must be strings")
+                        raise TypeError(
+                            f"attachment ID: expected str, got {type(attachment_id).__name__}"
+                        )
                     try:
                         uuid.UUID(attachment_id)
                     except ValueError as e:

--- a/src/family_assistant/tools/stored_scripts.py
+++ b/src/family_assistant/tools/stored_scripts.py
@@ -41,12 +41,12 @@ def _validate_parameters_schema_shape(
     Returns an error message on failure, or None if valid.
     """
     if not isinstance(schema, dict):
-        return "schema must be a dict"
+        return f"schema: expected dict, got {type(schema).__name__}"
 
     properties = schema.get("properties")
     if properties is not None:
         if not isinstance(properties, dict):
-            return "'properties' must be a dict"
+            return f"'properties': expected dict, got {type(properties).__name__}"
         for key in properties:
             if not isinstance(key, str):
                 return f"'properties' keys must be strings, got {type(key).__name__}"
@@ -54,7 +54,7 @@ def _validate_parameters_schema_shape(
     required = schema.get("required")
     if required is not None:
         if not isinstance(required, list):
-            return "'required' must be a list"
+            return f"'required': expected list, got {type(required).__name__}"
         for item in required:
             if not isinstance(item, str):
                 return f"'required' entries must be strings, got {type(item).__name__}"
@@ -90,14 +90,14 @@ async def validate_script_action_config(
     if not name:
         return None
     if not isinstance(name, str):
-        return "'script_name' must be a string"
+        return f"'script_name': expected str, got {type(name).__name__}"
     stored = await db_context.scripts.get_by_name(name)
     if stored is None:
         return f"Stored script '{name}' not found"
 
     raw_params = action_config.get("parameters")
     if raw_params is not None and not isinstance(raw_params, dict):
-        return "Script 'parameters' must be a dict"
+        return f"'parameters': expected dict, got {type(raw_params).__name__}"
 
     if stored.parameters_schema:
         params = raw_params or {}


### PR DESCRIPTION
Type validation errors in monty_engine.py and stored_scripts.py now use
"expected Y, got Z" format instead of generic "must be X" messages.

https://claude.ai/code/session_01FuCV1eaCGCQqkKsXKJFv7T