### PR TITLE
Harden Mailgun email intake

### DIFF
--- a/alembic/versions/2026_04_18-add_target_user_id_to_received_emails.py
+++ b/alembic/versions/2026_04_18-add_target_user_id_to_received_emails.py
@@ -1,0 +1,38 @@
+"""Add target user id to received emails.
+
+Revision ID: add_email_target_user
+Revises: add_scripts_table
+Create Date: 2026-04-18
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "add_email_target_user"
+down_revision: str | None = "add_scripts_table"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "received_emails",
+        sa.Column("target_user_id", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_received_emails_target_user_id"),
+        "received_emails",
+        ["target_user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_received_emails_target_user_id"), table_name="received_emails"
+    )
+    op.drop_column("received_emails", "target_user_id")

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -237,8 +237,9 @@ email_intake:
   # Mailgun webhook signing key. When set, timestamp/token/signature fields are required.
   mailgun_webhook_signing_key: null
   mailgun_signature_max_age_seconds: 300
-  # Empty allowlists mean unrestricted. Use lowercase concrete addresses for operational clarity.
+  # Empty allowlists mean unrestricted. Sender addresses are the authorized forwarding users.
   allowed_sender_addresses: []
+  # Recipient addresses are the Mailgun inbound addresses/aliases this app should accept.
   allowed_recipient_addresses: []
   # Require DMARC/SPF/DKIM checks reported by Mailgun/authentication headers.
   require_authenticated_sender: false

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -245,6 +245,10 @@ email_intake:
   require_authenticated_sender: false
   require_dmarc_pass: true
   allow_spf_or_dkim_fallback_when_dmarc_missing: false
+  # Require accepted emails to resolve to exactly one configured application user.
+  require_user_mapping: false
+  # Map authorized forwarding senders and/or Mailgun inbound aliases to app users.
+  user_mappings: []
   # Application-level limits in bytes, independent of any reverse proxy limits.
   max_raw_request_bytes: 26214400
   max_attachment_bytes: 10485760

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -229,6 +229,26 @@ mcp_config:
 notes_config:
   default_visibility_labels: ["default"]
 
+# --- Email Intake Security ---
+# Optional controls for the /webhook/mail Mailgun receiving webhook. By default
+# these are permissive to preserve existing indexing-only deployments; configure
+# them before enabling assistant actions from inbound email.
+email_intake:
+  # Mailgun webhook signing key. When set, timestamp/token/signature fields are required.
+  mailgun_webhook_signing_key: null
+  mailgun_signature_max_age_seconds: 300
+  # Empty allowlists mean unrestricted. Use lowercase concrete addresses for operational clarity.
+  allowed_sender_addresses: []
+  allowed_recipient_addresses: []
+  # Require DMARC/SPF/DKIM checks reported by Mailgun/authentication headers.
+  require_authenticated_sender: false
+  require_dmarc_pass: true
+  allow_spf_or_dkim_fallback_when_dmarc_missing: false
+  # Application-level limits in bytes, independent of any reverse proxy limits.
+  max_raw_request_bytes: 26214400
+  max_attachment_bytes: 10485760
+  max_total_attachment_bytes: 26214400
+
 # --- Skills Configuration ---
 # Directories for file-based skills (loaded at startup, shown in skill catalog).
 # builtin_dir defaults to the package's skills/builtin/ directory when not set.
@@ -1716,4 +1736,3 @@ otel:
 
 # Secrets (telegram_token, api_keys, database_url) are primarily from env.
 # Model, embedding_model, server_url, storage_paths are also top-level or env.
-

--- a/docs/operations/CONFIGURATION_REFERENCE.md
+++ b/docs/operations/CONFIGURATION_REFERENCE.md
@@ -134,6 +134,127 @@ Directory containing user documentation files.
 
 ______________________________________________________________________
 
+## Email Intake Security
+
+The `/webhook/mail` endpoint accepts Mailgun inbound email webhooks. Use this configuration when
+Mailgun routes are enabled, especially before allowing any assistant action from forwarded email.
+
+```yaml
+email_intake:
+  mailgun_webhook_signing_key: "your-mailgun-http-webhook-signing-key"
+  mailgun_signature_max_age_seconds: 300
+
+  allowed_sender_addresses:
+    - "alice@gmail.com"
+    - "bob@gmail.com"
+
+  allowed_recipient_addresses:
+    - "assistant-intake@mg.example.com"
+    - "assistant+alice@mg.example.com"
+    - "assistant+bob@mg.example.com"
+
+  require_authenticated_sender: true
+  require_dmarc_pass: true
+  allow_spf_or_dkim_fallback_when_dmarc_missing: false
+
+  max_raw_request_bytes: 26214400
+  max_attachment_bytes: 10485760
+  max_total_attachment_bytes: 26214400
+```
+
+### mailgun_webhook_signing_key
+
+Mailgun HTTP webhook signing key for the receiving domain.
+
+| Property  | Value                                   |
+| --------- | --------------------------------------- |
+| Required  | Yes when any email intake policy is set |
+| Default   | `null`                                  |
+| Sensitive | **Yes**                                 |
+| Example   | `0123456789abcdef0123456789abcdef`      |
+
+If this key is unset, the app skips Mailgun signature verification only for permissive indexing-only
+deployments. If sender allowlists, recipient allowlists, or sender authentication are enabled, the
+webhook fails closed until the signing key is configured. This prevents direct HTTP clients from
+forging Mailgun form fields such as `sender`, `recipient`, `dmarc`, `spf`, and `dkim`.
+
+### allowed_sender_addresses
+
+Authorized email accounts that may forward messages into the assistant.
+
+These are the SMTP envelope senders reported by Mailgun in the `sender` form field. In the common
+CUJ where Alice forwards an order confirmation from Gmail, this should contain Alice's Gmail
+address, not the merchant's address from the original forwarded message.
+
+| Property  | Value                        |
+| --------- | ---------------------------- |
+| Required  | Recommended for email intake |
+| Default   | `[]` (unrestricted)          |
+| Sensitive | No                           |
+| Example   | `["alice@gmail.com"]`        |
+
+Use concrete lowercase addresses. If this list is non-empty, the Mailgun signing key must also be
+set.
+
+### allowed_recipient_addresses
+
+Mailgun inbound addresses or aliases that this app should accept.
+
+These are the recipient addresses Mailgun reports in the `recipient` form field. They are addresses
+at your Mailgun receiving domain, not the order vendor's email address and not the human user's
+normal Gmail address unless Gmail is also the Mailgun recipient. Examples:
+
+- Shared intake mailbox: `assistant-intake@mg.example.com`
+- Per-user aliases: `assistant+alice@mg.example.com`, `assistant+bob@mg.example.com`
+- Per-user local parts: `alice@mg.example.com`, `bob@mg.example.com`
+
+Mailgun can route a catch-all or regex recipient pattern to the same `/webhook/mail` endpoint, while
+the app uses `allowed_recipient_addresses` to reject unexpected recipients. Per-user recipient
+aliases add friction because operators need to provision or communicate the aliases, but they give a
+clean way to distinguish which user intended the email intake path. This PR only validates and
+stores the recipient; later action-processing work can use the stored recipient to map the email to
+a user or confirmation channel.
+
+| Property  | Value                                     |
+| --------- | ----------------------------------------- |
+| Required  | Recommended for production Mailgun routes |
+| Default   | `[]` (unrestricted)                       |
+| Sensitive | No                                        |
+| Example   | `["assistant+alice@mg.example.com"]`      |
+
+If this list is non-empty, the Mailgun signing key must also be set.
+
+### Sender Authentication Policy
+
+`require_authenticated_sender` makes the webhook require sender authentication results reported by
+Mailgun or by the message `Authentication-Results` header. With the default strict policy,
+`require_dmarc_pass: true`, DMARC must pass. DMARC failure always fails closed. Set
+`allow_spf_or_dkim_fallback_when_dmarc_missing: true` only if you accept SPF or DKIM pass when DMARC
+is absent.
+
+| Option                                          | Default | Recommended |
+| ----------------------------------------------- | ------- | ----------- |
+| `require_authenticated_sender`                  | `false` | `true`      |
+| `require_dmarc_pass`                            | `true`  | `true`      |
+| `allow_spf_or_dkim_fallback_when_dmarc_missing` | `false` | `false`     |
+
+If `require_authenticated_sender` is true, the Mailgun signing key must also be set.
+
+### Size Limits
+
+Application-level payload limits for inbound email.
+
+| Option                       | Default    | Meaning                                 |
+| ---------------------------- | ---------- | --------------------------------------- |
+| `max_raw_request_bytes`      | `26214400` | Full webhook request body limit         |
+| `max_attachment_bytes`       | `10485760` | Per-attachment limit                    |
+| `max_total_attachment_bytes` | `26214400` | Total attachments for one inbound email |
+
+The webhook checks `Content-Length` before buffering the request body when the header is present,
+and also checks the actual buffered body length.
+
+______________________________________________________________________
+
 ## Authentication - Telegram
 
 ### TELEGRAM_BOT_TOKEN

--- a/docs/operations/CONFIGURATION_REFERENCE.md
+++ b/docs/operations/CONFIGURATION_REFERENCE.md
@@ -157,6 +157,19 @@ email_intake:
   require_dmarc_pass: true
   allow_spf_or_dkim_fallback_when_dmarc_missing: false
 
+  require_user_mapping: true
+  user_mappings:
+    - user_id: "alice"
+      sender_addresses:
+        - "alice@gmail.com"
+      recipient_addresses:
+        - "assistant+alice@mg.example.com"
+    - user_id: "bob"
+      sender_addresses:
+        - "bob@gmail.com"
+      recipient_addresses:
+        - "assistant+bob@mg.example.com"
+
   max_raw_request_bytes: 26214400
   max_attachment_bytes: 10485760
   max_total_attachment_bytes: 26214400
@@ -174,9 +187,9 @@ Mailgun HTTP webhook signing key for the receiving domain.
 | Example   | `0123456789abcdef0123456789abcdef`      |
 
 If this key is unset, the app skips Mailgun signature verification only for permissive indexing-only
-deployments. If sender allowlists, recipient allowlists, or sender authentication are enabled, the
-webhook fails closed until the signing key is configured. This prevents direct HTTP clients from
-forging Mailgun form fields such as `sender`, `recipient`, `dmarc`, `spf`, and `dkim`.
+deployments. If sender allowlists, recipient allowlists, sender authentication, or user mapping are
+enabled, the webhook fails closed until the signing key is configured. This prevents direct HTTP
+clients from forging Mailgun form fields such as `sender`, `recipient`, `dmarc`, `spf`, and `dkim`.
 
 ### allowed_sender_addresses
 
@@ -211,9 +224,7 @@ normal Gmail address unless Gmail is also the Mailgun recipient. Examples:
 Mailgun can route a catch-all or regex recipient pattern to the same `/webhook/mail` endpoint, while
 the app uses `allowed_recipient_addresses` to reject unexpected recipients. Per-user recipient
 aliases add friction because operators need to provision or communicate the aliases, but they give a
-clean way to distinguish which user intended the email intake path. This PR only validates and
-stores the recipient; later action-processing work can use the stored recipient to map the email to
-a user or confirmation channel.
+clean way to distinguish which user intended the email intake path.
 
 | Property  | Value                                     |
 | --------- | ----------------------------------------- |
@@ -223,6 +234,40 @@ a user or confirmation channel.
 | Example   | `["assistant+alice@mg.example.com"]`      |
 
 If this list is non-empty, the Mailgun signing key must also be set.
+
+### User Mapping
+
+`user_mappings` resolve accepted inbound email to an application `user_id`. The resolved value is
+stored on the received email as `target_user_id`, so later action-processing and confirmation flows
+can deterministically choose the right user context.
+
+Mappings can match by authorized forwarding sender, by Mailgun recipient alias, or by both:
+
+```yaml
+email_intake:
+  require_user_mapping: true
+  user_mappings:
+    - user_id: "alice"
+      sender_addresses: ["alice@gmail.com"]
+      recipient_addresses: ["assistant+alice@mg.example.com"]
+```
+
+When `require_user_mapping` is true, accepted email must map to exactly one configured user. If no
+mapping matches, the webhook returns `401`. If sender and recipient mappings point to different
+users, the webhook also returns `401` rather than guessing. If multiple mapping entries match the
+same `user_id`, that is accepted.
+
+For the least operational friction, map each user's stable forwarding address in `sender_addresses`.
+For stronger routing and clearer confirmation behavior, also give each user a Mailgun inbound alias
+and include it in `recipient_addresses`.
+
+| Option                 | Default | Recommended for actions |
+| ---------------------- | ------- | ----------------------- |
+| `require_user_mapping` | `false` | `true`                  |
+| `user_mappings`        | `[]`    | One entry per user      |
+
+If `require_user_mapping` is true or `user_mappings` is non-empty, the Mailgun signing key must also
+be set.
 
 ### Sender Authentication Policy
 

--- a/frontend/src/chat/__tests__/ErrorHandling.test.tsx
+++ b/frontend/src/chat/__tests__/ErrorHandling.test.tsx
@@ -42,9 +42,12 @@ describe.sequential('ErrorHandling', () => {
   }, 30000); // Increased timeout for parallel test runs
 
   it('handles API server errors', async () => {
+    let requestSeen = false;
+
     // Mock 500 server error
     server.use(
       http.post('/api/v1/chat/send_message_stream', () => {
+        requestSeen = true;
         return HttpResponse.json({ error: 'Internal Server Error' }, { status: 500 });
       })
     );
@@ -62,7 +65,10 @@ describe.sequential('ErrorHandling', () => {
     // Wait removed - using waitForReady option
 
     // App should handle server errors without crashing
-    expect(screen.getByText('Chat')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(requestSeen).toBe(true);
+      expect(screen.getByText('Chat')).toBeInTheDocument();
+    });
   }, 10000); // Add timeout
 
   it('handles malformed streaming responses', async () => {

--- a/frontend/src/components/assistant-ui/__tests__/attachment.test.tsx
+++ b/frontend/src/components/assistant-ui/__tests__/attachment.test.tsx
@@ -49,7 +49,7 @@ describe('AttachmentUI Loading States', () => {
   it('can upload a file through the hidden input', async () => {
     await renderChatApp({ waitForReady: true });
 
-    const fileInput = screen.getByTestId('file-input') as HTMLInputElement;
+    const fileInput = (await screen.findByTestId('file-input')) as HTMLInputElement;
     const testFile = new File(['test content'], 'test.png', { type: 'image/png' });
 
     // fireEvent is more stable than user.upload for this hidden input path.

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -556,6 +556,23 @@ class AttachmentConfig(BaseModel):
     )
 
 
+class EmailIntakeConfig(BaseModel):
+    """Security controls for inbound email webhooks."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mailgun_webhook_signing_key: str | None = None
+    mailgun_signature_max_age_seconds: int = Field(default=300, gt=0)
+    allowed_sender_addresses: list[str] = Field(default_factory=list)
+    allowed_recipient_addresses: list[str] = Field(default_factory=list)
+    require_authenticated_sender: bool = False
+    require_dmarc_pass: bool = True
+    allow_spf_or_dkim_fallback_when_dmarc_missing: bool = False
+    max_raw_request_bytes: int = Field(default=25 * 1024 * 1024, gt=0)
+    max_attachment_bytes: int = Field(default=10 * 1024 * 1024, gt=0)
+    max_total_attachment_bytes: int = Field(default=25 * 1024 * 1024, gt=0)
+
+
 class EventStorageConfig(BaseModel):
     """Event system storage configuration."""
 
