### PR TITLE
Add durable confirmation request core

### DIFF
--- a/alembic/versions/2026_04_19-add_confirmation_requests_table.py
+++ b/alembic/versions/2026_04_19-add_confirmation_requests_table.py
@@ -48,6 +48,10 @@ def upgrade() -> None:
             ["message_history.internal_id"],
             ondelete="SET NULL",
         ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'approved', 'rejected', 'expired')",
+            name="ck_confirmation_requests_status",
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("execution_task_id"),
     )

--- a/alembic/versions/2026_04_19-add_confirmation_requests_table.py
+++ b/alembic/versions/2026_04_19-add_confirmation_requests_table.py
@@ -9,6 +9,7 @@ Create Date: 2026-04-19
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
@@ -25,7 +26,13 @@ def upgrade() -> None:
         sa.Column("target_user_id", sa.String(length=255), nullable=False),
         sa.Column("status", sa.String(length=32), nullable=False),
         sa.Column("tool_name", sa.String(length=255), nullable=False),
-        sa.Column("tool_args_json", sa.JSON(), nullable=False),
+        sa.Column(
+            "tool_args_json",
+            sa.JSON().with_variant(
+                postgresql.JSONB(astext_type=sa.Text()), "postgresql"
+            ),
+            nullable=False,
+        ),
         sa.Column("tool_call_id", sa.String(length=255), nullable=True),
         sa.Column("source_message_internal_id", sa.Integer(), nullable=True),
         sa.Column("confirmation_prompt", sa.Text(), nullable=False),

--- a/alembic/versions/2026_04_19-add_confirmation_requests_table.py
+++ b/alembic/versions/2026_04_19-add_confirmation_requests_table.py
@@ -1,0 +1,90 @@
+"""Add confirmation_requests table.
+
+Revision ID: add_confirmation_requests
+Revises: add_email_target_user
+Create Date: 2026-04-19
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "add_confirmation_requests"
+down_revision: str | None = "add_email_target_user"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "confirmation_requests",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("target_user_id", sa.String(length=255), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("tool_name", sa.String(length=255), nullable=False),
+        sa.Column("tool_args_json", sa.JSON(), nullable=False),
+        sa.Column("tool_call_id", sa.String(length=255), nullable=True),
+        sa.Column("source_message_internal_id", sa.Integer(), nullable=True),
+        sa.Column("confirmation_prompt", sa.Text(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("resolved_by_user_id", sa.String(length=255), nullable=True),
+        sa.Column("resolved_via_interface", sa.String(length=50), nullable=True),
+        sa.Column("execution_task_id", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["source_message_internal_id"],
+            ["message_history.internal_id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("execution_task_id"),
+    )
+    op.create_index(
+        op.f("ix_confirmation_requests_target_user_id"),
+        "confirmation_requests",
+        ["target_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_confirmation_requests_status"),
+        "confirmation_requests",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_confirmation_requests_source_message_internal_id"),
+        "confirmation_requests",
+        ["source_message_internal_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_confirmation_requests_expires_at"),
+        "confirmation_requests",
+        ["expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_confirmation_requests_expires_at"),
+        table_name="confirmation_requests",
+    )
+    op.drop_index(
+        op.f("ix_confirmation_requests_source_message_internal_id"),
+        table_name="confirmation_requests",
+    )
+    op.drop_index(
+        op.f("ix_confirmation_requests_status"),
+        table_name="confirmation_requests",
+    )
+    op.drop_index(
+        op.f("ix_confirmation_requests_target_user_id"),
+        table_name="confirmation_requests",
+    )
+    op.drop_table("confirmation_requests")

--- a/src/family_assistant/services/__init__.py
+++ b/src/family_assistant/services/__init__.py
@@ -1,5 +1,6 @@
 """Services module for Family Assistant."""
 
 from .attachment_registry import AttachmentRegistry
+from .confirmation_service import ConfirmationService
 
-__all__ = ["AttachmentRegistry"]
+__all__ = ["AttachmentRegistry", "ConfirmationService"]

--- a/src/family_assistant/services/confirmation_service.py
+++ b/src/family_assistant/services/confirmation_service.py
@@ -1,0 +1,219 @@
+"""Service for durable tool confirmation requests."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from contextlib import AbstractAsyncContextManager
+
+    from family_assistant.storage.context import DatabaseContext
+    from family_assistant.storage.repositories.confirmation_requests import (
+        ConfirmationRequestRow,
+    )
+
+CONFIRMATION_TOOL_EXECUTION_TASK_TYPE = "confirmation_tool_execution"
+
+
+class ConfirmationError(Exception):
+    """Base class for confirmation service errors."""
+
+
+class ConfirmationNotFoundError(ConfirmationError):
+    """Raised when a confirmation request does not exist."""
+
+
+class ConfirmationAuthorizationError(ConfirmationError):
+    """Raised when a principal cannot resolve a confirmation request."""
+
+
+class ConfirmationExpiredError(ConfirmationError):
+    """Raised when a pending confirmation request has expired."""
+
+
+class ConfirmationAlreadyResolvedError(ConfirmationError):
+    """Raised when a request has already been resolved incompatibly."""
+
+
+class ConfirmationService:
+    """Service that owns durable confirmation transactions and authorization."""
+
+    def __init__(
+        self,
+        *,
+        db_context_factory: Callable[[], AbstractAsyncContextManager[DatabaseContext]],
+    ) -> None:
+        self._db_context_factory = db_context_factory
+
+    async def create_request(
+        self,
+        *,
+        target_user_id: str,
+        tool_name: str,
+        tool_args: dict[str, object],
+        tool_call_id: str | None,
+        source_message_internal_id: int | None,
+        confirmation_prompt: str,
+        expires_at: datetime,
+    ) -> ConfirmationRequestRow:
+        """Create a durable pending confirmation request."""
+        request_id = f"confirm_{uuid.uuid4().hex[:12]}"
+        async with self._db_context_factory() as db:
+            return await db.confirmation_requests.create(
+                request_id=request_id,
+                target_user_id=target_user_id,
+                tool_name=tool_name,
+                tool_args=tool_args,
+                tool_call_id=tool_call_id,
+                source_message_internal_id=source_message_internal_id,
+                confirmation_prompt=confirmation_prompt,
+                expires_at=expires_at,
+            )
+
+    async def approve_and_enqueue_execution(
+        self,
+        *,
+        request_id: str,
+        approving_user_id: str,
+        approving_interface: str,
+    ) -> ConfirmationRequestRow:
+        """Approve a pending request and enqueue its execution atomically."""
+        async with self._db_context_factory() as db:
+            request = await self._get_authorized_request(
+                db=db,
+                request_id=request_id,
+                user_id=approving_user_id,
+            )
+            if request["status"] == "approved":
+                return request
+            if request["status"] != "pending":
+                self._raise_if_not_pending(request)
+
+            now = datetime.now(UTC)
+            if request["expires_at"] <= now:
+                raise ConfirmationExpiredError(
+                    f"Confirmation request {request_id} has expired"
+                )
+
+            execution_task_id = f"confirmation_tool_execution:{request_id}"
+            approved = await db.confirmation_requests.approve_pending(
+                request_id=request_id,
+                resolving_user_id=approving_user_id,
+                resolving_interface=approving_interface,
+                execution_task_id=execution_task_id,
+                now=now,
+            )
+            if approved is None:
+                refreshed = await db.confirmation_requests.get(request_id)
+                if refreshed is None:
+                    raise ConfirmationNotFoundError(
+                        f"Confirmation request {request_id} not found"
+                    )
+                return self._handle_concurrent_resolution(refreshed)
+
+            await db.tasks.enqueue(
+                task_id=execution_task_id,
+                task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE,
+                payload={"confirmation_request_id": request_id},
+                original_task_id=execution_task_id,
+            )
+            return approved
+
+    async def reject(
+        self,
+        *,
+        request_id: str,
+        rejecting_user_id: str,
+        rejecting_interface: str,
+    ) -> ConfirmationRequestRow:
+        """Reject a pending confirmation request."""
+        async with self._db_context_factory() as db:
+            request = await self._get_authorized_request(
+                db=db,
+                request_id=request_id,
+                user_id=rejecting_user_id,
+            )
+            if request["status"] == "rejected":
+                return request
+            if request["status"] != "pending":
+                self._raise_if_not_pending(request)
+
+            now = datetime.now(UTC)
+            if request["expires_at"] <= now:
+                raise ConfirmationExpiredError(
+                    f"Confirmation request {request_id} has expired"
+                )
+
+            rejected = await db.confirmation_requests.reject_pending(
+                request_id=request_id,
+                resolving_user_id=rejecting_user_id,
+                resolving_interface=rejecting_interface,
+                now=now,
+            )
+            if rejected is None:
+                refreshed = await db.confirmation_requests.get(request_id)
+                if refreshed is None:
+                    raise ConfirmationNotFoundError(
+                        f"Confirmation request {request_id} not found"
+                    )
+                return self._handle_concurrent_resolution(refreshed)
+            return rejected
+
+    async def list_pending_for_user(
+        self,
+        *,
+        user_id: str,
+    ) -> list[ConfirmationRequestRow]:
+        """List pending requests for a user."""
+        async with self._db_context_factory() as db:
+            return await db.confirmation_requests.list_pending_for_user(user_id)
+
+    async def mark_expired(self, *, now: datetime) -> int:
+        """Expire pending requests whose deadline has passed."""
+        async with self._db_context_factory() as db:
+            return await db.confirmation_requests.mark_expired(now=now)
+
+    @staticmethod
+    async def _get_authorized_request(
+        *,
+        db: DatabaseContext,
+        request_id: str,
+        user_id: str,
+    ) -> ConfirmationRequestRow:
+        request = await db.confirmation_requests.get(request_id)
+        if request is None:
+            raise ConfirmationNotFoundError(
+                f"Confirmation request {request_id} not found"
+            )
+        if request["target_user_id"] != user_id:
+            raise ConfirmationAuthorizationError(
+                f"User {user_id} cannot resolve confirmation request {request_id}"
+            )
+        return request
+
+    @staticmethod
+    def _raise_if_not_pending(request: ConfirmationRequestRow) -> None:
+        if request["status"] == "expired":
+            raise ConfirmationExpiredError(
+                f"Confirmation request {request['id']} has expired"
+            )
+        raise ConfirmationAlreadyResolvedError(
+            f"Confirmation request {request['id']} is already {request['status']}"
+        )
+
+    @staticmethod
+    def _handle_concurrent_resolution(
+        request: ConfirmationRequestRow,
+    ) -> ConfirmationRequestRow:
+        if request["status"] in {"approved", "rejected"}:
+            return request
+        if request["status"] == "expired":
+            raise ConfirmationExpiredError(
+                f"Confirmation request {request['id']} has expired"
+            )
+        raise ConfirmationAlreadyResolvedError(
+            f"Confirmation request {request['id']} could not be resolved"
+        )

