### PR TITLE
Add MAILGUN_WEBHOOK_SIGNING_KEY environment variable support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,17 @@ python scripts/generate_vapid_keys.py
 # VAPID_PUBLIC_KEY=<url-safe-base64-no-padding>
 ```
 
+### Environment Variables for Email Intake
+
+The following environment variable can be used instead of hardcoding the value in `config.yaml`:
+
+- **`MAILGUN_WEBHOOK_SIGNING_KEY`** - Mailgun webhook signing key for verifying incoming email
+  webhooks
+
+  - Maps to `email_intake.mailgun_webhook_signing_key` in config
+  - Found in the Mailgun dashboard under Sending → Webhooks
+  - Example: `export MAILGUN_WEBHOOK_SIGNING_KEY=your-signing-key-here`
+
 ### Code Generation
 
 ```bash

--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -67,6 +67,9 @@ ENV_VAR_MAPPINGS: list[EnvVarMapping] = [
     # Secrets and API keys
     EnvVarMapping("TELEGRAM_BOT_TOKEN", "telegram_token"),
     EnvVarMapping("OPENROUTER_API_KEY", "openrouter_api_key"),
+    EnvVarMapping(
+        "MAILGUN_WEBHOOK_SIGNING_KEY", "email_intake.mailgun_webhook_signing_key"
+    ),
     EnvVarMapping("GEMINI_API_KEY", "gemini_api_key"),
     EnvVarMapping("WILLYWEATHER_API_KEY", "willyweather_api_key"),
     EnvVarMapping("WILLYWEATHER_LOCATION_ID", "willyweather_location_id", int),

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -539,6 +539,17 @@ class TestApplyEnvVarOverrides:
             apply_env_var_overrides(config)
         assert config["otel"]["traces_sample_rate"] == 0.25
 
+    def test_applies_mailgun_webhook_signing_key_env_var(self) -> None:
+        """Test applying MAILGUN_WEBHOOK_SIGNING_KEY env var."""
+        config: dict[str, Any] = {"email_intake": {}}
+        with mock.patch.dict(
+            os.environ, {"MAILGUN_WEBHOOK_SIGNING_KEY": "test-signing-key"}, clear=False
+        ):
+            apply_env_var_overrides(config)
+        assert (
+            config["email_intake"]["mailgun_webhook_signing_key"] == "test-signing-key"
+        )
+
 
 class TestApplyCalendarEnvVars:
     """Tests for apply_calendar_env_vars function."""


### PR DESCRIPTION
## Summary
Added support for configuring the Mailgun webhook signing key via the `MAILGUN_WEBHOOK_SIGNING_KEY` environment variable, allowing users to avoid hardcoding sensitive credentials in `config.yaml`.

## Key Changes
- Added `MAILGUN_WEBHOOK_SIGNING_KEY` environment variable mapping in `config_loader.py` that maps to `email_intake.mailgun_webhook_signing_key` config path
- Added unit test to verify the environment variable override is correctly applied to the config
- Updated `AGENTS.md` documentation with instructions for using the new environment variable, including where to find the key in the Mailgun dashboard

## Implementation Details
- The environment variable mapping follows the existing pattern used for other sensitive credentials (e.g., `TELEGRAM_BOT_TOKEN`, `OPENROUTER_API_KEY`)
- The mapping supports nested config paths using dot notation (`email_intake.mailgun_webhook_signing_key`)
- Documentation includes the Mailgun dashboard location (Sending → Webhooks) for users to find their signing key

https://claude.ai/code/session_01Gkbqd2a34w8Dcqc498PECt