@@ -915,6 +932,7 @@ class AppConfig(BaseSettings):
         default_factory=IndexingPipelineConfig
     )
     attachment_config: AttachmentConfig = Field(default_factory=AttachmentConfig)
+    email_intake: EmailIntakeConfig = Field(default_factory=EmailIntakeConfig)
     event_system: EventSystemConfig = Field(default_factory=EventSystemConfig)
     message_batching_config: MessageBatchingConfig = Field(
         default_factory=MessageBatchingConfig

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -18,10 +18,11 @@ from __future__ import annotations
 import contextlib
 import zoneinfo
 from contextvars import ContextVar
+from email.utils import parseaddr
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import cloudcoil.models.kubernetes.core.v1 as k8s_models  # noqa: TC002 - Pydantic needs at runtime
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
@@ -556,6 +557,45 @@ class AttachmentConfig(BaseModel):
     )
 
 
+class EmailIntakeUserMapping(BaseModel):
+    """Maps authorized inbound email addresses to an application user."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str = Field(min_length=1)
+    sender_addresses: set[str] = Field(default_factory=set)
+    recipient_addresses: set[str] = Field(default_factory=set)
+
+    @field_validator("sender_addresses", "recipient_addresses", mode="before")
+    @classmethod
+    def normalize_addresses(cls, values: object) -> set[str]:
+        if values is None:
+            return set()
+        if not isinstance(values, (list, set, tuple)):
+            msg = "Email intake mapping addresses must be a list or set"
+            raise TypeError(msg)
+
+        normalized_addresses: set[str] = set()
+        for value in values:
+            if not isinstance(value, str):
+                msg = "Email intake mapping addresses must be strings"
+                raise TypeError(msg)
+            _, parsed_address = parseaddr(value)
+            normalized = parsed_address.strip().lower()
+            if not normalized:
+                msg = f"Invalid email intake mapping address: {value!r}"
+                raise ValueError(msg)
+            normalized_addresses.add(normalized)
+        return normalized_addresses
+
+    @model_validator(mode="after")
+    def require_at_least_one_address(self) -> EmailIntakeUserMapping:
+        if not self.sender_addresses and not self.recipient_addresses:
+            msg = "Email intake user mappings require at least one sender or recipient address"
+            raise ValueError(msg)
+        return self
+
+
 class EmailIntakeConfig(BaseModel):
     """Security controls for inbound email webhooks."""
 
@@ -568,6 +608,8 @@ class EmailIntakeConfig(BaseModel):
     require_authenticated_sender: bool = False
     require_dmarc_pass: bool = True
     allow_spf_or_dkim_fallback_when_dmarc_missing: bool = False
+    require_user_mapping: bool = False
+    user_mappings: list[EmailIntakeUserMapping] = Field(default_factory=list)
     max_raw_request_bytes: int = Field(default=25 * 1024 * 1024, gt=0)
     max_attachment_bytes: int = Field(default=10 * 1024 * 1024, gt=0)
     max_total_attachment_bytes: int = Field(default=25 * 1024 * 1024, gt=0)

--- a/src/family_assistant/email_intake/__init__.py
+++ b/src/family_assistant/email_intake/__init__.py
@@ -1,0 +1,1 @@
+"""Inbound email intake helpers."""

--- a/src/family_assistant/email_intake/security.py
+++ b/src/family_assistant/email_intake/security.py
@@ -68,7 +68,7 @@ def verify_mailgun_signature(
 ) -> None:
     """Verify Mailgun's timestamp/token/signature tuple when a key is configured."""
     signing_key = config.mailgun_webhook_signing_key
