### PR TITLE
Fix calendar confirmation showing "Event details not found"

### DIFF
--- a/src/family_assistant/tools/infrastructure.py
+++ b/src/family_assistant/tools/infrastructure.py
@@ -21,7 +21,6 @@ from typing import (
     runtime_checkable,
 )
 
-from family_assistant import calendar_integration
 from family_assistant.tools.attachment_utils import process_attachment_arguments
 from family_assistant.tools.metadata import (
     ToolDescriptor,
@@ -41,7 +40,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
     from family_assistant.embeddings import EmbeddingGenerator
-    from family_assistant.tools.types import CalendarEvent
 
 logger = logging.getLogger(__name__)
 
@@ -834,64 +832,6 @@ class ConfirmingToolsProvider(ToolsProvider):
             return None
         return await self.wrapped_provider.get_tool_descriptor(name)
 
-    async def _get_event_details_for_confirmation(
-        self,
-        tool_name: str,
-        # ast-grep-ignore: no-dict-any - Tool arguments are dynamic JSON from LLM
-        args: dict[str, Any],
-        context: ToolExecutionContext,
-    ) -> CalendarEvent | None:
-        """Fetches additional details for tools that need them for confirmation.
-
-        This is specifically for calendar tools that need to fetch event details
-        before showing confirmation.
-        """
-        if tool_name in {"modify_calendar_event", "delete_calendar_event"}:
-            uid = args.get("uid")
-            calendar_url = args.get("calendar_url")
-            if uid and calendar_url:
-                # Try to get calendar config from the wrapped provider
-                calendar_config = None
-
-                # Check if wrapped provider is LocalToolsProvider with calendar config
-                if isinstance(self.wrapped_provider, LocalToolsProvider):
-                    calendar_config = self.wrapped_provider.get_calendar_config()
-                    logger.debug(
-                        f"Found calendar config in wrapped LocalToolsProvider: {bool(calendar_config)}"
-                    )
-                # Check if it's a CompositeToolsProvider wrapping a LocalToolsProvider
-                elif isinstance(self.wrapped_provider, CompositeToolsProvider):
-                    logger.debug(
-                        "Wrapped provider is CompositeToolsProvider, checking providers..."
-                    )
-                    for provider in self.wrapped_provider.get_providers():
-                        if isinstance(provider, LocalToolsProvider):
-                            calendar_config = provider.get_calendar_config()
-                            logger.debug(
-                                f"Found calendar config in provider {type(provider).__name__}: {bool(calendar_config)}"
-                            )
-                            break
-                else:
-                    logger.debug(
-                        f"Wrapped provider type: {type(self.wrapped_provider).__name__}, has no calendar config"
-                    )
-
-                if calendar_config:
-                    try:
-                        # Fetch event details using the dedicated function
-                        event_details = await calendar_integration.fetch_event_details_for_confirmation(
-                            uid=uid,
-                            calendar_url=calendar_url,
-                            calendar_config=cast("CalendarConfig", calendar_config),
-                            timezone=context.timezone,
-                        )
-                        return event_details
-                    except Exception as e:
-                        logger.error(
-                            f"Failed to fetch event details for {tool_name}: {e}"
-                        )
-        return None
-
     async def execute_tool(
         self,
         name: str,
@@ -923,6 +863,11 @@ class ConfirmingToolsProvider(ToolsProvider):
 
                 typed_callback = context.request_confirmation_callback
                 resolved_call_id = call_id or f"tool_{uuid.uuid4()}"
+
+                # Expose the provider chain so confirmation renderers can
+                # access calendar config and other provider-specific data.
+                if context.tools_provider is None:
+                    context.tools_provider = self
 
                 # The callback is expected to handle the timeout internally via asyncio.wait_for
                 # Pass context so renderers can fetch event details, timezone, etc.
@@ -1081,6 +1026,10 @@ class PolicyEnforcingToolsProvider(ToolsProvider):
             try:
                 typed_callback = context.request_confirmation_callback
                 resolved_call_id = call_id or f"tool_{uuid.uuid4()}"
+
+                if context.tools_provider is None:
+                    context.tools_provider = self
+
                 user_confirmed = await typed_callback(
                     interface_type=context.interface_type,
                     conversation_id=context.conversation_id,

--- a/tests/functional/calendar/test_calendar_confirmation.py
+++ b/tests/functional/calendar/test_calendar_confirmation.py
@@ -35,6 +35,7 @@ from family_assistant.tools.calendar import (
     search_calendar_events_tool,
 )
 from family_assistant.tools.confirmation import (
+    TOOL_CONFIRMATION_RENDERERS,
     render_delete_calendar_event_confirmation,
     render_modify_calendar_event_confirmation,
 )
@@ -465,6 +466,118 @@ async def test_confirming_tools_provider_with_calendar_events(
             or "successfully" in result_text.lower()
             or "modified" in result_text.lower()
         ), f"Tool execution failed: {result}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres
+async def test_confirming_provider_sets_tools_provider_for_renderer(
+    pg_vector_db_engine: AsyncEngine,
+    radicale_server: tuple[str, str, str, str],
+) -> None:
+    """Test that ConfirmingToolsProvider makes calendar config available to confirmation renderers.
+
+    Reproduces production path where context.tools_provider starts as None
+    and must be set by ConfirmingToolsProvider before the renderer runs.
+    """
+    radicale_base_url, r_user, r_pass, test_calendar_url = radicale_server
+
+    local_tz = ZoneInfo(TEST_TIMEZONE_STR)
+    event_summary = f"Renderer Integration {uuid.uuid4()}"
+    start_dt = datetime.now(local_tz).replace(
+        hour=11, minute=0, second=0, microsecond=0
+    ) + timedelta(days=2)
+    end_dt = start_dt + timedelta(hours=1)
+
+    event_uid = await create_test_event_in_radicale(
+        radicale_server, event_summary, start_dt, end_dt, pg_vector_db_engine
+    )
+
+    test_calendar_config = cast(
+        "CalendarConfig",
+        {
+            "caldav": {
+                "username": r_user,
+                "password": r_pass,
+                "base_url": radicale_base_url,
+                "calendar_urls": [test_calendar_url],
+            }
+        },
+    )
+
+    local_provider = LocalToolsProvider(
+        definitions=local_tools_definition,
+        implementations=local_tool_implementations,
+        calendar_config=test_calendar_config,
+    )
+
+    rendered_prompts: list[str] = []
+
+    async def rendering_confirmation_callback(
+        interface_type: str,
+        conversation_id: str,
+        turn_id: str | None,
+        tool_name: str,
+        call_id: str,
+        # ast-grep-ignore: no-dict-any - tool args from external LLM tool call have dynamic fields
+        tool_args: dict[str, Any],
+        timeout_seconds: float,
+        context: ToolExecutionContext,
+    ) -> bool:
+        """Callback that uses the actual confirmation renderer, like production."""
+        renderer = TOOL_CONFIRMATION_RENDERERS.get(tool_name)
+        if renderer:
+            prompt_text = await renderer(tool_args, context)
+            rendered_prompts.append(prompt_text)
+        return True
+
+    confirming_provider = ConfirmingToolsProvider(
+        wrapped_provider=local_provider,
+        tools_requiring_confirmation={"modify_calendar_event"},
+        confirmation_timeout=10.0,
+    )
+
+    async with get_db_context(engine=pg_vector_db_engine) as db_ctx:
+        exec_context = ToolExecutionContext(
+            interface_type="test",
+            conversation_id="test-conv-renderer",
+            user_name="TestUser",
+            turn_id="test-turn-renderer",
+            db_context=db_ctx,
+            processing_service=None,
+            clock=None,
+            home_assistant_client=None,
+            event_sources=None,
+            attachment_registry=None,
+            chat_interface=None,
+            timezone=ZoneInfo(TEST_TIMEZONE_STR),
+            request_confirmation_callback=rendering_confirmation_callback,
+            camera_backend=None,
+            # tools_provider intentionally left as None to mimic production
+        )
+
+        test_args = {
+            "uid": event_uid,
+            "calendar_url": test_calendar_url,
+            "new_summary": "Updated Summary",
+        }
+
+        await confirming_provider.execute_tool(
+            name="modify_calendar_event",
+            arguments=test_args,
+            context=exec_context,
+        )
+
+    assert len(rendered_prompts) == 1
+    prompt = rendered_prompts[0]
+
+    escaped_summary = telegramify_markdown.escape_markdown(event_summary)
+    assert event_summary in prompt or escaped_summary in prompt, (
+        f"Original event summary not in rendered prompt: {prompt}"
+    )
+    assert "Event details not found" not in prompt, (
+        f"Event details should have been fetched but got: {prompt}"
+    )
+    assert "Updated Summary" in prompt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
ConfirmingToolsProvider and PolicyEnforcingToolsProvider now set
context.tools_provider before calling the confirmation callback,
allowing confirmation renderers to traverse the provider chain
and find the calendar config needed to fetch event details.

Also removes dead _get_event_details_for_confirmation method that
was never called.

https://claude.ai/code/session_01XCovKWTz3pL1bxiJKs3sKH