--- a/src/family_assistant/services/confirmation_service.py
+++ b/src/family_assistant/services/confirmation_service.py
@@ -113,7 +113,7 @@ class ConfirmationService:
                     raise ConfirmationNotFoundError(
                         f"Confirmation request {request_id} not found"
                     )
-                return self._handle_concurrent_resolution(refreshed, "approved")
+                return self._handle_concurrent_resolution(refreshed, "approved", now)
 
             await db.tasks.enqueue(
                 task_id=execution_task_id,
@@ -160,7 +160,7 @@ class ConfirmationService:
                     raise ConfirmationNotFoundError(
                         f"Confirmation request {request_id} not found"
                     )
-                return self._handle_concurrent_resolution(refreshed, "rejected")
+                return self._handle_concurrent_resolution(refreshed, "rejected", now)
             return rejected
 
     async def list_pending_for_user(
@@ -212,9 +212,14 @@ class ConfirmationService:
     def _handle_concurrent_resolution(
         request: ConfirmationRequestRow,
         expected_status: ConfirmationStatus,
+        now: datetime,
     ) -> ConfirmationRequestRow:
         if request["status"] == expected_status:
             return request
+        if request["status"] == "pending" and request["expires_at"] <= now:
+            raise ConfirmationExpiredError(
+                f"Confirmation request {request['id']} has expired"
+            )
         if request["status"] == "expired":
             raise ConfirmationExpiredError(
                 f"Confirmation request {request['id']} has expired"

--- a/src/family_assistant/services/confirmation_service.py
+++ b/src/family_assistant/services/confirmation_service.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from family_assistant.storage.context import DatabaseContext
     from family_assistant.storage.repositories.confirmation_requests import (
         ConfirmationRequestRow,
+        ConfirmationStatus,
     )
 
 CONFIRMATION_TOOL_EXECUTION_TASK_TYPE = "confirmation_tool_execution"
@@ -112,7 +113,7 @@ class ConfirmationService:
                     raise ConfirmationNotFoundError(
                         f"Confirmation request {request_id} not found"
                     )
-                return self._handle_concurrent_resolution(refreshed)
+                return self._handle_concurrent_resolution(refreshed, "approved")
 
             await db.tasks.enqueue(
                 task_id=execution_task_id,
@@ -159,7 +160,7 @@ class ConfirmationService:
                     raise ConfirmationNotFoundError(
                         f"Confirmation request {request_id} not found"
                     )
-                return self._handle_concurrent_resolution(refreshed)
+                return self._handle_concurrent_resolution(refreshed, "rejected")
             return rejected
 
     async def list_pending_for_user(
@@ -207,13 +208,14 @@ class ConfirmationService:
     @staticmethod
     def _handle_concurrent_resolution(
         request: ConfirmationRequestRow,
+        expected_status: ConfirmationStatus,
     ) -> ConfirmationRequestRow:
-        if request["status"] in {"approved", "rejected"}:
+        if request["status"] == expected_status:
             return request
         if request["status"] == "expired":
             raise ConfirmationExpiredError(
                 f"Confirmation request {request['id']} has expired"
             )
         raise ConfirmationAlreadyResolvedError(
-            f"Confirmation request {request['id']} could not be resolved"
+            f"Confirmation request {request['id']} is already {request['status']}"
         )

--- a/src/family_assistant/services/confirmation_service.py
+++ b/src/family_assistant/services/confirmation_service.py
@@ -174,6 +174,9 @@ class ConfirmationService:
 
     async def mark_expired(self, *, now: datetime) -> int:
         """Expire pending requests whose deadline has passed."""
+        if now.tzinfo is None or now.utcoffset() is None:
+            raise ValueError("now must be timezone-aware")
+        now = now.astimezone(UTC)
         async with self._db_context_factory() as db:
             return await db.confirmation_requests.mark_expired(now=now)
 

--- a/src/family_assistant/storage/__init__.py
+++ b/src/family_assistant/storage/__init__.py
@@ -26,9 +26,10 @@ from family_assistant.storage.base import (
     create_engine_with_sqlite_optimizations,
     metadata,
 )
-from family_assistant.storage.context import DatabaseContext, get_db_context
 
 # Import table definitions for direct use
+from family_assistant.storage.confirmation_requests import confirmation_requests_table
+from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.storage.email import received_emails_table
 from family_assistant.storage.error_logs import error_logs_table
 from family_assistant.storage.events import (
@@ -321,6 +322,7 @@ __all__ = [
     "notes_table",
     "message_history_table",
     "tasks_table",
+    "confirmation_requests_table",
     "received_emails_table",
     "error_logs_table",
     "event_listeners_table",

--- a/src/family_assistant/storage/confirmation_requests.py
+++ b/src/family_assistant/storage/confirmation_requests.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy import (
     JSON,
+    CheckConstraint,
     Column,
     DateTime,
     ForeignKey,
@@ -42,4 +43,8 @@ confirmation_requests_table = Table(
     Column("resolved_by_user_id", String(255), nullable=True),
     Column("resolved_via_interface", String(50), nullable=True),
     Column("execution_task_id", String(255), nullable=True, unique=True),
+    CheckConstraint(
+        "status IN ('pending', 'approved', 'rejected', 'expired')",
+        name="ck_confirmation_requests_status",
+    ),
 )

--- a/src/family_assistant/storage/confirmation_requests.py
+++ b/src/family_assistant/storage/confirmation_requests.py
@@ -1,0 +1,45 @@
+"""Storage table for durable tool confirmation requests."""
+
+from sqlalchemy import (
+    JSON,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+    Text,
+)
+from sqlalchemy.dialects import postgresql
+
+from family_assistant.storage.base import metadata
+
+confirmation_requests_table = Table(
+    "confirmation_requests",
+    metadata,
+    Column("id", String(64), primary_key=True),
+    Column("target_user_id", String(255), nullable=False, index=True),
+    Column("status", String(32), nullable=False, index=True),
+    Column("tool_name", String(255), nullable=False),
+    Column(
+        "tool_args_json",
+        JSON().with_variant(postgresql.JSONB(astext_type=Text()), "postgresql"),
+        nullable=False,
+    ),
+    Column("tool_call_id", String(255), nullable=True),
+    Column(
+        "source_message_internal_id",
+        Integer,
+        ForeignKey("message_history.internal_id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    ),
+    Column("confirmation_prompt", Text, nullable=False),
+    Column("expires_at", DateTime(timezone=True), nullable=False, index=True),
+    Column("created_at", DateTime(timezone=True), nullable=False),
+    Column("updated_at", DateTime(timezone=True), nullable=False),
+    Column("resolved_at", DateTime(timezone=True), nullable=True),
+    Column("resolved_by_user_id", String(255), nullable=True),
+    Column("resolved_via_interface", String(50), nullable=True),
+    Column("execution_task_id", String(255), nullable=True, unique=True),
+)

--- a/src/family_assistant/storage/context.py
+++ b/src/family_assistant/storage/context.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
     from family_assistant.storage.repositories import (
         AutomationsRepository,
+        ConfirmationRequestsRepository,
         EmailRepository,
         ErrorLogsRepository,
         EventsRepository,
@@ -166,6 +167,7 @@ class DatabaseContext:
         self._tasks = None
         self._message_history = None
         self._email = None
+        self._confirmation_requests = None
         self._error_logs = None
         self._events = None
         self._vector = None
@@ -434,6 +436,17 @@ class DatabaseContext:
 
             self._email = EmailRepository(self)
         return self._email
+
+    @property
+    def confirmation_requests(self) -> "ConfirmationRequestsRepository":
+        """Get the confirmation requests repository instance."""
+        if self._confirmation_requests is None:
+            from family_assistant.storage.repositories import (  # noqa: PLC0415
+                ConfirmationRequestsRepository,
+            )
+
+            self._confirmation_requests = ConfirmationRequestsRepository(self)
+        return self._confirmation_requests
 
     @property
     def error_logs(self) -> "ErrorLogsRepository":

--- a/src/family_assistant/storage/repositories/__init__.py
+++ b/src/family_assistant/storage/repositories/__init__.py
@@ -3,6 +3,7 @@
 from .a2a_tasks import A2ATasksRepository
 from .automations import AutomationsRepository
 from .base import BaseRepository
+from .confirmation_requests import ConfirmationRequestsRepository
 from .email import EmailRepository
 from .error_logs import ErrorLogsRepository
 from .events import EventsRepository
@@ -19,6 +20,7 @@ __all__ = [
     "A2ATasksRepository",
     "AutomationsRepository",
     "BaseRepository",
+    "ConfirmationRequestsRepository",
     "EmailRepository",
     "ErrorLogsRepository",
     "EventsRepository",

--- a/src/family_assistant/storage/repositories/confirmation_requests.py
+++ b/src/family_assistant/storage/repositories/confirmation_requests.py
@@ -84,11 +84,13 @@ class ConfirmationRequestsRepository(BaseRepository):
 
     async def list_pending_for_user(self, user_id: str) -> list[ConfirmationRequestRow]:
         """List pending confirmation requests for a target user."""
+        now = datetime.now(UTC)
         stmt = (
             select(confirmation_requests_table)
             .where(
                 confirmation_requests_table.c.target_user_id == user_id,
                 confirmation_requests_table.c.status == "pending",
+                confirmation_requests_table.c.expires_at > now,
             )
             .order_by(confirmation_requests_table.c.created_at.asc())
         )

--- a/src/family_assistant/storage/repositories/confirmation_requests.py
+++ b/src/family_assistant/storage/repositories/confirmation_requests.py
@@ -1,0 +1,186 @@
+"""Repository for durable tool confirmation requests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal, TypedDict, cast
+
+from sqlalchemy import insert, select, update
+
+from family_assistant.storage.confirmation_requests import confirmation_requests_table
+from family_assistant.storage.datetime_utils import normalize_datetime
+from family_assistant.storage.repositories.base import BaseRepository
+
+ConfirmationStatus = Literal["pending", "approved", "rejected", "expired"]
+
+
+class ConfirmationRequestRow(TypedDict):
+    """Typed representation of a durable tool confirmation request row."""
+
+    id: str
+    target_user_id: str
+    status: ConfirmationStatus
+    tool_name: str
+    tool_args_json: dict[str, object]
+    tool_call_id: str | None
+    source_message_internal_id: int | None
+    confirmation_prompt: str
+    expires_at: datetime
+    created_at: datetime
+    updated_at: datetime
+    resolved_at: datetime | None
+    resolved_by_user_id: str | None
+    resolved_via_interface: str | None
+    execution_task_id: str | None
+
+
+class ConfirmationRequestsRepository(BaseRepository):
+    """Repository for durable confirmation request persistence."""
+
+    async def create(
+        self,
+        *,
+        request_id: str,
+        target_user_id: str,
+        tool_name: str,
+        tool_args: dict[str, object],
+        tool_call_id: str | None,
+        source_message_internal_id: int | None,
+        confirmation_prompt: str,
+        expires_at: datetime,
+    ) -> ConfirmationRequestRow:
+        """Create a pending confirmation request."""
+        if expires_at.tzinfo is None:
+            raise ValueError("expires_at must be timezone-aware")
+
+        now = datetime.now(UTC)
+        stmt = (
+            insert(confirmation_requests_table)
+            .values(
+                id=request_id,
+                target_user_id=target_user_id,
+                status="pending",
+                tool_name=tool_name,
+                tool_args_json=tool_args,
+                tool_call_id=tool_call_id,
+                source_message_internal_id=source_message_internal_id,
+                confirmation_prompt=confirmation_prompt,
+                expires_at=expires_at,
+                created_at=now,
+                updated_at=now,
+            )
+            .returning(confirmation_requests_table)
+        )
+        result = await self._execute_with_logging("create_confirmation_request", stmt)
+        return self._row_to_typed(dict(result.mappings().one()))
+
+    async def get(self, request_id: str) -> ConfirmationRequestRow | None:
+        """Get a confirmation request by id."""
+        stmt = select(confirmation_requests_table).where(
+            confirmation_requests_table.c.id == request_id
+        )
+        row = await self._db.fetch_one(stmt)
+        return self._row_to_typed(row) if row is not None else None
+
+    async def list_pending_for_user(self, user_id: str) -> list[ConfirmationRequestRow]:
+        """List pending confirmation requests for a target user."""
+        stmt = (
+            select(confirmation_requests_table)
+            .where(
+                confirmation_requests_table.c.target_user_id == user_id,
+                confirmation_requests_table.c.status == "pending",
+            )
+            .order_by(confirmation_requests_table.c.created_at.asc())
+        )
+        rows = await self._db.fetch_all(stmt)
+        return [self._row_to_typed(row) for row in rows]
+
+    async def approve_pending(
+        self,
+        *,
+        request_id: str,
+        resolving_user_id: str,
+        resolving_interface: str,
+        execution_task_id: str,
+        now: datetime,
+    ) -> ConfirmationRequestRow | None:
+        """Move a pending request to approved and store the execution task id."""
+        stmt = (
+            update(confirmation_requests_table)
+            .where(
+                confirmation_requests_table.c.id == request_id,
+                confirmation_requests_table.c.status == "pending",
+                confirmation_requests_table.c.expires_at > now,
+            )
+            .values(
+                status="approved",
+                updated_at=now,
+                resolved_at=now,
+                resolved_by_user_id=resolving_user_id,
+                resolved_via_interface=resolving_interface,
+                execution_task_id=execution_task_id,
+            )
+            .returning(confirmation_requests_table)
+        )
+        result = await self._execute_with_logging("approve_confirmation_request", stmt)
+        row = result.mappings().one_or_none()
+        return self._row_to_typed(dict(row)) if row is not None else None
+
+    async def reject_pending(
+        self,
+        *,
+        request_id: str,
+        resolving_user_id: str,
+        resolving_interface: str,
+        now: datetime,
+    ) -> ConfirmationRequestRow | None:
+        """Move a pending request to rejected."""
+        stmt = (
+            update(confirmation_requests_table)
+            .where(
+                confirmation_requests_table.c.id == request_id,
+                confirmation_requests_table.c.status == "pending",
+                confirmation_requests_table.c.expires_at > now,
+            )
+            .values(
+                status="rejected",
+                updated_at=now,
+                resolved_at=now,
+                resolved_by_user_id=resolving_user_id,
+                resolved_via_interface=resolving_interface,
+            )
+            .returning(confirmation_requests_table)
+        )
+        result = await self._execute_with_logging("reject_confirmation_request", stmt)
+        row = result.mappings().one_or_none()
+        return self._row_to_typed(dict(row)) if row is not None else None
+
+    async def mark_expired(self, *, now: datetime) -> int:
+        """Expire pending requests whose deadline has passed."""
+        stmt = (
+            update(confirmation_requests_table)
+            .where(
+                confirmation_requests_table.c.status == "pending",
+                confirmation_requests_table.c.expires_at <= now,
+            )
+            .values(status="expired", updated_at=now)
+        )
+        result = await self._execute_with_logging("expire_confirmation_requests", stmt)
+        return cast("int", result.rowcount)
+
+    @staticmethod
+    def _row_to_typed(row: dict[str, object]) -> ConfirmationRequestRow:
+        row = dict(row)
+        for field in ("expires_at", "created_at", "updated_at", "resolved_at"):
+            row[field] = ConfirmationRequestsRepository._normalize_datetime_field(
+                row.get(field)
+            )
+        return ConfirmationRequestRow(**row)  # type: ignore[typeddict-item]  # row keys match TypedDict
+
+    @staticmethod
+    def _normalize_datetime_field(value: object) -> datetime | None:
+        if value is None:
+            return None
+        if not isinstance(value, datetime | str):
+            raise TypeError(f"Expected datetime or str, got {type(value).__name__}")
+        return normalize_datetime(value)

--- a/tests/functional/storage/test_confirmation_requests.py
+++ b/tests/functional/storage/test_confirmation_requests.py
@@ -6,7 +6,7 @@ from types import TracebackType
 from typing import Literal, cast
 
 import pytest
-from sqlalchemy import insert
+from sqlalchemy import insert, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -25,7 +25,12 @@ from family_assistant.storage.repositories.confirmation_requests import (
 )
 from family_assistant.storage.repositories.tasks import TasksRepository
 
-RaceMode = Literal["reject_before_approve", "approve_before_reject"]
+RaceMode = Literal[
+    "reject_before_approve",
+    "approve_before_reject",
+    "expire_before_approve",
+    "expire_before_reject",
+]
 
 
 def _service(db_engine: AsyncEngine) -> ConfirmationService:
@@ -101,6 +106,8 @@ class _RacingConfirmationRequestsRepository:
                     resolving_interface="telegram",
                     now=now,
                 )
+        if self._race_mode == "expire_before_approve":
+            await self._expire_request(request_id=request_id, now=now)
         return await self._inner.approve_pending(
             request_id=request_id,
             resolving_user_id=resolving_user_id,
@@ -134,6 +141,8 @@ class _RacingConfirmationRequestsRepository:
                         payload={"confirmation_request_id": request_id},
                         original_task_id=execution_task_id,
                     )
+        if self._race_mode == "expire_before_reject":
+            await self._expire_request(request_id=request_id, now=now)
         return await self._inner.reject_pending(
             request_id=request_id,
             resolving_user_id=resolving_user_id,
@@ -143,6 +152,17 @@ class _RacingConfirmationRequestsRepository:
 
     async def mark_expired(self, *, now: datetime) -> int:
         return await self._inner.mark_expired(now=now)
+
+    async def _expire_request(self, *, request_id: str, now: datetime) -> None:
+        async with DatabaseContext(engine=self._db_engine) as racing_db:
+            await racing_db.execute_with_retry(
+                update(confirmation_requests_table)
+                .where(confirmation_requests_table.c.id == request_id)
+                .values(
+                    expires_at=now - timedelta(microseconds=1),
+                    updated_at=now,
+                )
+            )
 
 
 class _RacingDatabaseContext:
@@ -401,6 +421,52 @@ async def test_concurrent_approval_during_rejection_raises(
     assert [task["task_id"] for task in tasks] == [
         f"confirmation_tool_execution:{request_id}"
     ]
+
+
+@pytest.mark.asyncio
+async def test_expiry_during_approval_raises_expired_error(
+    db_engine: AsyncEngine,
+) -> None:
+    service = _racing_service(db_engine, "expire_before_approve")
+    request_id = await _create_request(db_engine)
+
+    with pytest.raises(ConfirmationExpiredError):
+        await service.approve_and_enqueue_execution(
+            request_id=request_id,
+            approving_user_id="user-1",
+            approving_interface="web",
+        )
+
+    async with DatabaseContext(engine=db_engine) as db:
+        request = await db.confirmation_requests.get(request_id)
+        tasks = await db.tasks.get_all(task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE)
+
+    assert request is not None
+    assert request["status"] == "pending"
+    assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_expiry_during_rejection_raises_expired_error(
+    db_engine: AsyncEngine,
+) -> None:
+    service = _racing_service(db_engine, "expire_before_reject")
+    request_id = await _create_request(db_engine)
+
+    with pytest.raises(ConfirmationExpiredError):
+        await service.reject(
+            request_id=request_id,
+            rejecting_user_id="user-1",
+            rejecting_interface="telegram",
+        )
+
+    async with DatabaseContext(engine=db_engine) as db:
+        request = await db.confirmation_requests.get(request_id)
+        tasks = await db.tasks.get_all(task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE)
+
+    assert request is not None
+    assert request["status"] == "pending"
+    assert tasks == []
 
 
 @pytest.mark.asyncio

--- a/tests/functional/storage/test_confirmation_requests.py
+++ b/tests/functional/storage/test_confirmation_requests.py
@@ -1,6 +1,9 @@
 """Functional tests for durable tool confirmations."""
 
+from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime, timedelta
+from types import TracebackType
+from typing import Literal, cast
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine
@@ -13,12 +16,168 @@ from family_assistant.services.confirmation_service import (
     ConfirmationService,
 )
 from family_assistant.storage.context import DatabaseContext
+from family_assistant.storage.repositories.confirmation_requests import (
+    ConfirmationRequestRow,
+    ConfirmationRequestsRepository,
+)
+from family_assistant.storage.repositories.tasks import TasksRepository
+
+RaceMode = Literal["reject_before_approve", "approve_before_reject"]
 
 
 def _service(db_engine: AsyncEngine) -> ConfirmationService:
     return ConfirmationService(
         db_context_factory=lambda: DatabaseContext(engine=db_engine)
     )
+
+
+def _racing_service(db_engine: AsyncEngine, race_mode: RaceMode) -> ConfirmationService:
+    def db_context_factory() -> AbstractAsyncContextManager[DatabaseContext]:
+        return cast(
+            "AbstractAsyncContextManager[DatabaseContext]",
+            _RacingDatabaseContext(db_engine, race_mode),
+        )
+
+    return ConfirmationService(db_context_factory=db_context_factory)
+
+
+class _RacingConfirmationRequestsRepository:
+    def __init__(
+        self,
+        inner: ConfirmationRequestsRepository,
+        db_engine: AsyncEngine,
+        race_mode: RaceMode,
+    ) -> None:
+        self._inner = inner
+        self._db_engine = db_engine
+        self._race_mode = race_mode
+
+    async def create(
+        self,
+        *,
+        request_id: str,
+        target_user_id: str,
+        tool_name: str,
+        tool_args: dict[str, object],
+        tool_call_id: str | None,
+        source_message_internal_id: int | None,
+        confirmation_prompt: str,
+        expires_at: datetime,
+    ) -> ConfirmationRequestRow:
+        return await self._inner.create(
+            request_id=request_id,
+            target_user_id=target_user_id,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            tool_call_id=tool_call_id,
+            source_message_internal_id=source_message_internal_id,
+            confirmation_prompt=confirmation_prompt,
+            expires_at=expires_at,
+        )
+
+    async def get(self, request_id: str) -> ConfirmationRequestRow | None:
+        return await self._inner.get(request_id)
+
+    async def list_pending_for_user(self, user_id: str) -> list[ConfirmationRequestRow]:
+        return await self._inner.list_pending_for_user(user_id)
+
+    async def approve_pending(
+        self,
+        *,
+        request_id: str,
+        resolving_user_id: str,
+        resolving_interface: str,
+        execution_task_id: str,
+        now: datetime,
+    ) -> ConfirmationRequestRow | None:
+        if self._race_mode == "reject_before_approve":
+            async with DatabaseContext(engine=self._db_engine) as racing_db:
+                await racing_db.confirmation_requests.reject_pending(
+                    request_id=request_id,
+                    resolving_user_id="racing-user",
+                    resolving_interface="telegram",
+                    now=now,
+                )
+        return await self._inner.approve_pending(
+            request_id=request_id,
+            resolving_user_id=resolving_user_id,
+            resolving_interface=resolving_interface,
+            execution_task_id=execution_task_id,
+            now=now,
+        )
+
+    async def reject_pending(
+        self,
+        *,
+        request_id: str,
+        resolving_user_id: str,
+        resolving_interface: str,
+        now: datetime,
+    ) -> ConfirmationRequestRow | None:
+        if self._race_mode == "approve_before_reject":
+            execution_task_id = f"confirmation_tool_execution:{request_id}"
+            async with DatabaseContext(engine=self._db_engine) as racing_db:
+                approved = await racing_db.confirmation_requests.approve_pending(
+                    request_id=request_id,
+                    resolving_user_id="racing-user",
+                    resolving_interface="web",
+                    execution_task_id=execution_task_id,
+                    now=now,
+                )
+                if approved is not None:
+                    await racing_db.tasks.enqueue(
+                        task_id=execution_task_id,
+                        task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE,
+                        payload={"confirmation_request_id": request_id},
+                        original_task_id=execution_task_id,
+                    )
+        return await self._inner.reject_pending(
+            request_id=request_id,
+            resolving_user_id=resolving_user_id,
+            resolving_interface=resolving_interface,
+            now=now,
+        )
+
+    async def mark_expired(self, *, now: datetime) -> int:
+        return await self._inner.mark_expired(now=now)
+
+
+class _RacingDatabaseContext:
+    def __init__(self, db_engine: AsyncEngine, race_mode: RaceMode) -> None:
+        self._db_engine = db_engine
+        self._inner_context = DatabaseContext(engine=db_engine)
+        self._race_mode: RaceMode = race_mode
+        self._db: DatabaseContext | None = None
+        self._confirmation_requests: _RacingConfirmationRequestsRepository | None = None
+
+    async def __aenter__(self) -> "_RacingDatabaseContext":
+        self._db = await self._inner_context.__aenter__()
+        self._confirmation_requests = _RacingConfirmationRequestsRepository(
+            self._db.confirmation_requests,
+            self._db_engine,
+            self._race_mode,
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        await self._inner_context.__aexit__(exc_type, exc_val, exc_tb)
+
+    @property
+    def confirmation_requests(self) -> _RacingConfirmationRequestsRepository:
+        if self._confirmation_requests is None:
+            raise RuntimeError("Racing context has not been entered")
+        return self._confirmation_requests
+
+    @property
+    def tasks(self) -> TasksRepository:
+        if self._db is None:
+            raise RuntimeError("Racing context has not been entered")
+        return self._db.tasks
 
 
 async def _create_request(
@@ -167,6 +326,54 @@ async def test_reject_blocks_later_approval(db_engine: AsyncEngine) -> None:
         tasks = await db.tasks.get_all(task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE)
 
     assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_rejection_during_approval_raises(
+    db_engine: AsyncEngine,
+) -> None:
+    service = _racing_service(db_engine, "reject_before_approve")
+    request_id = await _create_request(db_engine)
+
+    with pytest.raises(ConfirmationAlreadyResolvedError):
+        await service.approve_and_enqueue_execution(
+            request_id=request_id,
+            approving_user_id="user-1",
+            approving_interface="web",
+        )
+
+    async with DatabaseContext(engine=db_engine) as db:
+        request = await db.confirmation_requests.get(request_id)
+        tasks = await db.tasks.get_all(task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE)
+
+    assert request is not None
+    assert request["status"] == "rejected"
+    assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_approval_during_rejection_raises(
+    db_engine: AsyncEngine,
+) -> None:
+    service = _racing_service(db_engine, "approve_before_reject")
+    request_id = await _create_request(db_engine)
+
+    with pytest.raises(ConfirmationAlreadyResolvedError):
+        await service.reject(
+            request_id=request_id,
+            rejecting_user_id="user-1",
+            rejecting_interface="telegram",
+        )
+
+    async with DatabaseContext(engine=db_engine) as db:
+        request = await db.confirmation_requests.get(request_id)
+        tasks = await db.tasks.get_all(task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE)
+
+    assert request is not None
+    assert request["status"] == "approved"
+    assert [task["task_id"] for task in tasks] == [
+        f"confirmation_tool_execution:{request_id}"
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/functional/storage/test_confirmation_requests.py
+++ b/tests/functional/storage/test_confirmation_requests.py
@@ -450,6 +450,26 @@ async def test_mark_expired_expires_only_pending_requests(
 
 
 @pytest.mark.asyncio
+async def test_mark_expired_rejects_naive_now(db_engine: AsyncEngine) -> None:
+    service = _service(db_engine)
+    request_id = await _create_request(
+        db_engine,
+        expires_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        await service.mark_expired(
+            now=datetime(2026, 4, 19, 12, 0, 0),  # noqa: DTZ001
+        )
+
+    async with DatabaseContext(engine=db_engine) as db:
+        request = await db.confirmation_requests.get(request_id)
+
+    assert request is not None
+    assert request["status"] == "pending"
+
+
+@pytest.mark.asyncio
 async def test_approval_of_expired_request_does_not_enqueue_task(
     db_engine: AsyncEngine,
 ) -> None:

--- a/tests/functional/storage/test_confirmation_requests.py
+++ b/tests/functional/storage/test_confirmation_requests.py
@@ -377,6 +377,25 @@ async def test_concurrent_approval_during_rejection_raises(
 
 
 @pytest.mark.asyncio
+async def test_list_pending_for_user_excludes_expired_requests(
+    db_engine: AsyncEngine,
+) -> None:
+    service = _service(db_engine)
+    await _create_request(
+        db_engine,
+        expires_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+    pending_id = await _create_request(
+        db_engine,
+        expires_at=datetime.now(UTC) + timedelta(minutes=30),
+    )
+
+    pending_requests = await service.list_pending_for_user(user_id="user-1")
+
+    assert [request["id"] for request in pending_requests] == [pending_id]
+
+
+@pytest.mark.asyncio
 async def test_mark_expired_expires_only_pending_requests(
     db_engine: AsyncEngine,
 ) -> None:

--- a/tests/functional/storage/test_confirmation_requests.py
+++ b/tests/functional/storage/test_confirmation_requests.py
@@ -1,0 +1,252 @@
+"""Functional tests for durable tool confirmations."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from family_assistant.services.confirmation_service import (
+    CONFIRMATION_TOOL_EXECUTION_TASK_TYPE,
+    ConfirmationAlreadyResolvedError,
+    ConfirmationAuthorizationError,
+    ConfirmationExpiredError,
+    ConfirmationService,
+)
+from family_assistant.storage.context import DatabaseContext
+
+
+def _service(db_engine: AsyncEngine) -> ConfirmationService:
+    return ConfirmationService(
+        db_context_factory=lambda: DatabaseContext(engine=db_engine)
+    )
+
+
+async def _create_request(
+    db_engine: AsyncEngine,
+    *,
+    target_user_id: str = "user-1",
+    expires_at: datetime | None = None,
+) -> str:
+    request = await _service(db_engine).create_request(
+        target_user_id=target_user_id,
+        tool_name="calendar.create_event",
+        tool_args={"title": "Flight", "start": "2026-05-01T09:00:00-07:00"},
+        tool_call_id="call-1",
+        source_message_internal_id=None,
+        confirmation_prompt="Create calendar event: Flight",
+        expires_at=expires_at or datetime.now(UTC) + timedelta(hours=1),
+    )
+    return request["id"]
+
+
+@pytest.mark.asyncio
+async def test_create_request_is_visible_from_separate_context(
+    db_engine: AsyncEngine,
+) -> None:
+    service = _service(db_engine)
+    created = await service.create_request(
+        target_user_id="user-1",
+        tool_name="calendar.create_event",
+        tool_args={"title": "Ticket", "start": "2026-05-01T09:00:00-07:00"},
+        tool_call_id="call-1",
+        source_message_internal_id=None,
+        confirmation_prompt="Create calendar event: Ticket",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    async with DatabaseContext(engine=db_engine) as db:
+        fetched = await db.confirmation_requests.get(created["id"])
+
+    assert fetched is not None
+    assert fetched["status"] == "pending"
+    assert fetched["target_user_id"] == "user-1"
+    assert fetched["tool_args_json"]["title"] == "Ticket"
+
+
+@pytest.mark.asyncio
+async def test_approval_enqueues_execution_task_atomically(
+    db_engine: AsyncEngine,
+) -> None:
+    service = _service(db_engine)
+    request_id = await _create_request(db_engine)
+
+    approved = await service.approve_and_enqueue_execution(
+        request_id=request_id,
+        approving_user_id="user-1",
+        approving_interface="web",
+    )
+
+    expected_task_id = f"confirmation_tool_execution:{request_id}"
+    assert approved["status"] == "approved"
+    assert approved["resolved_by_user_id"] == "user-1"
+    assert approved["resolved_via_interface"] == "web"
+    assert approved["execution_task_id"] == expected_task_id
+
+    async with DatabaseContext(engine=db_engine) as db:
+        tasks = await db.tasks.get_all(
+            status="pending",
+            task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE,
+        )
+
+    assert len(tasks) == 1
+    assert tasks[0]["task_id"] == expected_task_id
+    assert tasks[0]["payload"] == {"confirmation_request_id": request_id}
+
+
+@pytest.mark.asyncio
+async def test_replayed_approval_does_not_enqueue_second_task(
+    db_engine: AsyncEngine,
+) -> None:
+    service = _service(db_engine)
+    request_id = await _create_request(db_engine)
+
+    first = await service.approve_and_enqueue_execution(
+        request_id=request_id,
+        approving_user_id="user-1",
+        approving_interface="web",
+    )
+    second = await service.approve_and_enqueue_execution(
+        request_id=request_id,
+        approving_user_id="user-1",
+        approving_interface="web",
+    )
+
+    assert second["id"] == first["id"]
+    assert second["status"] == "approved"
+    async with DatabaseContext(engine=db_engine) as db:
+        tasks = await db.tasks.get_all(task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE)
+
+    assert [task["task_id"] for task in tasks] == [
+        f"confirmation_tool_execution:{request_id}"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_wrong_user_cannot_approve_request(db_engine: AsyncEngine) -> None:
+    service = _service(db_engine)
+    request_id = await _create_request(db_engine, target_user_id="user-1")
+
+    with pytest.raises(ConfirmationAuthorizationError):
+        await service.approve_and_enqueue_execution(
+            request_id=request_id,
+            approving_user_id="user-2",
+            approving_interface="web",
+        )
+
+    async with DatabaseContext(engine=db_engine) as db:
+        request = await db.confirmation_requests.get(request_id)
+        tasks = await db.tasks.get_all(task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE)
+
+    assert request is not None
+    assert request["status"] == "pending"
+    assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_reject_blocks_later_approval(db_engine: AsyncEngine) -> None:
+    service = _service(db_engine)
+    request_id = await _create_request(db_engine)
+
+    rejected = await service.reject(
+        request_id=request_id,
+        rejecting_user_id="user-1",
+        rejecting_interface="telegram",
+    )
+
+    assert rejected["status"] == "rejected"
+    assert rejected["resolved_via_interface"] == "telegram"
+
+    with pytest.raises(ConfirmationAlreadyResolvedError):
+        await service.approve_and_enqueue_execution(
+            request_id=request_id,
+            approving_user_id="user-1",
+            approving_interface="web",
+        )
+
+    async with DatabaseContext(engine=db_engine) as db:
+        tasks = await db.tasks.get_all(task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE)
+
+    assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_mark_expired_expires_only_pending_requests(
+    db_engine: AsyncEngine,
+) -> None:
+    service = _service(db_engine)
+    expired_id = await _create_request(
+        db_engine,
+        expires_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+    pending_id = await _create_request(
+        db_engine,
+        expires_at=datetime.now(UTC) + timedelta(minutes=30),
+    )
+
+    expired_count = await service.mark_expired(now=datetime.now(UTC))
+
+    assert expired_count == 1
+    async with DatabaseContext(engine=db_engine) as db:
+        expired = await db.confirmation_requests.get(expired_id)
+        pending = await db.confirmation_requests.get(pending_id)
+
+    assert expired is not None
+    assert expired["status"] == "expired"
+    assert pending is not None
+    assert pending["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_approval_of_expired_request_does_not_enqueue_task(
+    db_engine: AsyncEngine,
+) -> None:
+    service = _service(db_engine)
+    request_id = await _create_request(
+        db_engine,
+        expires_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+
+    with pytest.raises(ConfirmationExpiredError):
+        await service.approve_and_enqueue_execution(
+            request_id=request_id,
+            approving_user_id="user-1",
+            approving_interface="web",
+        )
+
+    async with DatabaseContext(engine=db_engine) as db:
+        request = await db.confirmation_requests.get(request_id)
+        tasks = await db.tasks.get_all(task_type=CONFIRMATION_TOOL_EXECUTION_TASK_TYPE)
+
+    assert request is not None
+    assert request["status"] == "pending"
+    assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_enqueue_failure_rolls_back_approval(db_engine: AsyncEngine) -> None:
+    service = _service(db_engine)
+    request_id = await _create_request(db_engine)
+    execution_task_id = f"confirmation_tool_execution:{request_id}"
+
+    async with DatabaseContext(engine=db_engine) as db:
+        await db.tasks.enqueue(
+            task_id=execution_task_id,
+            task_type="preexisting_task",
+            payload={"reason": "force duplicate task id"},
+        )
+
+    with pytest.raises(RuntimeError, match="already exists"):
+        await service.approve_and_enqueue_execution(
+            request_id=request_id,
+            approving_user_id="user-1",
+            approving_interface="web",
+        )
+
+    async with DatabaseContext(engine=db_engine) as db:
+        request = await db.confirmation_requests.get(request_id)
+        tasks = await db.tasks.get_all()
+
+    assert request is not None
+    assert request["status"] == "pending"
+    assert request.get("execution_task_id") is None
+    assert [task["task_id"] for task in tasks] == [execution_task_id]

--- a/tests/functional/storage/test_confirmation_requests.py
+++ b/tests/functional/storage/test_confirmation_requests.py
@@ -6,6 +6,8 @@ from types import TracebackType
 from typing import Literal, cast
 
 import pytest
+from sqlalchemy import insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from family_assistant.services.confirmation_service import (
@@ -15,6 +17,7 @@ from family_assistant.services.confirmation_service import (
     ConfirmationExpiredError,
     ConfirmationService,
 )
+from family_assistant.storage.confirmation_requests import confirmation_requests_table
 from family_assistant.storage.context import DatabaseContext
 from family_assistant.storage.repositories.confirmation_requests import (
     ConfirmationRequestRow,
@@ -220,6 +223,30 @@ async def test_create_request_is_visible_from_separate_context(
     assert fetched["status"] == "pending"
     assert fetched["target_user_id"] == "user-1"
     assert fetched["tool_args_json"]["title"] == "Ticket"
+
+
+@pytest.mark.asyncio
+async def test_invalid_confirmation_status_is_rejected_by_database(
+    db_engine: AsyncEngine,
+) -> None:
+    now = datetime.now(UTC)
+    with pytest.raises(IntegrityError):
+        async with DatabaseContext(engine=db_engine) as db:
+            await db.execute_with_retry(
+                insert(confirmation_requests_table).values(
+                    id="confirm_invalid_status",
+                    target_user_id="user-1",
+                    status="invalid",
+                    tool_name="calendar.create_event",
+                    tool_args_json={"title": "Flight"},
+                    tool_call_id=None,
+                    source_message_internal_id=None,
+                    confirmation_prompt="Create calendar event: Flight",
+                    expires_at=now + timedelta(hours=1),
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add `confirmation_requests` storage model, Alembic migration, and repository wiring through `DatabaseContext`.
- Add `ConfirmationService` for durable request creation, authorization, approve/reject/expire state transitions, timezone-safe expiry sweeps, expiry-race handling, and atomic approval plus task enqueue handoff.
- Add functional storage/service tests covering cross-context visibility, authorization, idempotent approval, rejection, expiry, rollback when task enqueue fails, committed concurrent approve/reject conflicts, expiry races during approve/reject, hiding expired pending confirmations from pending lists, DB rejection of invalid confirmation statuses, and naive expiry timestamp rejection.

## Verification

- `scripts/format-and-lint.sh src/family_assistant/services/__init__.py src/family_assistant/services/confirmation_service.py src/family_assistant/storage/__init__.py src/family_assistant/storage/confirmation_requests.py src/family_assistant/storage/context.py src/family_assistant/storage/repositories/__init__.py src/family_assistant/storage/repositories/confirmation_requests.py tests/functional/storage/test_confirmation_requests.py`
- `uv run pytest tests/functional/storage/test_confirmation_requests.py -xq`
- `uv run alembic heads`
- `uv run scripts/review-changes.py --json`
- `uv run poe test` (first pass: 2992 passed, 3 skipped; all gates passed)
- `uv run scripts/review-changes.py --commit --json`
- After race/JSONB review fixes: `uv run pytest tests/functional/storage/test_confirmation_requests.py -xq` (20 passed)
- After race/JSONB review fixes: `uv run poe test` (2996 passed, 3 skipped, 1 rerun; all gates passed)
- After expired-list review fix: `uv run pytest tests/functional/storage/test_confirmation_requests.py -xq` (22 passed)
- After expired-list review fix: `uv run poe test` (2998 passed, 3 skipped; all gates passed)
- After status-constraint review fix: `scripts/format-and-lint.sh alembic/versions/2026_04_19-add_confirmation_requests_table.py src/family_assistant/storage/confirmation_requests.py tests/functional/storage/test_confirmation_requests.py`
- After status-constraint review fix: `uv run pytest tests/functional/storage/test_confirmation_requests.py -xq` (24 passed)
- After status-constraint review fix: `uv run scripts/review-changes.py --json`
- After status-constraint review fix: `uv run poe test` (3000 passed, 3 skipped; all gates passed)
- After status-constraint review fix: `uv run scripts/review-changes.py --commit --json`
- After timezone review fix: `scripts/format-and-lint.sh src/family_assistant/services/confirmation_service.py tests/functional/storage/test_confirmation_requests.py`
- After timezone review fix: `uv run pytest tests/functional/storage/test_confirmation_requests.py -xq` (26 passed)
- After timezone review fix: `uv run scripts/review-changes.py --json`
- After timezone review fix: `uv run poe test` (3002 passed, 3 skipped, 2 rerun; all gates passed)
- After timezone review fix: `uv run scripts/review-changes.py --commit --json`
- After expiry-race review fix: `scripts/format-and-lint.sh src/family_assistant/services/confirmation_service.py tests/functional/storage/test_confirmation_requests.py`
- After expiry-race review fix: `uv run pytest tests/functional/storage/test_confirmation_requests.py -xq` (30 passed)
- After expiry-race review fix: `uv run scripts/review-changes.py --json`
- After expiry-race review fix: `uv run poe test` (final pass: 3006 passed, 3 skipped, 1 rerun; all gates passed)
- After expiry-race review fix: `uv run scripts/review-changes.py --commit --json`

## Notes

This is the first implementation slice from the durable confirmation design: durable storage and the atomic task queue handoff. The actual confirmation UI/adapters and tool execution task handler are intentionally left for follow-up PRs so each step has independent test coverage.