-    if signing_key is None:
+    if not signing_key:
         if _requires_verified_mailgun(config):
             msg = (
                 "Mailgun signature verification must be configured before enabling "

--- a/src/family_assistant/email_intake/security.py
+++ b/src/family_assistant/email_intake/security.py
@@ -150,6 +150,35 @@ def verify_sender_authorization(
     raise EmailIntakeSecurityError(msg)
 
 
+def resolve_target_user_id(
+    form_data: FormData, config: EmailIntakeConfig
+) -> str | None:
+    """Resolve the intended application user for an accepted inbound email."""
+    sender = normalize_email_address(_string_field(form_data, "sender"))
+    recipient = normalize_email_address(_string_field(form_data, "recipient"))
+
+    matched_user_ids: set[str] = set()
+    for mapping in config.user_mappings:
+        if (sender is not None and sender in mapping.sender_addresses) or (
+            recipient is not None and recipient in mapping.recipient_addresses
+        ):
+            matched_user_ids.add(mapping.user_id)
+
+    if len(matched_user_ids) > 1:
+        sorted_user_ids = ", ".join(sorted(matched_user_ids))
+        msg = f"Inbound email maps to multiple users: {sorted_user_ids}"
+        raise EmailIntakeSecurityError(msg)
+
+    if matched_user_ids:
+        return next(iter(matched_user_ids))
+
+    if config.require_user_mapping:
+        msg = "Inbound email does not map to a configured user"
+        raise EmailIntakeSecurityError(msg)
+
+    return None
+
+
 def enforce_attachment_size_limits(
     *,
     attachment_name: str,
@@ -227,6 +256,8 @@ def _requires_verified_mailgun(config: EmailIntakeConfig) -> bool:
         config.allowed_sender_addresses
         or config.allowed_recipient_addresses
         or config.require_authenticated_sender
+        or config.require_user_mapping
+        or config.user_mappings
     )
 
 

--- a/src/family_assistant/email_intake/security.py
+++ b/src/family_assistant/email_intake/security.py
@@ -69,6 +69,12 @@ def verify_mailgun_signature(
     """Verify Mailgun's timestamp/token/signature tuple when a key is configured."""
     signing_key = config.mailgun_webhook_signing_key
     if signing_key is None:
+        if _requires_verified_mailgun(config):
+            msg = (
+                "Mailgun signature verification must be configured before enabling "
+                "sender, recipient, or authentication policy"
+            )
+            raise EmailIntakeSecurityError(msg)
         return
 
     if not timestamp or not token or not signature:
@@ -214,6 +220,14 @@ def _string_field(form_data: FormData, key: str) -> str | None:
         if stripped_value:
             return stripped_value
     return None
+
+
+def _requires_verified_mailgun(config: EmailIntakeConfig) -> bool:
+    return bool(
+        config.allowed_sender_addresses
+        or config.allowed_recipient_addresses
+        or config.require_authenticated_sender
+    )
 
 
 def _coalesce_auth_result(*values: str | None) -> str | None:

--- a/src/family_assistant/email_intake/security.py
+++ b/src/family_assistant/email_intake/security.py
@@ -1,0 +1,277 @@
+"""Security checks for inbound Mailgun email webhooks."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass
+from email.utils import parseaddr
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from starlette.datastructures import FormData
+
+    from family_assistant.config_models import EmailIntakeConfig
+
+
+class EmailIntakeSecurityError(ValueError):
+    """Raised when an inbound email webhook fails security checks."""
+
+
+class EmailIntakePayloadTooLargeError(EmailIntakeSecurityError):
+    """Raised when an inbound email webhook exceeds configured size limits."""
+
+
+@dataclass(frozen=True, slots=True)
+class SenderAuthentication:
+    """Normalized sender authentication results from Mailgun/form headers."""
+
+    dmarc: str | None
+    spf: str | None
+    dkim: str | None
+
+    @property
+    def dmarc_passed(self) -> bool:
+        """Return whether DMARC passed."""
+        return _is_pass(self.dmarc)
+
+    @property
+    def spf_passed(self) -> bool:
+        """Return whether SPF passed."""
+        return _is_pass(self.spf)
+
+    @property
+    def dkim_passed(self) -> bool:
+        """Return whether DKIM passed."""
+        return _is_pass(self.dkim)
+
+
+def enforce_raw_request_size(raw_body: bytes, config: EmailIntakeConfig) -> None:
+    """Reject oversized raw webhook payloads before form parsing."""
+    if len(raw_body) > config.max_raw_request_bytes:
+        msg = (
+            "Inbound email webhook payload exceeds configured limit "
+            f"({len(raw_body)} > {config.max_raw_request_bytes} bytes)"
+        )
+        raise EmailIntakePayloadTooLargeError(msg)
+
+
+def verify_mailgun_signature(
+    *,
+    timestamp: str | None,
+    token: str | None,
+    signature: str | None,
+    config: EmailIntakeConfig,
+    now: float | None = None,
+) -> None:
+    """Verify Mailgun's timestamp/token/signature tuple when a key is configured."""
+    signing_key = config.mailgun_webhook_signing_key
+    if signing_key is None:
+        return
+
+    if not timestamp or not token or not signature:
+        msg = "Missing Mailgun signature fields"
+        raise EmailIntakeSecurityError(msg)
+
+    try:
+        timestamp_seconds = int(timestamp)
+    except ValueError as exc:
+        msg = "Invalid Mailgun signature timestamp"
+        raise EmailIntakeSecurityError(msg) from exc
+
+    current_time = time.time() if now is None else now
+    timestamp_age = abs(current_time - timestamp_seconds)
+    if timestamp_age > config.mailgun_signature_max_age_seconds:
+        msg = "Mailgun signature timestamp is outside the allowed replay window"
+        raise EmailIntakeSecurityError(msg)
+
+    digest = hmac.new(
+        key=signing_key.encode("utf-8"),
+        msg=f"{timestamp}{token}".encode(),
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(digest, signature):
+        msg = "Invalid Mailgun signature"
+        raise EmailIntakeSecurityError(msg)
+
+
+def verify_sender_authorization(
+    form_data: FormData,
+    config: EmailIntakeConfig,
+) -> None:
+    """Verify sender/recipient allowlists and sender authentication policy."""
+    sender = normalize_email_address(_string_field(form_data, "sender"))
+    if config.allowed_sender_addresses:
+        allowed_senders = {
+            normalize_email_address(address)
+            for address in config.allowed_sender_addresses
+        }
+        if sender is None or sender not in allowed_senders:
+            msg = f"Sender {sender or '<missing>'} is not authorized"
+            raise EmailIntakeSecurityError(msg)
+
+    recipient = normalize_email_address(_string_field(form_data, "recipient"))
+    if config.allowed_recipient_addresses:
+        allowed_recipients = {
+            normalize_email_address(address)
+            for address in config.allowed_recipient_addresses
+        }
+        if recipient is None or recipient not in allowed_recipients:
+            msg = f"Recipient {recipient or '<missing>'} is not authorized"
+            raise EmailIntakeSecurityError(msg)
+
+    if not config.require_authenticated_sender:
+        return
+
+    authentication = extract_sender_authentication(form_data)
+    if authentication.dmarc_passed:
+        return
+
+    if authentication.dmarc is not None or config.require_dmarc_pass:
+        msg = "Sender authentication failed DMARC policy"
+        raise EmailIntakeSecurityError(msg)
+
+    if (
+        config.allow_spf_or_dkim_fallback_when_dmarc_missing
+        and authentication.dmarc is None
+        and (authentication.spf_passed or authentication.dkim_passed)
+    ):
+        return
+
+    msg = "Sender authentication did not meet the configured policy"
+    raise EmailIntakeSecurityError(msg)
+
+
+def enforce_attachment_size_limits(
+    *,
+    attachment_name: str,
+    attachment_size: int,
+    total_attachment_size: int,
+    config: EmailIntakeConfig,
+) -> None:
+    """Reject attachments that exceed per-file or total configured limits."""
+    if attachment_size > config.max_attachment_bytes:
+        msg = (
+            f"Attachment {attachment_name!r} exceeds configured limit "
+            f"({attachment_size} > {config.max_attachment_bytes} bytes)"
+        )
+        raise EmailIntakePayloadTooLargeError(msg)
+
+    if total_attachment_size > config.max_total_attachment_bytes:
+        msg = (
+            "Inbound email attachments exceed configured total limit "
+            f"({total_attachment_size} > {config.max_total_attachment_bytes} bytes)"
+        )
+        raise EmailIntakePayloadTooLargeError(msg)
+
+
+def normalize_email_address(raw_address: str | None) -> str | None:
+    """Extract and normalize an email address from a header or form field."""
+    if not raw_address:
+        return None
+    _, parsed_address = parseaddr(raw_address)
+    normalized = parsed_address.strip().lower()
+    return normalized or None
+
+
+def extract_sender_authentication(form_data: FormData) -> SenderAuthentication:
+    """Extract DMARC/SPF/DKIM results from Mailgun fields or Authentication-Results."""
+    authentication_results = _string_field(form_data, "Authentication-Results")
+    if authentication_results is None:
+        authentication_results = _string_field(form_data, "authentication-results")
+    if authentication_results is None:
+        authentication_results = _message_header_value(
+            form_data, "Authentication-Results"
+        )
+
+    return SenderAuthentication(
+        dmarc=_coalesce_auth_result(
+            _string_field(form_data, "dmarc"),
+            _string_field(form_data, "DMARC"),
+            _string_field(form_data, "Dmarc"),
+            _extract_authentication_results_value(authentication_results, "dmarc"),
+        ),
+        spf=_coalesce_auth_result(
+            _string_field(form_data, "spf"),
+            _string_field(form_data, "SPF"),
+            _extract_authentication_results_value(authentication_results, "spf"),
+        ),
+        dkim=_coalesce_auth_result(
+            _string_field(form_data, "dkim"),
+            _string_field(form_data, "Dkim"),
+            _string_field(form_data, "DKIM"),
+            _extract_authentication_results_value(authentication_results, "dkim"),
+        ),
+    )
+
+
+def _string_field(form_data: FormData, key: str) -> str | None:
+    value = form_data.get(key)
+    if isinstance(value, str):
+        stripped_value = value.strip()
+        if stripped_value:
+            return stripped_value
+    return None
+
+
+def _coalesce_auth_result(*values: str | None) -> str | None:
+    for value in values:
+        if value is not None:
+            return value.lower()
+    return None
+
+
+def _extract_authentication_results_value(
+    authentication_results: str | None,
+    mechanism: str,
+) -> str | None:
+    if authentication_results is None:
+        return None
+
+    mechanism_prefix = f"{mechanism.lower()}="
+    for raw_token in authentication_results.replace(";", " ").split():
+        token = raw_token.strip().lower()
+        if token.startswith(mechanism_prefix):
+            return token.removeprefix(mechanism_prefix)
+    return None
+
+
+def _message_header_value(form_data: FormData, header_name: str) -> str | None:
+    headers_raw = _string_field(form_data, "message-headers")
+    if headers_raw is None:
+        return None
+
+    try:
+        parsed_headers = json.loads(headers_raw)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(parsed_headers, list):
+        return None
+
+    normalized_header_name = header_name.lower()
+    for header in parsed_headers:
+        if not isinstance(header, list) or len(header) < 2:
+            continue
+        raw_name, raw_value = header[0], header[1]
+        if not isinstance(raw_name, str):
+            continue
+        if raw_name.lower() == normalized_header_name and isinstance(raw_value, str):
+            return raw_value
+    return None
+
+
+def _is_pass(value: str | None) -> bool:
+    return value is not None and value.lower() in {"pass", "passed", "true", "yes"}
+
+
+def get_security_fields(
+    form_data: FormData,
+) -> tuple[str | None, str | None, str | None]:
+    """Return Mailgun timestamp/token/signature fields from form data."""
+    timestamp = _string_field(form_data, "timestamp")
+    token = _string_field(form_data, "token")
+    signature = _string_field(form_data, "signature")
+    return timestamp, token, signature

--- a/src/family_assistant/storage/email.py
+++ b/src/family_assistant/storage/email.py
@@ -50,6 +50,7 @@ class ParsedEmailData(BaseModel):
     attachment_info: list[AttachmentData] | None = None  # Processed by webhook handler
     mailgun_timestamp: str | None = Field(default=None, alias="timestamp")
     mailgun_token: str | None = Field(default=None, alias="token")
+    target_user_id: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -103,6 +104,9 @@ received_emails_table = sa.Table(
     # Add other potentially useful Mailgun fields if needed
     sa.Column("mailgun_timestamp", sa.Text, nullable=True),  # Mailgun 'timestamp' field
     sa.Column("mailgun_token", sa.Text, nullable=True),  # Mailgun 'token' field
+    sa.Column(
+        "target_user_id", sa.Text, nullable=True, index=True
+    ),  # Resolved application user for action-capable intake
     # --- Indexing Task Tracking ---
     sa.Column(
         "indexing_task_id", sa.String, nullable=True, index=True, unique=True

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -21,6 +21,7 @@ from family_assistant.email_intake.security import (
     enforce_attachment_size_limits,
     enforce_raw_request_size,
     get_security_fields,
+    resolve_target_user_id,
     verify_mailgun_signature,
     verify_sender_authorization,
 )
@@ -126,6 +127,7 @@ async def handle_mail_webhook(
             config=email_intake_config,
         )
         verify_sender_authorization(form_data, email_intake_config)
+        target_user_id = resolve_target_user_id(form_data, email_intake_config)
         await _save_raw_mail_webhook(
             raw_body_content=raw_body_content,
             mailbox_raw_dir=mailbox_raw_dir_to_use,
@@ -252,6 +254,7 @@ async def handle_mail_webhook(
             attachment_info=(
                 processed_attachments if processed_attachments else None
             ),  # Override
+            target_user_id=target_user_id,
         )
 
         # Pass the Pydantic model instance to the storage function

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -14,6 +14,16 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel, ValidationError
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
+from family_assistant.config_models import EmailIntakeConfig
+from family_assistant.email_intake.security import (
+    EmailIntakePayloadTooLargeError,
+    EmailIntakeSecurityError,
+    enforce_attachment_size_limits,
+    enforce_raw_request_size,
+    get_security_fields,
+    verify_mailgun_signature,
+    verify_sender_authorization,
+)
 from family_assistant.storage.context import DatabaseContext
 from family_assistant.storage.email import AttachmentData, ParsedEmailData
 from family_assistant.web.dependencies import get_db
@@ -32,6 +42,32 @@ DEFAULT_ATTACHMENT_STORAGE_PATH = "/mnt/data/mailbox/attachments_fallback"
 DEFAULT_MAILBOX_RAW_DIR_FALLBACK = "/mnt/data/mailbox/raw_requests_fallback"
 
 
+async def _save_raw_mail_webhook(
+    *,
+    raw_body_content: bytes,
+    mailbox_raw_dir: str,
+    content_type_header: str,
+) -> None:
+    """Save an accepted raw Mailgun webhook request for debugging/replay."""
+    try:
+        os.makedirs(mailbox_raw_dir, exist_ok=True)
+        now_dt = datetime.now(UTC)
+        timestamp_str = now_dt.strftime("%Y%m%d_%H%M%S_%f")
+        safe_content_type = (
+            re.sub(r'[<>:"/\\|?*]', "_", content_type_header).split(";")[0].strip()
+        )
+        raw_filename = f"{timestamp_str}_{safe_content_type}.raw"
+        raw_filepath = os.path.join(mailbox_raw_dir, raw_filename)
+
+        async with aiofiles.open(raw_filepath, "wb") as f:
+            await f.write(raw_body_content)
+        logger.info(
+            f"Saved raw webhook request body ({len(raw_body_content)} bytes) to: {raw_filepath}"
+        )
+    except Exception as e:
+        logger.error(f"Failed to save raw webhook request body: {e}", exc_info=True)
+
+
 @webhooks_router.post("/webhook/mail")
 async def handle_mail_webhook(
     request: Request,
@@ -42,17 +78,19 @@ async def handle_mail_webhook(
     parses it, saves attachments, and passes structured data to the storage layer.
     """
     logger.info("Received POST request on /webhook/mail")
-    # --- Save raw request body for debugging/replay ---
-    # It's good to read the body once if needed for both raw saving and form parsing.
-    # However, request.form() consumes the body. If raw saving is critical,
-    # read body first, then pass to a method that can parse from bytes if FastAPI allows,
-    # or accept that form() is the primary way. For now, keeping existing raw save logic.
     raw_body_content = await request.body()
 
     # Determine directory for saving raw requests from app config or fallback
 
     mailbox_raw_dir_to_use: str = DEFAULT_MAILBOX_RAW_DIR_FALLBACK
     config: AppConfig | None = getattr(request.app.state, "config", None)
+    email_intake_config = config.email_intake if config else EmailIntakeConfig()
+    try:
+        enforce_raw_request_size(raw_body_content, email_intake_config)
+    except EmailIntakePayloadTooLargeError as exc:
+        logger.warning("Rejecting oversized inbound email webhook: %s", exc)
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
+
     if config and config.mailbox_raw_dir:
         mailbox_raw_dir_to_use = config.mailbox_raw_dir
     if mailbox_raw_dir_to_use == DEFAULT_MAILBOX_RAW_DIR_FALLBACK:
@@ -61,30 +99,24 @@ async def handle_mail_webhook(
         )
 
     try:
-        os.makedirs(mailbox_raw_dir_to_use, exist_ok=True)
-        now_dt = datetime.now(UTC)
-        timestamp_str = now_dt.strftime("%Y%m%d_%H%M%S_%f")
-        content_type_header = request.headers.get(
-            "content-type", "unknown_content_type"
-        )
-        safe_content_type = (
-            re.sub(r'[<>:"/\\|?*]', "_", content_type_header).split(";")[0].strip()
-        )
-        raw_filename = f"{timestamp_str}_{safe_content_type}.raw"
-        raw_filepath = os.path.join(mailbox_raw_dir_to_use, raw_filename)
-
-        async with aiofiles.open(raw_filepath, "wb") as f:
-            await f.write(raw_body_content)
-        logger.info(
-            f"Saved raw webhook request body ({len(raw_body_content)} bytes) to: {raw_filepath}"
-        )
-    except Exception as e:
-        logger.error(f"Failed to save raw webhook request body: {e}", exc_info=True)
-    # --- End raw request saving ---
-
-    try:
         # FastAPI's request.form() will parse multipart/form-data
         form_data = await request.form()
+
+        timestamp, token, signature = get_security_fields(form_data)
+        verify_mailgun_signature(
+            timestamp=timestamp,
+            token=token,
+            signature=signature,
+            config=email_intake_config,
+        )
+        verify_sender_authorization(form_data, email_intake_config)
+        await _save_raw_mail_webhook(
+            raw_body_content=raw_body_content,
+            mailbox_raw_dir=mailbox_raw_dir_to_use,
+            content_type_header=request.headers.get(
+                "content-type", "unknown_content_type"
+            ),
+        )
 
         # --- Parse Email Date ---
         email_date_parsed: datetime | None = None
@@ -115,6 +147,7 @@ async def handle_mail_webhook(
             attachment_count = int(attachment_count_str)
             # Generate a single UUID for this email's attachments directory
             email_attachment_batch_id = str(uuid.uuid4())
+            total_attachment_size = 0
 
             # Get attachment storage path from app config
             attachment_storage_path = DEFAULT_ATTACHMENT_STORAGE_PATH
@@ -141,16 +174,17 @@ async def handle_mail_webhook(
 
                         # Save the uploaded file
                         await form_item.seek(0)  # Ensure pointer is at the start
-                        async with aiofiles.open(final_file_path, "wb") as f_out:
-                            content = await form_item.read()
-                            await f_out.write(content)
-
-                        # Get size after reading
-                        size = (
-                            form_item.size
-                            if form_item.size is not None
-                            else len(content)
+                        content = await form_item.read()
+                        size = len(content)
+                        total_attachment_size += size
+                        enforce_attachment_size_limits(
+                            attachment_name=safe_filename,
+                            attachment_size=size,
+                            total_attachment_size=total_attachment_size,
+                            config=email_intake_config,
                         )
+                        async with aiofiles.open(final_file_path, "wb") as f_out:
+                            await f_out.write(content)
 
                         processed_attachments.append(
                             AttachmentData(
@@ -164,6 +198,8 @@ async def handle_mail_webhook(
                         logger.info(
                             f"Saved attachment '{safe_filename}' to {final_file_path}"
                         )
+                    except EmailIntakePayloadTooLargeError:
+                        raise
                     except Exception as e:
                         logger.error(
                             f"Failed to save attachment {form_item.filename}: {e}",
@@ -207,6 +243,12 @@ async def handle_mail_webhook(
 
         return Response(status_code=200, content="Email received and processed.")
 
+    except EmailIntakePayloadTooLargeError as exc:
+        logger.warning("Rejecting oversized inbound email webhook: %s", exc)
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
+    except EmailIntakeSecurityError as exc:
+        logger.warning("Rejecting unauthorized inbound email webhook: %s", exc)
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
     except ValidationError as ve:
         logger.error(
             f"Pydantic validation error processing mail webhook: {ve.errors()}",

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -78,13 +78,29 @@ async def handle_mail_webhook(
     parses it, saves attachments, and passes structured data to the storage layer.
     """
     logger.info("Received POST request on /webhook/mail")
-    raw_body_content = await request.body()
-
-    # Determine directory for saving raw requests from app config or fallback
 
     mailbox_raw_dir_to_use: str = DEFAULT_MAILBOX_RAW_DIR_FALLBACK
     config: AppConfig | None = getattr(request.app.state, "config", None)
     email_intake_config = config.email_intake if config else EmailIntakeConfig()
+
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            content_length_bytes = int(content_length)
+        except ValueError:
+            logger.warning("Ignoring invalid Content-Length header: %s", content_length)
+        else:
+            if content_length_bytes > email_intake_config.max_raw_request_bytes:
+                msg = (
+                    "Inbound email webhook payload exceeds configured limit "
+                    f"({content_length_bytes} > "
+                    f"{email_intake_config.max_raw_request_bytes} bytes)"
+                )
+                logger.warning("Rejecting oversized inbound email webhook: %s", msg)
+                raise HTTPException(status_code=413, detail=msg)
+
+    raw_body_content = await request.body()
+
     try:
         enforce_raw_request_size(raw_body_content, email_intake_config)
     except EmailIntakePayloadTooLargeError as exc:

--- a/tests/functional/web/api/test_mail_webhook_security.py
+++ b/tests/functional/web/api/test_mail_webhook_security.py
@@ -11,7 +11,11 @@ from typing import TYPE_CHECKING
 import pytest
 from sqlalchemy import select
 
-from family_assistant.config_models import AppConfig, EmailIntakeConfig
+from family_assistant.config_models import (
+    AppConfig,
+    EmailIntakeConfig,
+    EmailIntakeUserMapping,
+)
 from family_assistant.storage.context import DatabaseContext
 from family_assistant.storage.email import received_emails_table
 from family_assistant.web.app_creator import app as fastapi_app
@@ -101,6 +105,16 @@ async def _email_exists(engine: AsyncEngine, message_id: str) -> bool:
     return row is not None
 
 
+async def _email_target_user_id(engine: AsyncEngine, message_id: str) -> str | None:
+    async with DatabaseContext(engine=engine) as db_context:
+        row = await db_context.fetch_one(
+            select(received_emails_table.c.target_user_id).where(
+                received_emails_table.c.message_id_header == message_id
+            )
+        )
+    return row["target_user_id"] if row else None
+
+
 def _raw_mail_files(tmp_path: Path) -> list[Path]:
     raw_dir = tmp_path / "raw"
     if not raw_dir.exists():
@@ -124,6 +138,13 @@ async def test_mail_webhook_accepts_signed_authorized_authenticated_sender(
             allowed_sender_addresses=["buyer@example.com"],
             allowed_recipient_addresses=["orders@example.net"],
             require_authenticated_sender=True,
+            require_user_mapping=True,
+            user_mappings=[
+                EmailIntakeUserMapping(
+                    user_id="alice",
+                    sender_addresses={"buyer@example.com"},
+                )
+            ],
         ),
     )
     form = _mailgun_form()
@@ -132,6 +153,7 @@ async def test_mail_webhook_accepts_signed_authorized_authenticated_sender(
 
     assert response.status_code == 200, response.text
     assert await _email_exists(db_engine, form["Message-Id"])
+    assert await _email_target_user_id(db_engine, form["Message-Id"]) == "alice"
     assert _raw_mail_files(tmp_path)
 
 
@@ -180,6 +202,36 @@ async def test_mail_webhook_rejects_policy_without_mailgun_signature_configurati
 
 
 @pytest.mark.asyncio
+async def test_mail_webhook_rejects_user_mapping_without_mailgun_signature_configuration(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            require_user_mapping=True,
+            user_mappings=[
+                EmailIntakeUserMapping(
+                    user_id="alice",
+                    sender_addresses={"buyer@example.com"},
+                )
+            ],
+        ),
+    )
+    form = _mailgun_form(signing_key=None)
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 401
+    assert "Mailgun signature verification must be configured" in response.text
+    assert not await _email_exists(db_engine, form["Message-Id"])
+    assert _raw_mail_files(tmp_path) == []
+
+
+@pytest.mark.asyncio
 async def test_mail_webhook_rejects_unlisted_sender(
     api_client: httpx.AsyncClient,
     db_engine: AsyncEngine,
@@ -202,6 +254,102 @@ async def test_mail_webhook_rejects_unlisted_sender(
     assert "not authorized" in response.text
     assert not await _email_exists(db_engine, form["Message-Id"])
     assert _raw_mail_files(tmp_path) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres
+async def test_mail_webhook_maps_recipient_alias_to_target_user(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            mailgun_webhook_signing_key="mailgun-test-key",
+            allowed_sender_addresses=["buyer@example.com"],
+            allowed_recipient_addresses=["assistant+alice@mg.example.com"],
+            require_user_mapping=True,
+            user_mappings=[
+                EmailIntakeUserMapping(
+                    user_id="alice",
+                    recipient_addresses={"assistant+alice@mg.example.com"},
+                )
+            ],
+        ),
+    )
+    form = _mailgun_form(recipient="assistant+alice@mg.example.com")
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 200, response.text
+    assert await _email_target_user_id(db_engine, form["Message-Id"]) == "alice"
+
+
+@pytest.mark.asyncio
+async def test_mail_webhook_rejects_unmapped_user_when_mapping_required(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            mailgun_webhook_signing_key="mailgun-test-key",
+            require_user_mapping=True,
+            user_mappings=[
+                EmailIntakeUserMapping(
+                    user_id="alice",
+                    sender_addresses={"alice@example.com"},
+                )
+            ],
+        ),
+    )
+    form = _mailgun_form(sender="buyer@example.com")
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 401
+    assert "does not map to a configured user" in response.text
+    assert not await _email_exists(db_engine, form["Message-Id"])
+
+
+@pytest.mark.asyncio
+async def test_mail_webhook_rejects_ambiguous_user_mapping(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            mailgun_webhook_signing_key="mailgun-test-key",
+            require_user_mapping=True,
+            user_mappings=[
+                EmailIntakeUserMapping(
+                    user_id="alice",
+                    sender_addresses={"buyer@example.com"},
+                ),
+                EmailIntakeUserMapping(
+                    user_id="bob",
+                    recipient_addresses={"assistant+bob@mg.example.com"},
+                ),
+            ],
+        ),
+    )
+    form = _mailgun_form(recipient="assistant+bob@mg.example.com")
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 401
+    assert "maps to multiple users" in response.text
+    assert not await _email_exists(db_engine, form["Message-Id"])
 
 
 @pytest.mark.asyncio

--- a/tests/functional/web/api/test_mail_webhook_security.py
+++ b/tests/functional/web/api/test_mail_webhook_security.py
@@ -158,6 +158,28 @@ async def test_mail_webhook_rejects_invalid_mailgun_signature(
 
 
 @pytest.mark.asyncio
+async def test_mail_webhook_rejects_policy_without_mailgun_signature_configuration(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(allowed_sender_addresses=["buyer@example.com"]),
+    )
+    form = _mailgun_form(signing_key=None)
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 401
+    assert "Mailgun signature verification must be configured" in response.text
+    assert not await _email_exists(db_engine, form["Message-Id"])
+    assert _raw_mail_files(tmp_path) == []
+
+
+@pytest.mark.asyncio
 async def test_mail_webhook_rejects_unlisted_sender(
     api_client: httpx.AsyncClient,
     db_engine: AsyncEngine,
@@ -168,10 +190,11 @@ async def test_mail_webhook_rejects_unlisted_sender(
         monkeypatch,
         tmp_path,
         EmailIntakeConfig(
+            mailgun_webhook_signing_key="mailgun-test-key",
             allowed_sender_addresses=["authorized@example.com"],
         ),
     )
-    form = _mailgun_form(sender="attacker@example.com", signing_key=None)
+    form = _mailgun_form(sender="attacker@example.com")
 
     response = await api_client.post("/webhook/mail", data=form)
 
@@ -191,9 +214,12 @@ async def test_mail_webhook_rejects_dmarc_failure_even_when_spf_passes(
     _configure_email_intake(
         monkeypatch,
         tmp_path,
-        EmailIntakeConfig(require_authenticated_sender=True),
+        EmailIntakeConfig(
+            mailgun_webhook_signing_key="mailgun-test-key",
+            require_authenticated_sender=True,
+        ),
     )
-    form = _mailgun_form(dmarc="fail", spf="pass", dkim="fail", signing_key=None)
+    form = _mailgun_form(dmarc="fail", spf="pass", dkim="fail")
 
     response = await api_client.post("/webhook/mail", data=form)
 
@@ -213,9 +239,12 @@ async def test_mail_webhook_accepts_authentication_results_from_message_headers(
     _configure_email_intake(
         monkeypatch,
         tmp_path,
-        EmailIntakeConfig(require_authenticated_sender=True),
+        EmailIntakeConfig(
+            mailgun_webhook_signing_key="mailgun-test-key",
+            require_authenticated_sender=True,
+        ),
     )
-    form = _mailgun_form(dmarc=None, spf=None, dkim=None, signing_key=None)
+    form = _mailgun_form(dmarc=None, spf=None, dkim=None)
     form["message-headers"] = (
         '[["Authentication-Results", "mx.example.net; dmarc=pass spf=pass dkim=pass"]]'
     )
@@ -238,12 +267,13 @@ async def test_mail_webhook_accepts_explicit_spf_fallback_when_dmarc_missing(
         monkeypatch,
         tmp_path,
         EmailIntakeConfig(
+            mailgun_webhook_signing_key="mailgun-test-key",
             require_authenticated_sender=True,
             require_dmarc_pass=False,
             allow_spf_or_dkim_fallback_when_dmarc_missing=True,
         ),
     )
-    form = _mailgun_form(dmarc=None, spf="pass", dkim="fail", signing_key=None)
+    form = _mailgun_form(dmarc=None, spf="pass", dkim="fail")
 
     response = await api_client.post("/webhook/mail", data=form)
 
@@ -270,6 +300,28 @@ async def test_mail_webhook_rejects_oversized_raw_payload(
 
     assert response.status_code == 413
     assert not await _email_exists(db_engine, form["Message-Id"])
+
+
+@pytest.mark.asyncio
+async def test_mail_webhook_rejects_oversized_content_length_before_form_parsing(
+    api_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(max_raw_request_bytes=8),
+    )
+
+    response = await api_client.post(
+        "/webhook/mail",
+        content=b"this is larger than eight bytes",
+        headers={"content-type": "application/octet-stream"},
+    )
+
+    assert response.status_code == 413
+    assert _raw_mail_files(tmp_path) == []
 
 
 @pytest.mark.asyncio

--- a/tests/functional/web/api/test_mail_webhook_security.py
+++ b/tests/functional/web/api/test_mail_webhook_security.py
@@ -1,0 +1,303 @@
+"""Functional tests for inbound Mailgun email webhook security checks."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import select
+
+from family_assistant.config_models import AppConfig, EmailIntakeConfig
+from family_assistant.storage.context import DatabaseContext
+from family_assistant.storage.email import received_emails_table
+from family_assistant.web.app_creator import app as fastapi_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import httpx
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+def _signature(timestamp: str, token: str, signing_key: str) -> str:
+    return hmac.new(
+        key=signing_key.encode("utf-8"),
+        msg=f"{timestamp}{token}".encode(),
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+
+
+def _mailgun_form(
+    *,
+    sender: str = "buyer@example.com",
+    recipient: str = "orders@example.net",
+    dmarc: str | None = "pass",
+    spf: str | None = "pass",
+    dkim: str | None = "pass",
+    signing_key: str | None = "mailgun-test-key",
+    signature: str | None = None,
+    message_id: str | None = None,
+) -> dict[str, str]:
+    timestamp = str(int(time.time()))
+    token = f"token-{uuid.uuid4().hex}"
+    resolved_signature = (
+        signature
+        if signature is not None
+        else (_signature(timestamp, token, signing_key) if signing_key else "")
+    )
+
+    form = {
+        "subject": "Order confirmation",
+        "stripped-text": "Your order ABC-123 is confirmed for pickup tomorrow.",
+        "sender": sender,
+        "recipient": recipient,
+        "Message-Id": message_id or f"<mailgun-security-{uuid.uuid4()}@example.com>",
+        "From": f"Buyer <{sender}>",
+        "To": f"Orders <{recipient}>",
+        "timestamp": timestamp,
+        "token": token,
+        "signature": resolved_signature,
+        "message-headers": (
+            f'[["From", "Buyer <{sender}>"], ["To", "Orders <{recipient}>"]]'
+        ),
+    }
+    if dmarc is not None:
+        form["dmarc"] = dmarc
+    if spf is not None:
+        form["SPF"] = spf
+    if dkim is not None:
+        form["Dkim"] = dkim
+    return form
+
+
+def _configure_email_intake(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    email_intake: EmailIntakeConfig,
+) -> None:
+    monkeypatch.setattr(
+        fastapi_app.state,
+        "config",
+        AppConfig(
+            attachment_storage_path=str(tmp_path / "attachments"),
+            mailbox_raw_dir=str(tmp_path / "raw"),
+            email_intake=email_intake,
+        ),
+        raising=False,
+    )
+
+
+async def _email_exists(engine: AsyncEngine, message_id: str) -> bool:
+    async with DatabaseContext(engine=engine) as db_context:
+        row = await db_context.fetch_one(
+            select(received_emails_table.c.id).where(
+                received_emails_table.c.message_id_header == message_id
+            )
+        )
+    return row is not None
+
+
+def _raw_mail_files(tmp_path: Path) -> list[Path]:
+    raw_dir = tmp_path / "raw"
+    if not raw_dir.exists():
+        return []
+    return list(raw_dir.iterdir())
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres
+async def test_mail_webhook_accepts_signed_authorized_authenticated_sender(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            mailgun_webhook_signing_key="mailgun-test-key",
+            allowed_sender_addresses=["buyer@example.com"],
+            allowed_recipient_addresses=["orders@example.net"],
+            require_authenticated_sender=True,
+        ),
+    )
+    form = _mailgun_form()
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 200, response.text
+    assert await _email_exists(db_engine, form["Message-Id"])
+    assert _raw_mail_files(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_mail_webhook_rejects_invalid_mailgun_signature(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(mailgun_webhook_signing_key="mailgun-test-key"),
+    )
+    form = _mailgun_form(signature="not-a-valid-signature")
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 401
+    assert "Invalid Mailgun signature" in response.text
+    assert not await _email_exists(db_engine, form["Message-Id"])
+    assert _raw_mail_files(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_mail_webhook_rejects_unlisted_sender(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            allowed_sender_addresses=["authorized@example.com"],
+        ),
+    )
+    form = _mailgun_form(sender="attacker@example.com", signing_key=None)
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 401
+    assert "not authorized" in response.text
+    assert not await _email_exists(db_engine, form["Message-Id"])
+    assert _raw_mail_files(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_mail_webhook_rejects_dmarc_failure_even_when_spf_passes(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(require_authenticated_sender=True),
+    )
+    form = _mailgun_form(dmarc="fail", spf="pass", dkim="fail", signing_key=None)
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 401
+    assert "DMARC" in response.text
+    assert not await _email_exists(db_engine, form["Message-Id"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres
+async def test_mail_webhook_accepts_authentication_results_from_message_headers(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(require_authenticated_sender=True),
+    )
+    form = _mailgun_form(dmarc=None, spf=None, dkim=None, signing_key=None)
+    form["message-headers"] = (
+        '[["Authentication-Results", "mx.example.net; dmarc=pass spf=pass dkim=pass"]]'
+    )
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 200, response.text
+    assert await _email_exists(db_engine, form["Message-Id"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres
+async def test_mail_webhook_accepts_explicit_spf_fallback_when_dmarc_missing(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            require_authenticated_sender=True,
+            require_dmarc_pass=False,
+            allow_spf_or_dkim_fallback_when_dmarc_missing=True,
+        ),
+    )
+    form = _mailgun_form(dmarc=None, spf="pass", dkim="fail", signing_key=None)
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 200, response.text
+    assert await _email_exists(db_engine, form["Message-Id"])
+
+
+@pytest.mark.asyncio
+async def test_mail_webhook_rejects_oversized_raw_payload(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(max_raw_request_bytes=512),
+    )
+    form = _mailgun_form(signing_key=None)
+    form["stripped-text"] = "x" * 2048
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 413
+    assert not await _email_exists(db_engine, form["Message-Id"])
+
+
+@pytest.mark.asyncio
+async def test_mail_webhook_rejects_oversized_attachment(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(max_attachment_bytes=3),
+    )
+    form = _mailgun_form(signing_key=None)
+    form["attachment-count"] = "1"
+
+    response = await api_client.post(
+        "/webhook/mail",
+        data=form,
+        files={
+            "attachment-1": (
+                "ticket.pdf",
+                b"larger than three bytes",
+                "application/pdf",
+            )
+        },
+    )
+
+    assert response.status_code == 413
+    assert not await _email_exists(db_engine, form["Message-Id"])


### PR DESCRIPTION
## Summary

This is the first implementation slice for secure inbound email processing. It hardens the existing Mailgun webhook boundary before any future assistant-driven email workflow is added.

Changes:
- Add `email_intake` configuration for Mailgun signature validation, sender/recipient allowlists, SPF/DKIM/DMARC policy, and request/attachment size limits.
- Verify Mailgun webhook signatures with timestamp replay protection before storing accepted raw payloads or email content.
- Fail closed when sender/recipient/authentication policy is enabled without a configured Mailgun signing key.
- Require authorized sender and recipient addresses, with sender authentication derived from Mailgun fields or `Authentication-Results` in `message-headers`.
- Fail closed on oversized raw requests and attachments, including a `Content-Length` fast-fail before buffering the body.
- Move inbound email security logic into `family_assistant.email_intake.security`.
- Add functional web tests covering accepted mail, signature failures, missing signing-key policy failures, sender allowlist failures, DMARC/SPF/DKIM policy behavior, size limits, and raw dump ordering.
- Document operator configuration for Mailgun signing keys, sender/recipient allowlists, per-user inbound aliases, sender auth policy, and size limits.
- Stabilize two frontend tests that were exposed by full-suite verification.

## Verification

- `/review` via `uv run scripts/review-changes.py --json --command "pre-amend review for frontend error-handling test stability fix"` passed.
- `/review` via `uv run scripts/review-changes.py --commit --json --command "pre-push review for inbound Mailgun email intake security"` passed.
- `/review` via `uv run scripts/review-changes.py --json --command "pre-commit review for PR 769 security feedback fixes"` passed.
- `/review` via `uv run scripts/review-changes.py --json --command "pre-commit review for email intake operator configuration docs"` passed.
- `/review` via `uv run scripts/review-changes.py --commit --json --command "pre-push review for email intake operator docs"` passed.
- `scripts/format-and-lint.sh src/family_assistant/config_models.py src/family_assistant/email_intake/security.py src/family_assistant/web/routers/webhooks.py tests/functional/web/api/test_mail_webhook_security.py`
- `scripts/format-and-lint.sh src/family_assistant/email_intake/security.py src/family_assistant/web/routers/webhooks.py tests/functional/web/api/test_mail_webhook_security.py`
- `scripts/format-and-lint.sh defaults.yaml docs/operations/CONFIGURATION_REFERENCE.md`
- `.venv/bin/pytest tests/functional/web/api/test_mail_webhook_security.py -q --db all` -> `17 passed`
- `.venv/bin/pytest tests/functional/indexing/test_email_basic.py tests/functional/tools/test_defaults_tool_policy_parity.py -q --db postgres` -> `3 passed`
- `npm test --prefix frontend -- src/components/assistant-ui/__tests__/attachment.test.tsx --run`
- `npm test --prefix frontend -- src/chat/__tests__/ErrorHandling.test.tsx --run`
- `npm run check --prefix frontend`
- `.venv/bin/poe test` -> `2969 passed, 3 skipped, 54 warnings` plus frontend tests, linting, and type checking all passed.