### PR TITLE
Implement local DKIM/SPF/DMARC verification for inbound email

### DIFF
--- a/alembic/versions/2026_04_21-add_email_auth_results.py
+++ b/alembic/versions/2026_04_21-add_email_auth_results.py
@@ -1,0 +1,59 @@
+"""Add DKIM/SPF/DMARC verification results to received_emails.
+
+Revision ID: add_email_auth_results
+Revises: add_confirmation_requests
+Create Date: 2026-04-21
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "add_email_auth_results"
+down_revision: str | None = "add_confirmation_requests"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "received_emails",
+        sa.Column("dkim_result", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "received_emails",
+        sa.Column("spf_result", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "received_emails",
+        sa.Column("dmarc_result", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "received_emails",
+        sa.Column("dmarc_policy", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "received_emails",
+        sa.Column("dkim_domain", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_received_emails_dmarc_result"),
+        "received_emails",
+        ["dmarc_result"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_received_emails_dmarc_result"),
+        table_name="received_emails",
+    )
+    op.drop_column("received_emails", "dkim_domain")
+    op.drop_column("received_emails", "dmarc_policy")
+    op.drop_column("received_emails", "dmarc_result")
+    op.drop_column("received_emails", "spf_result")
+    op.drop_column("received_emails", "dkim_result")

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -233,6 +233,11 @@ notes_config:
 # Optional controls for the /webhook/mail Mailgun receiving webhook. By default
 # these are permissive to preserve existing indexing-only deployments; configure
 # them before enabling assistant actions from inbound email.
+#
+# Sender authentication (DKIM and DMARC) is performed locally against the raw MIME
+# forwarded by Mailgun. The Mailgun route action must therefore use the MIME-type
+# forwarding option (e.g. `forward('https://.../webhook/mail', 'mime')`) so the
+# webhook body includes a `body-mime` field containing the raw RFC 822 message.
 email_intake:
   # Mailgun webhook signing key. When set, timestamp/token/signature fields are required.
   mailgun_webhook_signing_key: null
@@ -241,10 +246,9 @@ email_intake:
   allowed_sender_addresses: []
   # Recipient addresses are the Mailgun inbound addresses/aliases this app should accept.
   allowed_recipient_addresses: []
-  # Require DMARC/SPF/DKIM checks reported by Mailgun/authentication headers.
+  # Require DMARC pass (aligned DKIM or SPF) before accepting an email. When enabled,
+  # Mailgun must be configured to forward raw MIME (see comment above).
   require_authenticated_sender: false
-  require_dmarc_pass: true
-  allow_spf_or_dkim_fallback_when_dmarc_missing: false
   # Require accepted emails to resolve to exactly one configured application user.
   require_user_mapping: false
   # Map authorized forwarding senders and/or Mailgun inbound aliases to app users.

--- a/docs/design/local-email-authentication.md
+++ b/docs/design/local-email-authentication.md
@@ -1,0 +1,132 @@
+# Local DKIM/SPF/DMARC Verification for Inbound Email
+
+## Status
+
+Proposed / In Progress (April 2026).
+
+Replaces the Mailgun-header-based email authentication checks previously described in
+[Secure Email Intake Actions](secure-email-intake-actions.md).
+
+## Background
+
+The inbound email webhook (`POST /webhook/mail`) previously trusted Mailgun's parsed
+`dmarc`/`spf`/`dkim` form fields and the `Authentication-Results` header embedded in
+`message-headers` to decide whether a sender was authenticated. In practice Mailgun does not
+reliably populate these fields, so messages that should fail DMARC can slip past as "missing" rather
+than "fail" and any strict policy either lets everything through or rejects everything.
+
+## Goals
+
+- Verify DKIM signatures cryptographically against DNS-published public keys.
+- Evaluate DMARC policy for the visible `From:` domain using DNS.
+- Make the verification deterministic and testable without live DNS.
+- Drop the dependency on Mailgun-emitted authentication results.
+- Preserve existing allowlisting, user-mapping, and indexing behaviour.
+
+## Non-Goals
+
+- Implementing our own DKIM/ARC/DMARC from scratch — use maintained libraries.
+- Performing live DNS lookups during the HTTP request path in tests — inject a resolver.
+- Replacing Mailgun for message delivery; only the authentication evaluation moves in-house.
+- Fully featured SPF semantics. We support SPF opportunistically via `authheaders` when a client IP
+  is discoverable from `Received` headers, but DMARC can pass on aligned DKIM alone.
+
+## Mailgun Configuration Change
+
+Mailgun must be configured to forward the raw RFC 822 message. This is done by using the "forward to
+URL" route action with the **MIME-type forwarding option** (or by calling the Mailgun routes API
+with `action = "forward('https://.../webhook/mail', 'mime')"`). With this option the webhook body
+includes a `body-mime` multipart field containing the original raw MIME bytes. Without `body-mime`
+we cannot verify DKIM.
+
+The migration procedure is:
+
+1. Update Mailgun routes to include the MIME-type forwarding option.
+2. Deploy this change (the code tolerates both, logging a warning if `body-mime` is missing).
+3. Once the warning is no longer observed, enable `require_authenticated_sender`.
+
+## Implementation
+
+### Dependencies
+
+- `dkimpy` — DKIM signature verification (pure Python, permits an injectable DNS resolver).
+- `authheaders` — wrapper that runs DKIM + SPF + DMARC and returns a structured result.
+- `pyspf` — SPF evaluation used by `authheaders`.
+- `dnspython` — DNS lookups (already a transitive dependency but declared explicitly).
+
+### New module: `src/family_assistant/email_intake/authentication.py`
+
+Provides:
+
+- `EmailAuthenticationResult` dataclass with `dkim`, `spf`, `dmarc` fields (each a normalised
+  string: `"pass"`, `"fail"`, `"none"`, `"neutral"`, `"temperror"`, `"permerror"`). Includes
+  `dmarc_aligned_with_from` and details for logging.
+- `verify_email_authentication(raw_mime, *, envelope_from, client_ip, helo, dns_resolver=None)` runs
+  DKIM and DMARC on the supplied raw MIME bytes. SPF is run only when a client IP is available.
+- `DnsResolver` protocol so tests can inject a fake resolver (maps `(name, rdtype)` to TXT records).
+
+### Updated module: `src/family_assistant/email_intake/security.py`
+
+- The old `SenderAuthentication` dataclass and `extract_sender_authentication` helper (which read
+  Mailgun form fields / `Authentication-Results`) are removed.
+- `verify_sender_authorization(form_data, config, *, raw_mime=None, dns_resolver=None)` now
+  evaluates DMARC locally by delegating to `verify_email_authentication` when
+  `require_authenticated_sender` is set.
+- A new `extract_raw_mime(form_data)` helper pulls the raw message bytes out of the `body-mime` form
+  field (handling `str`/`bytes` surrogateescape conversion).
+- The old config options `require_dmarc_pass` and `allow_spf_or_dkim_fallback_when_dmarc_missing`
+  are removed; if `require_authenticated_sender` is set we require a DMARC `pass` (aligned DKIM or
+  aligned SPF) and otherwise we skip verification.
+
+### Updated webhook handler: `src/family_assistant/web/routers/webhooks.py`
+
+- After `verify_mailgun_signature`, read `body-mime` from the form.
+- If absent and `require_authenticated_sender` is set, return HTTP 401 with a clear error that names
+  the missing field.
+- If absent and authentication is not required, log a warning and skip verification (preserves
+  indexing-only deployments).
+- Pass the raw MIME bytes to `verify_sender_authorization` and `resolve_target_user_id`.
+
+### Client IP / envelope-from extraction
+
+- `envelope_from` is Mailgun's `sender` form field.
+- `client_ip` and `helo` come from the topmost third-party `Received` header in the raw MIME (i.e.
+  the `Received` added by Mailgun, which records the peer SMTP client). The
+  `email_intake.authentication` helper parses this with regex but prefers the Mailgun-provided
+  `X-Mailgun-Sending-Ip` / `X-Envelope-From` headers when present.
+
+### Storage
+
+Add columns to `received_emails` to preserve the verification outcome:
+
+- `dkim_result TEXT NULL`
+- `spf_result TEXT NULL`
+- `dmarc_result TEXT NULL`
+- `auth_details_json JSONB NULL`
+
+Alembic migration: `2026_04_21-add_email_auth_results.py`.
+
+### Tests
+
+Rewrite `tests/functional/web/api/test_mail_webhook_security.py` to build real DKIM-signed messages
+using `dkimpy.sign` with a test RSA key, and inject a fake DNS resolver that serves the matching
+`selector._domainkey.<domain>` record. DMARC is tested via matching `_dmarc.<domain>` records. A
+small helper in `tests/mocks/email_auth.py` provides `build_signed_message(...)` and
+`FakeDnsResolver`.
+
+The test matrix covers:
+
+- DKIM-signed, DMARC-aligned message → accepted.
+- DKIM signature invalid (body tampered) → rejected.
+- DMARC policy missing → rejected when authentication required.
+- DMARC aligned via SPF only (no DKIM) → accepted when client IP matches SPF record.
+- Missing `body-mime` with `require_authenticated_sender` → rejected with a helpful error.
+- Missing `body-mime` without `require_authenticated_sender` → accepted (indexing path preserved,
+  rejection logged).
+
+## Rollout
+
+1. Merge the library change with `require_authenticated_sender: false` (default).
+2. Update Mailgun routes to forward MIME.
+3. Observe logs for "missing body-mime" warnings; once they stop, flip
+   `require_authenticated_sender: true` in deployment config.

--- a/docs/operations/CONFIGURATION_REFERENCE.md
+++ b/docs/operations/CONFIGURATION_REFERENCE.md
@@ -154,8 +154,6 @@ email_intake:
     - "assistant+bob@mg.example.com"
 
   require_authenticated_sender: true
-  require_dmarc_pass: true
-  allow_spf_or_dkim_fallback_when_dmarc_missing: false
 
   require_user_mapping: true
   user_mappings:
@@ -271,17 +269,20 @@ be set.
 
 ### Sender Authentication Policy
 
-`require_authenticated_sender` makes the webhook require sender authentication results reported by
-Mailgun or by the message `Authentication-Results` header. With the default strict policy,
-`require_dmarc_pass: true`, DMARC must pass. DMARC failure always fails closed. Set
-`allow_spf_or_dkim_fallback_when_dmarc_missing: true` only if you accept SPF or DKIM pass when DMARC
-is absent.
+`require_authenticated_sender` makes the webhook require a DMARC `pass` result that the app computes
+locally from the raw MIME message. The app verifies DKIM signatures and evaluates DMARC alignment
+with [`authheaders`](https://pypi.org/project/authheaders/) and
+[`dkimpy`](https://pypi.org/project/dkimpy/); it no longer trusts Mailgun's `dmarc`, `SPF`, or
+`Dkim` form fields or the embedded `Authentication-Results` header.
 
-| Option                                          | Default | Recommended |
-| ----------------------------------------------- | ------- | ----------- |
-| `require_authenticated_sender`                  | `false` | `true`      |
-| `require_dmarc_pass`                            | `true`  | `true`      |
-| `allow_spf_or_dkim_fallback_when_dmarc_missing` | `false` | `false`     |
+Because local DKIM verification needs the byte-exact raw message, Mailgun routes must be configured
+to forward the MIME payload rather than the parsed representation (`forward('url', 'mime')`). The
+webhook reads the raw message from the `body-mime` form field. When `require_authenticated_sender`
+is true, requests without `body-mime` fail closed with `401`. DMARC failures always fail closed.
+
+| Option                         | Default | Recommended |
+| ------------------------------ | ------- | ----------- |
+| `require_authenticated_sender` | `false` | `true`      |
 
 If `require_authenticated_sender` is true, the Mailgun signing key must also be set.
 

--- a/docs/operations/CONFIGURATION_REFERENCE.md
+++ b/docs/operations/CONFIGURATION_REFERENCE.md
@@ -275,10 +275,14 @@ with [`authheaders`](https://pypi.org/project/authheaders/) and
 [`dkimpy`](https://pypi.org/project/dkimpy/); it no longer trusts Mailgun's `dmarc`, `SPF`, or
 `Dkim` form fields or the embedded `Authentication-Results` header.
 
-Because local DKIM verification needs the byte-exact raw message, Mailgun routes must be configured
-to forward the MIME payload rather than the parsed representation (`forward('url', 'mime')`). The
-webhook reads the raw message from the `body-mime` form field. When `require_authenticated_sender`
-is true, requests without `body-mime` fail closed with `401`. DMARC failures always fail closed.
+Because local DKIM verification needs the byte-exact raw message, Mailgun must be configured to
+forward the MIME payload rather than the parsed representation. Mailgun only includes the raw
+message in the `body-mime` form field when the route's Destination URL path ends in `mime` or
+`raw-mime`; otherwise it sends parsed `body-plain`/`body-html` fields instead. The app therefore
+exposes the same webhook at both `/webhook/mail` and `/webhook/mail/mime`. Point the Mailgun route
+at the `/webhook/mail/mime` URL so Mailgun triggers raw-MIME forwarding. When
+`require_authenticated_sender` is true, requests without `body-mime` fail closed with `401`. DMARC
+failures always fail closed.
 
 | Option                         | Default | Recommended |
 | ------------------------------ | ------- | ----------- |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,10 @@ dependencies = [
     "opentelemetry-instrumentation-sqlalchemy>=0.46b0",
     "opentelemetry-instrumentation-logging>=0.46b0",
     "aiomqtt>=2.5.1",
+    "dkimpy>=1.1.8",
+    "authheaders>=0.16.3",
+    "pyspf>=2.0.14",
+    "dnspython>=2.8.0",
 ]
 
 [project.optional-dependencies]

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -597,7 +597,13 @@ class EmailIntakeUserMapping(BaseModel):
 
 
 class EmailIntakeConfig(BaseModel):
-    """Security controls for inbound email webhooks."""
+    """Security controls for inbound email webhooks.
+
+    DKIM and DMARC are always evaluated locally against the raw MIME message that
+    Mailgun forwards in the ``body-mime`` form field. When
+    :attr:`require_authenticated_sender` is set, DMARC pass (aligned DKIM or SPF) is
+    required before an email is accepted.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -606,8 +612,6 @@ class EmailIntakeConfig(BaseModel):
     allowed_sender_addresses: list[str] = Field(default_factory=list)
     allowed_recipient_addresses: list[str] = Field(default_factory=list)
     require_authenticated_sender: bool = False
-    require_dmarc_pass: bool = True
-    allow_spf_or_dkim_fallback_when_dmarc_missing: bool = False
     require_user_mapping: bool = False
     user_mappings: list[EmailIntakeUserMapping] = Field(default_factory=list)
     max_raw_request_bytes: int = Field(default=25 * 1024 * 1024, gt=0)

--- a/src/family_assistant/email_intake/authentication.py
+++ b/src/family_assistant/email_intake/authentication.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
+from email.parser import BytesHeaderParser
 from email.utils import getaddresses, parseaddr
 from typing import TYPE_CHECKING, Protocol
 
@@ -141,20 +142,21 @@ def extract_from_domain(raw_mime: bytes) -> str | None:
 
 
 def extract_client_ip(raw_mime: bytes) -> str | None:
-    """Extract the peer SMTP client IP from Mailgun-provided inbound headers.
+    """Extract the peer SMTP client IP from trusted inbound headers.
 
-    Prefers the ``X-Mailgun-Sending-Ip``/``X-Envelope-From`` headers Mailgun adds to
-    forwarded MIME. Falls back to the topmost ``Received:`` header, extracting the
-    ``from ... (ip)`` portion.
+    Prefers the ``X-Mailgun-Sending-Ip`` header Mailgun adds to forwarded MIME.
+    Falls back to parsing the topmost ``Received:`` header, which is the hop
+    Mailgun itself recorded (i.e. the peer SMTP client). Does not trust
+    ``X-Forwarded-For`` or other attacker-controllable headers that can appear
+    in inbound email and would allow SPF spoofing if used.
     """
     headers = _parse_headers(raw_mime)
 
-    for header_name in ("x-mailgun-sending-ip", "x-forwarded-for"):
-        value = headers.get(header_name)
-        if value:
-            match = _IP_PATTERN.search(value)
-            if match:
-                return match.group(0)
+    value = headers.get("x-mailgun-sending-ip")
+    if value:
+        match = _IP_PATTERN.search(value)
+        if match:
+            return match.group(0)
 
     received_values = _all_headers(raw_mime, "received")
     for value in received_values:
@@ -186,43 +188,21 @@ def _all_headers(raw_mime: bytes, name: str) -> list[str]:
     ]
 
 
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
 def _header_pairs(raw_mime: bytes) -> list[tuple[str, str]]:
     """Parse the header block into ``(name, value)`` pairs without touching the body."""
-    try:
-        text = raw_mime.decode("utf-8", errors="replace")
-    except AttributeError:
+    if not isinstance(raw_mime, (bytes, bytearray)):
         return []
-    separator = _header_body_split(text)
-    header_block = text[:separator]
-    pairs: list[tuple[str, str]] = []
-    current_name: str | None = None
-    current_value: list[str] = []
-    for line in header_block.splitlines():
-        if not line:
-            continue
-        if line[0] in {" ", "\t"} and current_name is not None:
-            current_value.append(line.strip())
-            continue
-        if current_name is not None:
-            pairs.append((current_name, " ".join(current_value).strip()))
-        name_part, _, value_part = line.partition(":")
-        if not _:
-            current_name = None
-            current_value = []
-            continue
-        current_name = name_part.strip()
-        current_value = [value_part.strip()]
-    if current_name is not None:
-        pairs.append((current_name, " ".join(current_value).strip()))
-    return pairs
-
-
-def _header_body_split(text: str) -> int:
-    for marker in ("\r\n\r\n", "\n\n"):
-        idx = text.find(marker)
-        if idx != -1:
-            return idx
-    return len(text)
+    try:
+        msg = BytesHeaderParser().parsebytes(raw_mime)
+    except Exception:
+        return []
+    return [
+        (name, _WHITESPACE_RE.sub(" ", str(value)).strip())
+        for name, value in msg.items()
+    ]
 
 
 def _from_addresses(raw_mime: bytes) -> list[str]:

--- a/src/family_assistant/email_intake/authentication.py
+++ b/src/family_assistant/email_intake/authentication.py
@@ -144,23 +144,32 @@ def extract_from_domain(raw_mime: bytes) -> str | None:
 def extract_client_ip(raw_mime: bytes) -> str | None:
     """Extract the peer SMTP client IP from trusted inbound headers.
 
-    Prefers the ``X-Mailgun-Sending-Ip`` header Mailgun adds to forwarded MIME.
-    Falls back to parsing the topmost ``Received:`` header, which is the hop
-    Mailgun itself recorded (i.e. the peer SMTP client). Does not trust
-    ``X-Forwarded-For`` or other attacker-controllable headers that can appear
-    in inbound email and would allow SPF spoofing if used.
-    """
-    headers = _parse_headers(raw_mime)
+    Mailgun prepends ``X-Mailgun-Sending-Ip`` and a ``Received:`` trace line to
+    every forwarded message, so the *first* value of each header (in header
+    order) is the one Mailgun added and therefore trusted. An attacker can
+    stamp duplicates of either header inside the original message they sent,
+    so we must only look at the topmost occurrence:
 
-    value = headers.get("x-mailgun-sending-ip")
-    if value:
-        match = _IP_PATTERN.search(value)
+    * Picking a later ``X-Mailgun-Sending-Ip`` duplicate would let an attacker
+      override the SPF client IP with an address covered by the spoofed
+      sender's SPF record.
+    * Falling through past the topmost ``Received:`` header to an older hop
+      would let an attacker supply their own parseable ``Received:`` line to
+      influence SPF if Mailgun's trace line was not parseable for any reason.
+
+    We therefore fail closed on the topmost ``Received:`` header: if its IP
+    cannot be parsed we return ``None`` rather than trust an older hop. Also
+    never trusts ``X-Forwarded-For`` or other attacker-controllable headers.
+    """
+    mailgun_values = _all_headers(raw_mime, "x-mailgun-sending-ip")
+    if mailgun_values:
+        match = _IP_PATTERN.search(mailgun_values[0])
         if match:
             return match.group(0)
 
     received_values = _all_headers(raw_mime, "received")
-    for value in received_values:
-        match = _RECEIVED_IP_PATTERN.search(value)
+    if received_values:
+        match = _RECEIVED_IP_PATTERN.search(received_values[0])
         if match:
             return match.group(1)
     return None
@@ -170,14 +179,6 @@ _IP_PATTERN = re.compile(
     r"\b(?:\d{1,3}\.){3}\d{1,3}\b|\b[0-9a-fA-F:]{2,}:[0-9a-fA-F:]*\b"
 )
 _RECEIVED_IP_PATTERN = re.compile(r"\[((?:\d{1,3}\.){3}\d{1,3}|[0-9a-fA-F:]+)\]")
-
-
-def _parse_headers(raw_mime: bytes) -> dict[str, str]:
-    """Return a case-insensitive dict of headers (last value wins)."""
-    headers: dict[str, str] = {}
-    for name, value in _header_pairs(raw_mime):
-        headers[name.lower()] = value
-    return headers
 
 
 def _all_headers(raw_mime: bytes, name: str) -> list[str]:

--- a/src/family_assistant/email_intake/authentication.py
+++ b/src/family_assistant/email_intake/authentication.py
@@ -1,0 +1,264 @@
+"""Local DKIM/SPF/DMARC verification for inbound email webhooks.
+
+Replaces the previous scheme of trusting Mailgun's parsed `dmarc`/`spf`/`dkim` form fields
+and the `Authentication-Results` header. DKIM signatures are verified cryptographically
+against DNS-published public keys and DMARC policy is evaluated locally.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from email.utils import getaddresses, parseaddr
+from typing import TYPE_CHECKING, Protocol
+
+from authheaders import check_dkim, check_dmarc, check_spf
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class DnsResolver(Protocol):
+    """Resolve a TXT record for a domain name.
+
+    Returns the TXT record value as a string (e.g. ``"v=DMARC1; p=reject"``) or ``None``
+    when no record exists. The resolver must handle both lowercased and original-case
+    domain names.
+    """
+
+    def __call__(self, name: str) -> str | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EmailAuthenticationResult:
+    """Normalised authentication result for an inbound email."""
+
+    dkim: str
+    """DKIM verification: ``"pass"``, ``"fail"``, ``"none"``, ``"temperror"``, ``"permerror"``."""
+
+    spf: str
+    """SPF verification using envelope sender + client IP. ``"none"`` when not evaluated."""
+
+    dmarc: str
+    """DMARC evaluation: combines DKIM/SPF alignment against the From: domain."""
+
+    dmarc_policy: str
+    """DMARC policy published by the From: domain (``"none"``/``"quarantine"``/``"reject"``)."""
+
+    from_domain: str
+    """Domain extracted from the ``From:`` header."""
+
+    dkim_domain: str
+    """Domain advertised in the verified DKIM signature (``d=`` tag). Empty if no DKIM."""
+
+    details: str
+    """Free-form details for logging (DMARC comment, SPF reason, etc.)."""
+
+    @property
+    def dmarc_passed(self) -> bool:
+        return self.dmarc == "pass"
+
+    @property
+    def dkim_passed(self) -> bool:
+        return self.dkim == "pass"
+
+    @property
+    def spf_passed(self) -> bool:
+        return self.spf == "pass"
+
+
+def verify_email_authentication(
+    raw_mime: bytes,
+    *,
+    envelope_from: str | None = None,
+    client_ip: str | None = None,
+    helo: str | None = None,
+    dns_resolver: DnsResolver | None = None,
+) -> EmailAuthenticationResult:
+    """Verify DKIM, SPF, and DMARC for a raw RFC 822 message.
+
+    Args:
+        raw_mime: The raw MIME message bytes, exactly as received upstream. DKIM hashing
+            is byte-sensitive, so callers must avoid re-encoding the message.
+        envelope_from: SMTP ``MAIL FROM`` address (typically ``form["sender"]`` from Mailgun).
+            Required for SPF evaluation.
+        client_ip: IP address of the peer SMTP client, if known. Required for SPF
+            evaluation. When ``None`` or missing, SPF is reported as ``"none"``.
+        helo: SMTP ``HELO``/``EHLO`` name, if known. Falls back to the envelope domain.
+        dns_resolver: Optional injectable DNS resolver, used in tests. In production the
+            underlying libraries query real DNS.
+
+    Returns:
+        :class:`EmailAuthenticationResult` with normalised statuses.
+    """
+    dkim_dnsfunc, dmarc_dnsfunc = _adapt_dns_resolver(dns_resolver)
+
+    dkim_result = check_dkim(raw_mime, dnsfunc=dkim_dnsfunc)
+
+    spf_result = None
+    spf_status = "none"
+    if client_ip and envelope_from:
+        effective_helo = helo or _domain_of(envelope_from) or envelope_from
+        try:
+            spf_result = check_spf(client_ip, envelope_from, effective_helo)
+        except Exception as exc:
+            logger.warning("SPF evaluation error for %s: %s", envelope_from, exc)
+            spf_result = None
+        else:
+            spf_status = spf_result.result or "none"
+
+    dmarc_result = check_dmarc(
+        raw_mime,
+        spf_result=spf_result,
+        dkim_result=dkim_result,
+        dnsfunc=dmarc_dnsfunc,
+    )
+
+    dkim_status = dkim_result.result or "none"
+    dmarc_status = dmarc_result.result or "none"
+
+    return EmailAuthenticationResult(
+        dkim=dkim_status,
+        spf=spf_status,
+        dmarc=dmarc_status,
+        dmarc_policy=getattr(dmarc_result, "policy", "") or "",
+        from_domain=getattr(dmarc_result, "header_from", "") or "",
+        dkim_domain=getattr(dkim_result, "header_d", "") or "",
+        details=str(getattr(dmarc_result, "result_comment", "") or ""),
+    )
+
+
+def extract_from_domain(raw_mime: bytes) -> str | None:
+    """Return the domain portion of the RFC 5322 ``From:`` header, lowercased."""
+    from_addresses = _from_addresses(raw_mime)
+    if not from_addresses:
+        return None
+    domain = _domain_of(from_addresses[0])
+    return domain.lower() if domain else None
+
+
+def extract_client_ip(raw_mime: bytes) -> str | None:
+    """Extract the peer SMTP client IP from Mailgun-provided inbound headers.
+
+    Prefers the ``X-Mailgun-Sending-Ip``/``X-Envelope-From`` headers Mailgun adds to
+    forwarded MIME. Falls back to the topmost ``Received:`` header, extracting the
+    ``from ... (ip)`` portion.
+    """
+    headers = _parse_headers(raw_mime)
+
+    for header_name in ("x-mailgun-sending-ip", "x-forwarded-for"):
+        value = headers.get(header_name)
+        if value:
+            match = _IP_PATTERN.search(value)
+            if match:
+                return match.group(0)
+
+    received_values = _all_headers(raw_mime, "received")
+    for value in received_values:
+        match = _RECEIVED_IP_PATTERN.search(value)
+        if match:
+            return match.group(1)
+    return None
+
+
+_IP_PATTERN = re.compile(
+    r"\b(?:\d{1,3}\.){3}\d{1,3}\b|\b[0-9a-fA-F:]{2,}:[0-9a-fA-F:]*\b"
+)
+_RECEIVED_IP_PATTERN = re.compile(r"\[((?:\d{1,3}\.){3}\d{1,3}|[0-9a-fA-F:]+)\]")
+
+
+def _parse_headers(raw_mime: bytes) -> dict[str, str]:
+    """Return a case-insensitive dict of headers (last value wins)."""
+    headers: dict[str, str] = {}
+    for name, value in _header_pairs(raw_mime):
+        headers[name.lower()] = value
+    return headers
+
+
+def _all_headers(raw_mime: bytes, name: str) -> list[str]:
+    """Return every value for a header name, in order of appearance."""
+    target = name.lower()
+    return [
+        value for hname, value in _header_pairs(raw_mime) if hname.lower() == target
+    ]
+
+
+def _header_pairs(raw_mime: bytes) -> list[tuple[str, str]]:
+    """Parse the header block into ``(name, value)`` pairs without touching the body."""
+    try:
+        text = raw_mime.decode("utf-8", errors="replace")
+    except AttributeError:
+        return []
+    separator = _header_body_split(text)
+    header_block = text[:separator]
+    pairs: list[tuple[str, str]] = []
+    current_name: str | None = None
+    current_value: list[str] = []
+    for line in header_block.splitlines():
+        if not line:
+            continue
+        if line[0] in {" ", "\t"} and current_name is not None:
+            current_value.append(line.strip())
+            continue
+        if current_name is not None:
+            pairs.append((current_name, " ".join(current_value).strip()))
+        name_part, _, value_part = line.partition(":")
+        if not _:
+            current_name = None
+            current_value = []
+            continue
+        current_name = name_part.strip()
+        current_value = [value_part.strip()]
+    if current_name is not None:
+        pairs.append((current_name, " ".join(current_value).strip()))
+    return pairs
+
+
+def _header_body_split(text: str) -> int:
+    for marker in ("\r\n\r\n", "\n\n"):
+        idx = text.find(marker)
+        if idx != -1:
+            return idx
+    return len(text)
+
+
+def _from_addresses(raw_mime: bytes) -> list[str]:
+    values = _all_headers(raw_mime, "from")
+    addresses: list[str] = []
+    for value in values:
+        for _, addr in getaddresses([value]):
+            if addr:
+                addresses.append(addr)
+    return addresses
+
+
+def _domain_of(address: str) -> str | None:
+    _, parsed = parseaddr(address)
+    if "@" not in parsed:
+        return None
+    return parsed.split("@", 1)[1].strip().lower() or None
+
+
+def _adapt_dns_resolver(
+    dns_resolver: DnsResolver | None,
+) -> tuple[Callable[..., bytes | None] | None, Callable[..., str | None] | None]:
+    if dns_resolver is None:
+        return None, None
+
+    def dkim_dnsfunc(name: bytes, timeout: int = 5) -> bytes | None:
+        # dkimpy passes bytes names; authheaders expects str.
+        lookup = (
+            name.decode("ascii", errors="replace") if isinstance(name, bytes) else name
+        )
+        value = dns_resolver(lookup)
+        if value is None:
+            return None
+        return value.encode("ascii", errors="replace")
+
+    def dmarc_dnsfunc(name: str, *_args: object, **_kwargs: object) -> str | None:
+        return dns_resolver(name)
+
+    return dkim_dnsfunc, dmarc_dnsfunc

--- a/src/family_assistant/email_intake/security.py
+++ b/src/family_assistant/email_intake/security.py
@@ -1,19 +1,33 @@
-"""Security checks for inbound Mailgun email webhooks."""
+"""Security checks for inbound Mailgun email webhooks.
+
+Sender authentication (DKIM/SPF/DMARC) is performed locally against the raw MIME
+body forwarded by Mailgun. The legacy scheme of trusting Mailgun-populated form fields
+is no longer supported because Mailgun does not reliably populate them. See
+:mod:`family_assistant.email_intake.authentication` for the verification implementation.
+"""
 
 from __future__ import annotations
 
 import hashlib
 import hmac
-import json
+import logging
 import time
-from dataclasses import dataclass
 from email.utils import parseaddr
 from typing import TYPE_CHECKING
+
+from family_assistant.email_intake.authentication import (
+    DnsResolver,
+    EmailAuthenticationResult,
+    extract_client_ip,
+    verify_email_authentication,
+)
 
 if TYPE_CHECKING:
     from starlette.datastructures import FormData
 
     from family_assistant.config_models import EmailIntakeConfig
+
+logger = logging.getLogger(__name__)
 
 
 class EmailIntakeSecurityError(ValueError):
@@ -22,30 +36,6 @@ class EmailIntakeSecurityError(ValueError):
 
 class EmailIntakePayloadTooLargeError(EmailIntakeSecurityError):
     """Raised when an inbound email webhook exceeds configured size limits."""
-
-
-@dataclass(frozen=True, slots=True)
-class SenderAuthentication:
-    """Normalized sender authentication results from Mailgun/form headers."""
-
-    dmarc: str | None
-    spf: str | None
-    dkim: str | None
-
-    @property
-    def dmarc_passed(self) -> bool:
-        """Return whether DMARC passed."""
-        return _is_pass(self.dmarc)
-
-    @property
-    def spf_passed(self) -> bool:
-        """Return whether SPF passed."""
-        return _is_pass(self.spf)
-
-    @property
-    def dkim_passed(self) -> bool:
-        """Return whether DKIM passed."""
-        return _is_pass(self.dkim)
 
 
 def enforce_raw_request_size(raw_body: bytes, config: EmailIntakeConfig) -> None:
@@ -106,8 +96,14 @@ def verify_mailgun_signature(
 def verify_sender_authorization(
     form_data: FormData,
     config: EmailIntakeConfig,
-) -> None:
-    """Verify sender/recipient allowlists and sender authentication policy."""
+    *,
+    raw_mime: bytes | None = None,
+    dns_resolver: DnsResolver | None = None,
+) -> EmailAuthenticationResult | None:
+    """Verify sender/recipient allowlists and (when required) DKIM/DMARC authentication.
+
+    Returns the authentication result when authentication was evaluated, else ``None``.
+    """
     sender = normalize_email_address(_string_field(form_data, "sender"))
     if config.allowed_sender_addresses:
         allowed_senders = {
@@ -129,25 +125,35 @@ def verify_sender_authorization(
             raise EmailIntakeSecurityError(msg)
 
     if not config.require_authenticated_sender:
-        return
+        if raw_mime is None:
+            return None
+        return _evaluate_authentication(
+            raw_mime=raw_mime,
+            envelope_from=sender,
+            dns_resolver=dns_resolver,
+        )
 
-    authentication = extract_sender_authentication(form_data)
-    if authentication.dmarc_passed:
-        return
-
-    if authentication.dmarc is not None or config.require_dmarc_pass:
-        msg = "Sender authentication failed DMARC policy"
+    if raw_mime is None:
+        msg = (
+            "Sender authentication is required but the Mailgun webhook did not "
+            "include the raw MIME message (body-mime). Configure the Mailgun route "
+            "to forward the full MIME message."
+        )
         raise EmailIntakeSecurityError(msg)
 
-    if (
-        config.allow_spf_or_dkim_fallback_when_dmarc_missing
-        and authentication.dmarc is None
-        and (authentication.spf_passed or authentication.dkim_passed)
-    ):
-        return
-
-    msg = "Sender authentication did not meet the configured policy"
-    raise EmailIntakeSecurityError(msg)
+    authentication = _evaluate_authentication(
+        raw_mime=raw_mime,
+        envelope_from=sender,
+        dns_resolver=dns_resolver,
+    )
+    if not authentication.dmarc_passed:
+        msg = (
+            "Sender authentication failed DMARC policy "
+            f"(dkim={authentication.dkim}, spf={authentication.spf}, "
+            f"dmarc={authentication.dmarc})"
+        )
+        raise EmailIntakeSecurityError(msg)
+    return authentication
 
 
 def resolve_target_user_id(
@@ -211,34 +217,41 @@ def normalize_email_address(raw_address: str | None) -> str | None:
     return normalized or None
 
 
-def extract_sender_authentication(form_data: FormData) -> SenderAuthentication:
-    """Extract DMARC/SPF/DKIM results from Mailgun fields or Authentication-Results."""
-    authentication_results = _string_field(form_data, "Authentication-Results")
-    if authentication_results is None:
-        authentication_results = _string_field(form_data, "authentication-results")
-    if authentication_results is None:
-        authentication_results = _message_header_value(
-            form_data, "Authentication-Results"
-        )
+def extract_raw_mime(form_data: FormData) -> bytes | None:
+    """Return the raw MIME message bytes from a Mailgun webhook, if present.
 
-    return SenderAuthentication(
-        dmarc=_coalesce_auth_result(
-            _string_field(form_data, "dmarc"),
-            _string_field(form_data, "DMARC"),
-            _string_field(form_data, "Dmarc"),
-            _extract_authentication_results_value(authentication_results, "dmarc"),
-        ),
-        spf=_coalesce_auth_result(
-            _string_field(form_data, "spf"),
-            _string_field(form_data, "SPF"),
-            _extract_authentication_results_value(authentication_results, "spf"),
-        ),
-        dkim=_coalesce_auth_result(
-            _string_field(form_data, "dkim"),
-            _string_field(form_data, "Dkim"),
-            _string_field(form_data, "DKIM"),
-            _extract_authentication_results_value(authentication_results, "dkim"),
-        ),
+    Mailgun includes the raw RFC 822 message in ``body-mime`` when the inbound route
+    is configured with the MIME-type forwarding option (``forward('url', 'mime')``).
+    Without this configuration we cannot cryptographically verify DKIM signatures.
+    """
+    value = form_data.get("body-mime")
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.encode("utf-8", errors="surrogateescape")
+    # Starlette UploadFile — not expected for this field, but handle defensively.
+    read = getattr(value, "read", None)
+    if callable(read):
+        data = read()
+        if isinstance(data, bytes):
+            return data
+    return None
+
+
+def _evaluate_authentication(
+    *,
+    raw_mime: bytes,
+    envelope_from: str | None,
+    dns_resolver: DnsResolver | None,
+) -> EmailAuthenticationResult:
+    client_ip = extract_client_ip(raw_mime)
+    return verify_email_authentication(
+        raw_mime,
+        envelope_from=envelope_from,
+        client_ip=client_ip,
+        dns_resolver=dns_resolver,
     )
 
 
@@ -259,57 +272,6 @@ def _requires_verified_mailgun(config: EmailIntakeConfig) -> bool:
         or config.require_user_mapping
         or config.user_mappings
     )
-
-
-def _coalesce_auth_result(*values: str | None) -> str | None:
-    for value in values:
-        if value is not None:
-            return value.lower()
-    return None
-
-
-def _extract_authentication_results_value(
-    authentication_results: str | None,
-    mechanism: str,
-) -> str | None:
-    if authentication_results is None:
-        return None
-
-    mechanism_prefix = f"{mechanism.lower()}="
-    for raw_token in authentication_results.replace(";", " ").split():
-        token = raw_token.strip().lower()
-        if token.startswith(mechanism_prefix):
-            return token.removeprefix(mechanism_prefix)
-    return None
-
-
-def _message_header_value(form_data: FormData, header_name: str) -> str | None:
-    headers_raw = _string_field(form_data, "message-headers")
-    if headers_raw is None:
-        return None
-
-    try:
-        parsed_headers = json.loads(headers_raw)
-    except json.JSONDecodeError:
-        return None
-
-    if not isinstance(parsed_headers, list):
-        return None
-
-    normalized_header_name = header_name.lower()
-    for header in parsed_headers:
-        if not isinstance(header, list) or len(header) < 2:
-            continue
-        raw_name, raw_value = header[0], header[1]
-        if not isinstance(raw_name, str):
-            continue
-        if raw_name.lower() == normalized_header_name and isinstance(raw_value, str):
-            return raw_value
-    return None
-
-
-def _is_pass(value: str | None) -> bool:
-    return value is not None and value.lower() in {"pass", "passed", "true", "yes"}
 
 
 def get_security_fields(

--- a/src/family_assistant/email_intake/security.py
+++ b/src/family_assistant/email_intake/security.py
@@ -128,11 +128,19 @@ def verify_sender_authorization(
     if not config.require_authenticated_sender:
         if raw_mime is None:
             return None
-        return _evaluate_authentication(
-            raw_mime=raw_mime,
-            envelope_from=sender,
-            dns_resolver=dns_resolver,
-        )
+        try:
+            return _evaluate_authentication(
+                raw_mime=raw_mime,
+                envelope_from=sender,
+                dns_resolver=dns_resolver,
+            )
+        except Exception:
+            logger.warning(
+                "Permissive inbound email authentication evaluation failed; "
+                "accepting message without auth telemetry",
+                exc_info=True,
+            )
+            return None
 
     if raw_mime is None:
         msg = (

--- a/src/family_assistant/email_intake/security.py
+++ b/src/family_assistant/email_intake/security.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import inspect
 import logging
 import time
 from email.utils import parseaddr
@@ -217,12 +218,16 @@ def normalize_email_address(raw_address: str | None) -> str | None:
     return normalized or None
 
 
-def extract_raw_mime(form_data: FormData) -> bytes | None:
+async def extract_raw_mime(form_data: FormData) -> bytes | None:
     """Return the raw MIME message bytes from a Mailgun webhook, if present.
 
     Mailgun includes the raw RFC 822 message in ``body-mime`` when the inbound route
     is configured with the MIME-type forwarding option (``forward('url', 'mime')``).
     Without this configuration we cannot cryptographically verify DKIM signatures.
+
+    Starlette parses large form fields as ``UploadFile`` objects whose ``read()`` is
+    an awaitable coroutine; we await it to avoid silently returning ``None`` and
+    causing authentication to fail for large emails.
     """
     value = form_data.get("body-mime")
     if value is None:
@@ -231,12 +236,15 @@ def extract_raw_mime(form_data: FormData) -> bytes | None:
         return value
     if isinstance(value, str):
         return value.encode("utf-8", errors="surrogateescape")
-    # Starlette UploadFile — not expected for this field, but handle defensively.
     read = getattr(value, "read", None)
     if callable(read):
         data = read()
+        if inspect.isawaitable(data):
+            data = await data
         if isinstance(data, bytes):
             return data
+        if isinstance(data, str):
+            return data.encode("utf-8", errors="surrogateescape")
     return None
 
 

--- a/src/family_assistant/storage/email.py
+++ b/src/family_assistant/storage/email.py
@@ -51,6 +51,11 @@ class ParsedEmailData(BaseModel):
     mailgun_timestamp: str | None = Field(default=None, alias="timestamp")
     mailgun_token: str | None = Field(default=None, alias="token")
     target_user_id: str | None = None
+    dkim_result: str | None = None
+    spf_result: str | None = None
+    dmarc_result: str | None = None
+    dmarc_policy: str | None = None
+    dkim_domain: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -107,6 +112,12 @@ received_emails_table = sa.Table(
     sa.Column(
         "target_user_id", sa.Text, nullable=True, index=True
     ),  # Resolved application user for action-capable intake
+    # --- Local DKIM/SPF/DMARC verification results ---
+    sa.Column("dkim_result", sa.Text, nullable=True),
+    sa.Column("spf_result", sa.Text, nullable=True),
+    sa.Column("dmarc_result", sa.Text, nullable=True, index=True),
+    sa.Column("dmarc_policy", sa.Text, nullable=True),
+    sa.Column("dkim_domain", sa.Text, nullable=True),
     # --- Indexing Task Tracking ---
     sa.Column(
         "indexing_task_id", sa.String, nullable=True, index=True, unique=True

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -127,7 +127,7 @@ async def handle_mail_webhook(
             signature=signature,
             config=email_intake_config,
         )
-        raw_mime = extract_raw_mime(form_data)
+        raw_mime = await extract_raw_mime(form_data)
         if raw_mime is None and not email_intake_config.require_authenticated_sender:
             logger.warning(
                 "Inbound email webhook did not include body-mime; DKIM/DMARC "

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -20,6 +20,7 @@ from family_assistant.email_intake.security import (
     EmailIntakeSecurityError,
     enforce_attachment_size_limits,
     enforce_raw_request_size,
+    extract_raw_mime,
     get_security_fields,
     resolve_target_user_id,
     verify_mailgun_signature,
@@ -126,7 +127,30 @@ async def handle_mail_webhook(
             signature=signature,
             config=email_intake_config,
         )
-        verify_sender_authorization(form_data, email_intake_config)
+        raw_mime = extract_raw_mime(form_data)
+        if raw_mime is None and not email_intake_config.require_authenticated_sender:
+            logger.warning(
+                "Inbound email webhook did not include body-mime; DKIM/DMARC "
+                "verification skipped. Configure the Mailgun route to use MIME "
+                "forwarding before enabling require_authenticated_sender."
+            )
+        dns_resolver = getattr(request.app.state, "email_intake_dns_resolver", None)
+        authentication = verify_sender_authorization(
+            form_data,
+            email_intake_config,
+            raw_mime=raw_mime,
+            dns_resolver=dns_resolver,
+        )
+        if authentication is not None:
+            logger.info(
+                "Inbound email authentication: dkim=%s spf=%s dmarc=%s "
+                "from_domain=%s dkim_domain=%s",
+                authentication.dkim,
+                authentication.spf,
+                authentication.dmarc,
+                authentication.from_domain,
+                authentication.dkim_domain,
+            )
         target_user_id = resolve_target_user_id(form_data, email_intake_config)
         await _save_raw_mail_webhook(
             raw_body_content=raw_body_content,
@@ -255,6 +279,11 @@ async def handle_mail_webhook(
                 processed_attachments if processed_attachments else None
             ),  # Override
             target_user_id=target_user_id,
+            dkim_result=authentication.dkim if authentication else None,
+            spf_result=authentication.spf if authentication else None,
+            dmarc_result=authentication.dmarc if authentication else None,
+            dmarc_policy=authentication.dmarc_policy if authentication else None,
+            dkim_domain=authentication.dkim_domain if authentication else None,
         )
 
         # Pass the Pydantic model instance to the storage function

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -71,6 +71,7 @@ async def _save_raw_mail_webhook(
 
 
 @webhooks_router.post("/webhook/mail")
+@webhooks_router.post("/webhook/mail/mime")
 async def handle_mail_webhook(
     request: Request,
     db_context: Annotated[DatabaseContext, Depends(get_db)],
@@ -78,6 +79,11 @@ async def handle_mail_webhook(
     """
     Receives incoming email via webhook (expects multipart/form-data from Mailgun),
     parses it, saves attachments, and passes structured data to the storage layer.
+
+    Mailgun only includes the raw RFC 822 message in the ``body-mime`` form field when
+    the route's Destination URL path ends in ``mime`` or ``raw-mime``. The alias route
+    ``/webhook/mail/mime`` exists so operators can point Mailgun at a URL that satisfies
+    that suffix requirement without renaming the legacy ``/webhook/mail`` path.
     """
     logger.info("Received POST request on /webhook/mail")
 

--- a/tests/functional/telegram/helpers.py
+++ b/tests/functional/telegram/helpers.py
@@ -115,8 +115,8 @@ async def assert_bot_sent_message_with_keyboard(
     updates = await wait_for_bot_response(client, timeout)
 
     for update in updates:
-        message = update.get("message", {})
-        reply_markup = message.get("reply_markup", {})
+        message = update.get("message") or {}
+        reply_markup = message.get("reply_markup") or {}
         if reply_markup.get("inline_keyboard"):
             return update
 

--- a/tests/functional/web/api/test_mail_webhook_security.py
+++ b/tests/functional/web/api/test_mail_webhook_security.py
@@ -494,6 +494,47 @@ async def test_mail_webhook_rejects_unsigned_message_when_dmarc_required(
 
 
 @pytest.mark.asyncio
+@pytest.mark.postgres
+async def test_mail_webhook_swallows_permissive_auth_errors(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Fail-open telemetry: DNS/library errors during permissive evaluation must not 5xx.
+
+    With ``require_authenticated_sender=False`` the webhook evaluates DKIM/DMARC only
+    for telemetry, so operators can observe the result before flipping enforcement on.
+    An unreachable DNS resolver or a crash inside ``authheaders`` must not bubble up
+    and reject messages that would otherwise have been accepted.
+    """
+
+    def raising_resolver(_: str) -> str | None:
+        msg = "DNS unavailable"
+        raise RuntimeError(msg)
+
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(mailgun_webhook_signing_key=SIGNING_KEY),
+        dns_resolver=FakeDnsResolver(),
+    )
+    monkeypatch.setattr(
+        fastapi_app.state,
+        "email_intake_dns_resolver",
+        raising_resolver,
+        raising=False,
+    )
+    form = _mailgun_form()
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 200, response.text
+    assert await _email_exists(db_engine, form["Message-Id"])
+    assert await _email_dmarc_result(db_engine, form["Message-Id"]) is None
+
+
+@pytest.mark.asyncio
 async def test_mail_webhook_rejects_missing_body_mime_when_auth_required(
     api_client: httpx.AsyncClient,
     db_engine: AsyncEngine,

--- a/tests/functional/web/api/test_mail_webhook_security.py
+++ b/tests/functional/web/api/test_mail_webhook_security.py
@@ -14,6 +14,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 import pytest
+from authheaders import SPFAuthenticationResult
 from sqlalchemy import select
 
 from family_assistant.config_models import (
@@ -431,6 +432,80 @@ async def test_mail_webhook_rejects_ambiguous_user_mapping(
     assert response.status_code == 401
     assert "maps to multiple users" in response.text
     assert not await _email_exists(db_engine, form["Message-Id"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres
+async def test_mail_webhook_passes_dmarc_via_spf_alignment(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Covers the SPF-only DMARC alignment path.
+
+    A message without DKIM still passes DMARC when SPF passes and the envelope
+    sender domain aligns with the From: domain. We need ``extract_client_ip`` to
+    pull the trusted IP from the Mailgun-added ``X-Mailgun-Sending-Ip`` header
+    and feed it into SPF, then ``check_dmarc`` must propagate the aligned SPF
+    pass to the overall DMARC result. Previously this path had no coverage
+    because every test message omitted ``X-Mailgun-Sending-Ip``/``Received:``,
+    so ``client_ip`` was always ``None`` and SPF evaluation was skipped.
+    """
+    client_ip = "203.0.113.7"
+    message_id = f"<spf-only-{uuid.uuid4()}@example.com>"
+    raw = (
+        f"X-Mailgun-Sending-Ip: {client_ip}\r\n"
+        f"From: {SENDER}\r\n"
+        f"To: {RECIPIENT}\r\n"
+        "Subject: SPF-only DMARC alignment\r\n"
+        "Date: Mon, 21 Apr 2026 12:00:00 +0000\r\n"
+        f"Message-ID: {message_id}\r\n"
+        "\r\n"
+        "body\r\n"
+    ).encode()
+
+    observed: dict[str, object] = {}
+
+    def fake_check_spf(ip: str, mail_from: str, helo: str) -> SPFAuthenticationResult:
+        observed["ip"] = ip
+        observed["mail_from"] = mail_from
+        observed["helo"] = helo
+        return SPFAuthenticationResult(
+            result="pass",
+            reason="test fixture",
+            smtp_mailfrom=mail_from,
+            smtp_helo=helo,
+        )
+
+    monkeypatch.setattr(
+        "family_assistant.email_intake.authentication.check_spf",
+        fake_check_spf,
+    )
+
+    dns = FakeDnsResolver({
+        f"_dmarc.{SENDER_DOMAIN}": "v=DMARC1; p=reject; adkim=s; aspf=s",
+    })
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            mailgun_webhook_signing_key=SIGNING_KEY,
+            require_authenticated_sender=True,
+        ),
+        dns_resolver=dns,
+    )
+    form = _mailgun_form(raw_mime=raw, message_id=message_id)
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 200, response.text
+    assert observed == {
+        "ip": client_ip,
+        "mail_from": SENDER,
+        "helo": SENDER_DOMAIN,
+    }
+    assert await _email_dmarc_result(db_engine, message_id) == "pass"
 
 
 @pytest.mark.asyncio

--- a/tests/functional/web/api/test_mail_webhook_security.py
+++ b/tests/functional/web/api/test_mail_webhook_security.py
@@ -205,6 +205,40 @@ async def test_mail_webhook_accepts_signed_authorized_authenticated_sender(
 
 
 @pytest.mark.asyncio
+@pytest.mark.postgres
+async def test_mail_webhook_mime_alias_accepts_same_payload(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The ``/webhook/mail/mime`` alias exists so Mailgun forwards raw MIME.
+
+    Mailgun only populates the ``body-mime`` form field when the destination URL
+    path ends in ``mime`` or ``raw-mime``. We expose the same handler at both
+    ``/webhook/mail`` and ``/webhook/mail/mime`` so operators can migrate by
+    swapping the Destination in Mailgun without changing the legacy path.
+    """
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            mailgun_webhook_signing_key=SIGNING_KEY,
+            allowed_sender_addresses=[SENDER],
+            allowed_recipient_addresses=[RECIPIENT],
+            require_authenticated_sender=True,
+        ),
+    )
+    form = _mailgun_form()
+
+    response = await api_client.post("/webhook/mail/mime", data=form)
+
+    assert response.status_code == 200, response.text
+    assert await _email_exists(db_engine, form["Message-Id"])
+    assert await _email_dmarc_result(db_engine, form["Message-Id"]) == "pass"
+
+
+@pytest.mark.asyncio
 async def test_mail_webhook_rejects_invalid_mailgun_signature(
     api_client: httpx.AsyncClient,
     db_engine: AsyncEngine,

--- a/tests/functional/web/api/test_mail_webhook_security.py
+++ b/tests/functional/web/api/test_mail_webhook_security.py
@@ -1,4 +1,9 @@
-"""Functional tests for inbound Mailgun email webhook security checks."""
+"""Functional tests for inbound Mailgun email webhook security checks.
+
+Authentication (DKIM/SPF/DMARC) is evaluated locally against the raw MIME that Mailgun
+forwards in the ``body-mime`` field. A fake in-memory DNS resolver is injected via
+``app.state.email_intake_dns_resolver`` so the tests do not rely on real DNS.
+"""
 
 from __future__ import annotations
 
@@ -19,12 +24,23 @@ from family_assistant.config_models import (
 from family_assistant.storage.context import DatabaseContext
 from family_assistant.storage.email import received_emails_table
 from family_assistant.web.app_creator import app as fastapi_app
+from tests.mocks.email_auth import (
+    FakeDnsResolver,
+    build_dns_for,
+    build_signed_message,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     import httpx
     from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+SIGNING_KEY = "mailgun-test-key"
+SENDER = "buyer@example.com"
+RECIPIENT = "orders@example.net"
+SENDER_DOMAIN = "example.com"
 
 
 def _signature(timestamp: str, token: str, signing_key: str) -> str:
@@ -37,14 +53,15 @@ def _signature(timestamp: str, token: str, signing_key: str) -> str:
 
 def _mailgun_form(
     *,
-    sender: str = "buyer@example.com",
-    recipient: str = "orders@example.net",
-    dmarc: str | None = "pass",
-    spf: str | None = "pass",
-    dkim: str | None = "pass",
-    signing_key: str | None = "mailgun-test-key",
+    sender: str = SENDER,
+    recipient: str = RECIPIENT,
+    signing_key: str | None = SIGNING_KEY,
     signature: str | None = None,
     message_id: str | None = None,
+    include_body_mime: bool = True,
+    raw_mime: bytes | None = None,
+    subject: str = "Order confirmation",
+    from_header: str | None = None,
 ) -> dict[str, str]:
     timestamp = str(int(time.time()))
     token = f"token-{uuid.uuid4().hex}"
@@ -54,27 +71,36 @@ def _mailgun_form(
         else (_signature(timestamp, token, signing_key) if signing_key else "")
     )
 
+    resolved_message_id = message_id or f"<mailgun-security-{uuid.uuid4()}@example.com>"
+    resolved_from = from_header or f"Buyer <{sender}>"
+
     form = {
-        "subject": "Order confirmation",
+        "subject": subject,
         "stripped-text": "Your order ABC-123 is confirmed for pickup tomorrow.",
         "sender": sender,
         "recipient": recipient,
-        "Message-Id": message_id or f"<mailgun-security-{uuid.uuid4()}@example.com>",
-        "From": f"Buyer <{sender}>",
+        "Message-Id": resolved_message_id,
+        "From": resolved_from,
         "To": f"Orders <{recipient}>",
         "timestamp": timestamp,
         "token": token,
         "signature": resolved_signature,
         "message-headers": (
-            f'[["From", "Buyer <{sender}>"], ["To", "Orders <{recipient}>"]]'
+            f'[["From", "{resolved_from}"], ["To", "Orders <{recipient}>"]]'
         ),
     }
-    if dmarc is not None:
-        form["dmarc"] = dmarc
-    if spf is not None:
-        form["SPF"] = spf
-    if dkim is not None:
-        form["Dkim"] = dkim
+    if include_body_mime:
+        mime = (
+            raw_mime
+            if raw_mime is not None
+            else build_signed_message(
+                from_address=sender,
+                to_address=recipient,
+                subject=subject,
+                message_id=resolved_message_id,
+            )
+        )
+        form["body-mime"] = mime.decode("utf-8", errors="surrogateescape")
     return form
 
 
@@ -82,6 +108,8 @@ def _configure_email_intake(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     email_intake: EmailIntakeConfig,
+    *,
+    dns_resolver: FakeDnsResolver | None = None,
 ) -> None:
     monkeypatch.setattr(
         fastapi_app.state,
@@ -91,6 +119,14 @@ def _configure_email_intake(
             mailbox_raw_dir=str(tmp_path / "raw"),
             email_intake=email_intake,
         ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        fastapi_app.state,
+        "email_intake_dns_resolver",
+        dns_resolver
+        if dns_resolver is not None
+        else build_dns_for(domain=SENDER_DOMAIN),
         raising=False,
     )
 
@@ -115,6 +151,16 @@ async def _email_target_user_id(engine: AsyncEngine, message_id: str) -> str | N
     return row["target_user_id"] if row else None
 
 
+async def _email_dmarc_result(engine: AsyncEngine, message_id: str) -> str | None:
+    async with DatabaseContext(engine=engine) as db_context:
+        row = await db_context.fetch_one(
+            select(received_emails_table.c.dmarc_result).where(
+                received_emails_table.c.message_id_header == message_id
+            )
+        )
+    return row["dmarc_result"] if row else None
+
+
 def _raw_mail_files(tmp_path: Path) -> list[Path]:
     raw_dir = tmp_path / "raw"
     if not raw_dir.exists():
@@ -134,15 +180,15 @@ async def test_mail_webhook_accepts_signed_authorized_authenticated_sender(
         monkeypatch,
         tmp_path,
         EmailIntakeConfig(
-            mailgun_webhook_signing_key="mailgun-test-key",
-            allowed_sender_addresses=["buyer@example.com"],
-            allowed_recipient_addresses=["orders@example.net"],
+            mailgun_webhook_signing_key=SIGNING_KEY,
+            allowed_sender_addresses=[SENDER],
+            allowed_recipient_addresses=[RECIPIENT],
             require_authenticated_sender=True,
             require_user_mapping=True,
             user_mappings=[
                 EmailIntakeUserMapping(
                     user_id="alice",
-                    sender_addresses={"buyer@example.com"},
+                    sender_addresses={SENDER},
                 )
             ],
         ),
@@ -154,6 +200,7 @@ async def test_mail_webhook_accepts_signed_authorized_authenticated_sender(
     assert response.status_code == 200, response.text
     assert await _email_exists(db_engine, form["Message-Id"])
     assert await _email_target_user_id(db_engine, form["Message-Id"]) == "alice"
+    assert await _email_dmarc_result(db_engine, form["Message-Id"]) == "pass"
     assert _raw_mail_files(tmp_path)
 
 
@@ -167,7 +214,7 @@ async def test_mail_webhook_rejects_invalid_mailgun_signature(
     _configure_email_intake(
         monkeypatch,
         tmp_path,
-        EmailIntakeConfig(mailgun_webhook_signing_key="mailgun-test-key"),
+        EmailIntakeConfig(mailgun_webhook_signing_key=SIGNING_KEY),
     )
     form = _mailgun_form(signature="not-a-valid-signature")
 
@@ -189,7 +236,7 @@ async def test_mail_webhook_rejects_policy_without_mailgun_signature_configurati
     _configure_email_intake(
         monkeypatch,
         tmp_path,
-        EmailIntakeConfig(allowed_sender_addresses=["buyer@example.com"]),
+        EmailIntakeConfig(allowed_sender_addresses=[SENDER]),
     )
     form = _mailgun_form(signing_key=None)
 
@@ -216,7 +263,7 @@ async def test_mail_webhook_rejects_user_mapping_without_mailgun_signature_confi
             user_mappings=[
                 EmailIntakeUserMapping(
                     user_id="alice",
-                    sender_addresses={"buyer@example.com"},
+                    sender_addresses={SENDER},
                 )
             ],
         ),
@@ -242,7 +289,7 @@ async def test_mail_webhook_rejects_unlisted_sender(
         monkeypatch,
         tmp_path,
         EmailIntakeConfig(
-            mailgun_webhook_signing_key="mailgun-test-key",
+            mailgun_webhook_signing_key=SIGNING_KEY,
             allowed_sender_addresses=["authorized@example.com"],
         ),
     )
@@ -268,8 +315,8 @@ async def test_mail_webhook_maps_recipient_alias_to_target_user(
         monkeypatch,
         tmp_path,
         EmailIntakeConfig(
-            mailgun_webhook_signing_key="mailgun-test-key",
-            allowed_sender_addresses=["buyer@example.com"],
+            mailgun_webhook_signing_key=SIGNING_KEY,
+            allowed_sender_addresses=[SENDER],
             allowed_recipient_addresses=["assistant+alice@mg.example.com"],
             require_user_mapping=True,
             user_mappings=[
@@ -299,7 +346,7 @@ async def test_mail_webhook_rejects_unmapped_user_when_mapping_required(
         monkeypatch,
         tmp_path,
         EmailIntakeConfig(
-            mailgun_webhook_signing_key="mailgun-test-key",
+            mailgun_webhook_signing_key=SIGNING_KEY,
             require_user_mapping=True,
             user_mappings=[
                 EmailIntakeUserMapping(
@@ -309,7 +356,7 @@ async def test_mail_webhook_rejects_unmapped_user_when_mapping_required(
             ],
         ),
     )
-    form = _mailgun_form(sender="buyer@example.com")
+    form = _mailgun_form(sender=SENDER)
 
     response = await api_client.post("/webhook/mail", data=form)
 
@@ -329,12 +376,12 @@ async def test_mail_webhook_rejects_ambiguous_user_mapping(
         monkeypatch,
         tmp_path,
         EmailIntakeConfig(
-            mailgun_webhook_signing_key="mailgun-test-key",
+            mailgun_webhook_signing_key=SIGNING_KEY,
             require_user_mapping=True,
             user_mappings=[
                 EmailIntakeUserMapping(
                     user_id="alice",
-                    sender_addresses={"buyer@example.com"},
+                    sender_addresses={SENDER},
                 ),
                 EmailIntakeUserMapping(
                     user_id="bob",
@@ -353,7 +400,7 @@ async def test_mail_webhook_rejects_ambiguous_user_mapping(
 
 
 @pytest.mark.asyncio
-async def test_mail_webhook_rejects_dmarc_failure_even_when_spf_passes(
+async def test_mail_webhook_rejects_tampered_dkim_signature(
     api_client: httpx.AsyncClient,
     db_engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
@@ -363,11 +410,14 @@ async def test_mail_webhook_rejects_dmarc_failure_even_when_spf_passes(
         monkeypatch,
         tmp_path,
         EmailIntakeConfig(
-            mailgun_webhook_signing_key="mailgun-test-key",
+            mailgun_webhook_signing_key=SIGNING_KEY,
             require_authenticated_sender=True,
         ),
     )
-    form = _mailgun_form(dmarc="fail", spf="pass", dkim="fail")
+    tampered = build_signed_message(from_address=SENDER).replace(
+        b"Your order is confirmed.", b"Evil payload."
+    )
+    form = _mailgun_form(raw_mime=tampered)
 
     response = await api_client.post("/webhook/mail", data=form)
 
@@ -377,8 +427,7 @@ async def test_mail_webhook_rejects_dmarc_failure_even_when_spf_passes(
 
 
 @pytest.mark.asyncio
-@pytest.mark.postgres
-async def test_mail_webhook_accepts_authentication_results_from_message_headers(
+async def test_mail_webhook_rejects_unsigned_message_when_dmarc_required(
     api_client: httpx.AsyncClient,
     db_engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
@@ -388,24 +437,55 @@ async def test_mail_webhook_accepts_authentication_results_from_message_headers(
         monkeypatch,
         tmp_path,
         EmailIntakeConfig(
-            mailgun_webhook_signing_key="mailgun-test-key",
+            mailgun_webhook_signing_key=SIGNING_KEY,
             require_authenticated_sender=True,
         ),
     )
-    form = _mailgun_form(dmarc=None, spf=None, dkim=None)
-    form["message-headers"] = (
-        '[["Authentication-Results", "mx.example.net; dmarc=pass spf=pass dkim=pass"]]'
+    unsigned = (
+        b"From: buyer@example.com\r\n"
+        b"To: orders@example.net\r\n"
+        b"Subject: Plain\r\n"
+        b"Date: Mon, 21 Apr 2026 12:00:00 +0000\r\n"
+        b"Message-ID: <plain@example.com>\r\n"
+        b"\r\n"
+        b"Plain body\r\n"
     )
+    form = _mailgun_form(raw_mime=unsigned)
 
     response = await api_client.post("/webhook/mail", data=form)
 
-    assert response.status_code == 200, response.text
-    assert await _email_exists(db_engine, form["Message-Id"])
+    assert response.status_code == 401
+    assert "DMARC" in response.text
+    assert not await _email_exists(db_engine, form["Message-Id"])
+
+
+@pytest.mark.asyncio
+async def test_mail_webhook_rejects_missing_body_mime_when_auth_required(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            mailgun_webhook_signing_key=SIGNING_KEY,
+            require_authenticated_sender=True,
+        ),
+    )
+    form = _mailgun_form(include_body_mime=False)
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 401
+    assert "body-mime" in response.text
+    assert not await _email_exists(db_engine, form["Message-Id"])
 
 
 @pytest.mark.asyncio
 @pytest.mark.postgres
-async def test_mail_webhook_accepts_explicit_spf_fallback_when_dmarc_missing(
+async def test_mail_webhook_accepts_missing_body_mime_without_auth_required(
     api_client: httpx.AsyncClient,
     db_engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,
@@ -414,19 +494,47 @@ async def test_mail_webhook_accepts_explicit_spf_fallback_when_dmarc_missing(
     _configure_email_intake(
         monkeypatch,
         tmp_path,
-        EmailIntakeConfig(
-            mailgun_webhook_signing_key="mailgun-test-key",
-            require_authenticated_sender=True,
-            require_dmarc_pass=False,
-            allow_spf_or_dkim_fallback_when_dmarc_missing=True,
-        ),
+        EmailIntakeConfig(mailgun_webhook_signing_key=SIGNING_KEY),
     )
-    form = _mailgun_form(dmarc=None, spf="pass", dkim="fail")
+    form = _mailgun_form(include_body_mime=False)
 
     response = await api_client.post("/webhook/mail", data=form)
 
     assert response.status_code == 200, response.text
     assert await _email_exists(db_engine, form["Message-Id"])
+    assert await _email_dmarc_result(db_engine, form["Message-Id"]) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres
+async def test_mail_webhook_rejects_from_domain_without_dmarc_policy(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dns = FakeDnsResolver({
+        # DKIM key for a domain with no DMARC record.
+        f"test._domainkey.{SENDER_DOMAIN}": build_dns_for(
+            domain=SENDER_DOMAIN
+        )._records[f"test._domainkey.{SENDER_DOMAIN}"],
+    })
+    _configure_email_intake(
+        monkeypatch,
+        tmp_path,
+        EmailIntakeConfig(
+            mailgun_webhook_signing_key=SIGNING_KEY,
+            require_authenticated_sender=True,
+        ),
+        dns_resolver=dns,
+    )
+    form = _mailgun_form()
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 401
+    assert "DMARC" in response.text
+    assert not await _email_exists(db_engine, form["Message-Id"])
 
 
 @pytest.mark.asyncio
@@ -441,7 +549,7 @@ async def test_mail_webhook_rejects_oversized_raw_payload(
         tmp_path,
         EmailIntakeConfig(max_raw_request_bytes=512),
     )
-    form = _mailgun_form(signing_key=None)
+    form = _mailgun_form(signing_key=None, include_body_mime=False)
     form["stripped-text"] = "x" * 2048
 
     response = await api_client.post("/webhook/mail", data=form)
@@ -484,7 +592,7 @@ async def test_mail_webhook_rejects_oversized_attachment(
         tmp_path,
         EmailIntakeConfig(max_attachment_bytes=3),
     )
-    form = _mailgun_form(signing_key=None)
+    form = _mailgun_form(signing_key=None, include_body_mime=False)
     form["attachment-count"] = "1"
 
     response = await api_client.post(

--- a/tests/mocks/email_auth.py
+++ b/tests/mocks/email_auth.py
@@ -1,0 +1,131 @@
+"""Helpers for building DKIM-signed MIME messages and fake DNS resolvers in tests."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from functools import lru_cache
+
+import dkim
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@dataclass(frozen=True, slots=True)
+class TestKeyPair:
+    """An RSA key pair usable for DKIM signing and a DKIM TXT record value."""
+
+    private_pem: bytes
+    public_b64: str
+
+    @property
+    def dkim_record(self) -> str:
+        return f"v=DKIM1; k=rsa; p={self.public_b64}"
+
+
+@lru_cache(maxsize=1)
+def default_test_key() -> TestKeyPair:
+    """Return a cached 2048-bit RSA key pair for test signing."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_der = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    public_b64 = base64.b64encode(public_der).decode("ascii")
+    return TestKeyPair(private_pem=private_pem, public_b64=public_b64)
+
+
+class FakeDnsResolver:
+    """In-memory DNS resolver. Maps domain names to TXT record values."""
+
+    def __init__(self, records: dict[str, str] | None = None) -> None:
+        self._records: dict[str, str] = {}
+        if records:
+            for name, value in records.items():
+                self.add(name, value)
+
+    def add(self, name: str, value: str) -> None:
+        self._records[name.lower().rstrip(".")] = value
+
+    def __call__(self, name: str) -> str | None:
+        return self._records.get(name.lower().rstrip("."))
+
+
+def build_signed_message(
+    *,
+    from_address: str = "alice@example.com",
+    to_address: str = "orders@example.net",
+    subject: str = "Order confirmation",
+    body: str = "Your order is confirmed.",
+    message_id: str | None = None,
+    date: str = "Mon, 21 Apr 2026 12:00:00 +0000",
+    domain: str | None = None,
+    selector: str = "test",
+    key_pair: TestKeyPair | None = None,
+    extra_headers: list[tuple[str, str]] | None = None,
+) -> bytes:
+    """Build a DKIM-signed RFC 822 message.
+
+    Signs over the common headers (From, To, Subject, Date, Message-ID) using simple
+    canonicalization compatible with dkimpy's verifier.
+    """
+    if key_pair is None:
+        key_pair = default_test_key()
+    if domain is None:
+        domain = from_address.split("@", 1)[1]
+    if message_id is None:
+        message_id = f"<test-{abs(hash((from_address, subject, body)))}@{domain}>"
+
+    lines = [
+        f"From: {from_address}",
+        f"To: {to_address}",
+        f"Subject: {subject}",
+        f"Date: {date}",
+        f"Message-ID: {message_id}",
+        "MIME-Version: 1.0",
+        "Content-Type: text/plain; charset=UTF-8",
+    ]
+    if extra_headers:
+        for name, value in extra_headers:
+            lines.append(f"{name}: {value}")
+    lines.append("")
+    lines.append(body)
+    lines.append("")
+
+    raw = "\r\n".join(lines).encode("utf-8")
+
+    signature = dkim.sign(
+        message=raw,
+        selector=selector.encode("ascii"),
+        domain=domain.encode("ascii"),
+        privkey=key_pair.private_pem,
+        include_headers=[b"From", b"To", b"Subject", b"Date", b"Message-ID"],
+    )
+    return signature + raw
+
+
+def build_dns_for(
+    *,
+    domain: str = "example.com",
+    selector: str = "test",
+    dmarc_policy: str = "reject",
+    dmarc_adkim: str = "r",
+    dmarc_aspf: str = "r",
+    key_pair: TestKeyPair | None = None,
+) -> FakeDnsResolver:
+    """Build a :class:`FakeDnsResolver` with DKIM and DMARC records for ``domain``."""
+    if key_pair is None:
+        key_pair = default_test_key()
+
+    records = {
+        f"{selector}._domainkey.{domain}": key_pair.dkim_record,
+        f"_dmarc.{domain}": (
+            f"v=DMARC1; p={dmarc_policy}; adkim={dmarc_adkim}; aspf={dmarc_aspf}"
+        ),
+    }
+    return FakeDnsResolver(records)

--- a/tests/unit/test_email_authentication.py
+++ b/tests/unit/test_email_authentication.py
@@ -65,3 +65,63 @@ def test_extract_client_ip_returns_none_when_no_sources() -> None:
     raw = b"From: buyer@example.com\r\n\r\nbody\r\n"
 
     assert extract_client_ip(raw) is None
+
+
+def test_extract_client_ip_uses_first_x_mailgun_sending_ip_header() -> None:
+    """A forged duplicate ``X-Mailgun-Sending-Ip`` must not override the trusted one.
+
+    Mailgun prepends its own ``X-Mailgun-Sending-Ip`` to every forwarded message,
+    so the first value in header order is the one Mailgun added. An attacker can
+    stamp their own duplicate further down in the original message; using a
+    last-value-wins lookup would let that duplicate choose the SPF client IP.
+    """
+    raw = (
+        b"X-Mailgun-Sending-Ip: 203.0.113.7\r\n"
+        b"X-Mailgun-Sending-Ip: 192.0.2.50\r\n"
+        b"From: attacker@example.com\r\n"
+        b"\r\n"
+        b"body\r\n"
+    )
+
+    assert extract_client_ip(raw) == "203.0.113.7"
+
+
+def test_extract_client_ip_only_trusts_topmost_received_hop() -> None:
+    """Older ``Received:`` hops are attacker-influenced and must not leak through.
+
+    Mailgun's own ``Received:`` trace line is prepended to the header block, so
+    only the first ``Received:`` in header order is trusted. Iterating past the
+    topmost hop to find a parseable IP would let an attacker stamp their own
+    ``Received:`` further down to influence SPF.
+    """
+    raw = (
+        b"Received: from mail.example.com ([198.51.100.10])\r\n"
+        b"\tby mx.mailgun.net with ESMTP; Mon, 21 Apr 2026 12:00:00 +0000\r\n"
+        b"Received: from evil.example.com ([192.0.2.50])\r\n"
+        b"\tby unknown with SMTP; Sun, 20 Apr 2026 10:00:00 +0000\r\n"
+        b"From: attacker@example.com\r\n"
+        b"\r\n"
+        b"body\r\n"
+    )
+
+    assert extract_client_ip(raw) == "198.51.100.10"
+
+
+def test_extract_client_ip_fails_closed_on_unparseable_topmost_received() -> None:
+    """If the topmost Received header has no parseable IP, return None.
+
+    Don't fall through to older, attacker-controlled ``Received:`` lines. Failing
+    closed forces SPF to be reported as ``none`` rather than deriving the client
+    IP from an untrusted hop.
+    """
+    raw = (
+        b"Received: from mail.example.com by mx.mailgun.net with ESMTP\r\n"
+        b"\tMon, 21 Apr 2026 12:00:00 +0000\r\n"
+        b"Received: from evil.example.com ([192.0.2.50])\r\n"
+        b"\tby unknown with SMTP; Sun, 20 Apr 2026 10:00:00 +0000\r\n"
+        b"From: attacker@example.com\r\n"
+        b"\r\n"
+        b"body\r\n"
+    )
+
+    assert extract_client_ip(raw) is None

--- a/tests/unit/test_email_authentication.py
+++ b/tests/unit/test_email_authentication.py
@@ -1,0 +1,67 @@
+"""Unit tests for email authentication helpers.
+
+Focuses on the header parsing paths used for client-IP extraction: we must not
+trust attacker-controllable headers like ``X-Forwarded-For`` because that would
+let a spoofed inbound email influence SPF evaluation.
+"""
+
+from __future__ import annotations
+
+from family_assistant.email_intake.authentication import extract_client_ip
+
+
+def test_extract_client_ip_prefers_x_mailgun_sending_ip() -> None:
+    raw = (
+        b"Received: from mail.example.com ([198.51.100.10])\r\n"
+        b"\tby mx.mailgun.net with ESMTP; Mon, 21 Apr 2026 12:00:00 +0000\r\n"
+        b"X-Mailgun-Sending-Ip: 203.0.113.7\r\n"
+        b"From: buyer@example.com\r\n"
+        b"\r\n"
+        b"body\r\n"
+    )
+
+    assert extract_client_ip(raw) == "203.0.113.7"
+
+
+def test_extract_client_ip_falls_back_to_received_header() -> None:
+    raw = (
+        b"Received: from mail.example.com ([198.51.100.10])\r\n"
+        b"\tby mx.mailgun.net with ESMTP; Mon, 21 Apr 2026 12:00:00 +0000\r\n"
+        b"From: buyer@example.com\r\n"
+        b"\r\n"
+        b"body\r\n"
+    )
+
+    assert extract_client_ip(raw) == "198.51.100.10"
+
+
+def test_extract_client_ip_ignores_forged_x_forwarded_for() -> None:
+    """A forged X-Forwarded-For header must not influence the extracted client IP.
+
+    Inbound email headers are attacker-controllable: any sender can stamp their own
+    ``X-Forwarded-For`` into a message. Trusting it would let attackers spoof the
+    client IP used for SPF evaluation and bypass authentication.
+    """
+    raw = (
+        b"X-Forwarded-For: 192.0.2.50\r\n"
+        b"Received: from mail.example.com ([198.51.100.10])\r\n"
+        b"\tby mx.mailgun.net with ESMTP; Mon, 21 Apr 2026 12:00:00 +0000\r\n"
+        b"From: attacker@example.com\r\n"
+        b"\r\n"
+        b"body\r\n"
+    )
+
+    assert extract_client_ip(raw) == "198.51.100.10"
+
+
+def test_extract_client_ip_ignores_forged_x_forwarded_for_without_received() -> None:
+    """Without a Received header we still refuse the attacker-controllable XFF header."""
+    raw = b"X-Forwarded-For: 192.0.2.50\r\nFrom: attacker@example.com\r\n\r\nbody\r\n"
+
+    assert extract_client_ip(raw) is None
+
+
+def test_extract_client_ip_returns_none_when_no_sources() -> None:
+    raw = b"From: buyer@example.com\r\n\r\nbody\r\n"
+
+    assert extract_client_ip(raw) is None

--- a/uv.lock
+++ b/uv.lock
@@ -792,6 +792,18 @@ wheels = [
 ]
 
 [[package]]
+name = "authheaders"
+version = "0.16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authres" },
+    { name = "dkimpy" },
+    { name = "dnspython" },
+    { name = "publicsuffix2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/3b/50fb88a96976e14730bb0eb699be194ed66146489a64ddb3ccfed5b75e85/authheaders-0.16.3.tar.gz", hash = "sha256:118edc6d3cb1ad18ffab3d788ccc562fca2854cd645faab08fc47033c648148a", size = 115428, upload-time = "2024-06-24T12:44:18.977Z" }
+
+[[package]]
 name = "authlib"
 version = "1.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -804,6 +816,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/ce/bb/73a1f1c64ee527877
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/aa/91355b5f539caf1b94f0e66ff1e4ee39373b757fce08204981f7829ede51/authlib-1.6.4-py2.py3-none-any.whl", hash = "sha256:39313d2a2caac3ecf6d8f95fbebdfd30ae6ea6ae6a6db794d976405fdd9aa796", size = 243076, upload-time = "2025-09-17T09:59:22.259Z" },
 ]
+
+[[package]]
+name = "authres"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/29/e28209b5d3d56c102845cca5a4a3abaf2724f79e83476a52b94d775ecce6/authres-1.2.0.tar.gz", hash = "sha256:93d1b995ad7ce21e62db649f361048125dd6022563a0ae8a23909465f1fd25b7", size = 23226, upload-time = "2019-08-03T19:38:00.494Z" }
 
 [[package]]
 name = "awesomeversion"
@@ -1583,6 +1601,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dkimpy"
+version = "1.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/6f/84e91828186bbfcedd7f9385ef5e0d369632444195c20e08951b7ffe0481/dkimpy-1.1.8.tar.gz", hash = "sha256:b5f60fb47bbf5d8d762f134bcea0c388eba6b498342a682a21f1686545094b77", size = 66979, upload-time = "2024-07-04T22:16:38.321Z" }
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1662,12 +1689,15 @@ dependencies = [
     { name = "anthropic" },
     { name = "anyio" },
     { name = "asyncpg" },
+    { name = "authheaders" },
     { name = "authlib" },
     { name = "backoff" },
     { name = "bcrypt", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13.2' or platform_python_implementation == 'PyPy'" },
     { name = "bcrypt", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13.2' and platform_python_implementation != 'PyPy'" },
     { name = "caldav" },
     { name = "cloudcoil-models-kubernetes" },
+    { name = "dkimpy" },
+    { name = "dnspython" },
     { name = "fastapi" },
     { name = "filetype" },
     { name = "genson" },
@@ -1704,6 +1734,7 @@ dependencies = [
     { name = "pycares" },
     { name = "pydantic-monty" },
     { name = "pydantic-settings" },
+    { name = "pyspf" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -1803,12 +1834,15 @@ requires-dist = [
     { name = "assertpy", marker = "extra == 'dev'", specifier = ">=1.1" },
     { name = "ast-grep-cli", marker = "extra == 'dev'", specifier = ">=0.39.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "authheaders", specifier = ">=0.16.3" },
     { name = "authlib", specifier = ">=1.3.1" },
     { name = "backoff", specifier = ">=2.2.1" },
     { name = "basedpyright", marker = "extra == 'dev'" },
     { name = "bcrypt", specifier = ">=4.0.0,<5.0.0" },
     { name = "caldav", specifier = ">=1.2.0" },
     { name = "cloudcoil-models-kubernetes", specifier = ">=1.32" },
+    { name = "dkimpy", specifier = ">=1.1.8" },
+    { name = "dnspython", specifier = ">=2.8.0" },
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "fastapi-sso", marker = "extra == 'dev'", specifier = ">=0.18.0" },
     { name = "filetype", specifier = ">=1.2.0" },
@@ -1865,6 +1899,7 @@ requires-dist = [
     { name = "pydantic-monty", specifier = ">=0.0.3" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pyspf", specifier = ">=2.0.14" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-alembic", marker = "extra == 'dev'", specifier = ">=0.11.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
@@ -4627,6 +4662,15 @@ wheels = [
 ]
 
 [[package]]
+name = "publicsuffix2"
+version = "2.20191221"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/04/1759906c4c5b67b2903f546de234a824d4028ef24eb0b1122daa43376c20/publicsuffix2-2.20191221.tar.gz", hash = "sha256:00f8cc31aa8d0d5592a5ced19cccba7de428ebca985db26ac852d920ddd6fe7b", size = 99592, upload-time = "2019-12-21T11:30:44.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/16/053c2945c5e3aebeefb4ccd5c5e7639e38bc30ad1bdc7ce86c6d01707726/publicsuffix2-2.20191221-py2.py3-none-any.whl", hash = "sha256:786b5e36205b88758bd3518725ec8cfe7a8173f5269354641f581c6b80a99893", size = 89033, upload-time = "2019-12-21T11:30:41.744Z" },
+]
+
+[[package]]
 name = "puremagic"
 version = "1.30"
 source = { registry = "https://pypi.org/simple" }
@@ -5046,6 +5090,12 @@ name = "pyspeex-noise"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/1d/7d2ebb8f73c2b2e929b4ba5370b35dbc91f37268ea53f4b6acd9afa532cb/pyspeex_noise-1.0.2.tar.gz", hash = "sha256:56a888ca2ef7fdea2316aa7fad3636d2fcf5f4450f3a0db58caa7c10a614b254", size = 49882, upload-time = "2024-08-27T17:00:34.859Z" }
+
+[[package]]
+name = "pyspf"
+version = "2.0.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/dc/5b3838ff90474e21fe0914920c53430f73402e07d6598ea228e61b74963e/pyspf-2.0.14.tar.gz", hash = "sha256:57a7ef01bda090173aafb6af0106251686ed73f03db4e911fcd34c57fc347186", size = 69446, upload-time = "2020-01-02T02:54:37.109Z" }
 
 [[package]]
 name = "pytest"
@@ -6360,8 +6410,8 @@ dependencies = [
     { name = "typing-extensions", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:fbe2e149c5174ef90d29a5f84a554dfaf28e003cb4f61fa2c8c024c17ec7ca58" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:057efd30a6778d2ee5e2374cd63a63f63311aa6f33321e627c655df60abdd390" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:fbe2e149c5174ef90d29a5f84a554dfaf28e003cb4f61fa2c8c024c17ec7ca58" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:057efd30a6778d2ee5e2374cd63a63f63311aa6f33321e627c655df60abdd390" },
 ]
 
 [[package]]
@@ -6386,14 +6436,14 @@ dependencies = [
     { name = "typing-extensions", marker = "platform_python_implementation == 'PyPy' or sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:8b5882276633cf91fe3d2d7246c743b94d44a7e660b27f1308007fdb1bb89f7d" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a5064b5e23772c8d164068cc7c12e01a75faf7b948ecd95a0d4007d7487e5f25" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8f81dedb4c6076ec325acc3b47525f9c550e5284a18eae1d9061c543f7b6e7de" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:e1ee1b2346ade3ea90306dfbec7e8ff17bc220d344109d189ae09078333b0856" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:64c187345509f2b1bb334feed4666e2c781ca381874bde589182f81247e61f88" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af81283ac671f434b1b25c95ba295f270e72db1fad48831eb5e4748ff9840041" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a9dbb6f64f63258bc811e2c0c99640a81e5af93c531ad96e95c5ec777ea46dab" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:6d93a7165419bc4b2b907e859ccab0dea5deeab261448ae9a5ec5431f14c0e64" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:8b5882276633cf91fe3d2d7246c743b94d44a7e660b27f1308007fdb1bb89f7d" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a5064b5e23772c8d164068cc7c12e01a75faf7b948ecd95a0d4007d7487e5f25" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8f81dedb4c6076ec325acc3b47525f9c550e5284a18eae1d9061c543f7b6e7de" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:e1ee1b2346ade3ea90306dfbec7e8ff17bc220d344109d189ae09078333b0856" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:64c187345509f2b1bb334feed4666e2c781ca381874bde589182f81247e61f88" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af81283ac671f434b1b25c95ba295f270e72db1fad48831eb5e4748ff9840041" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a9dbb6f64f63258bc811e2c0c99640a81e5af93c531ad96e95c5ec777ea46dab" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:6d93a7165419bc4b2b907e859ccab0dea5deeab261448ae9a5ec5431f14c0e64" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replace Mailgun-provided email authentication results with local cryptographic verification of DKIM signatures and DMARC policy evaluation. This eliminates the dependency on Mailgun's unreliable `dmarc`/`spf`/`dkim` form fields and `Authentication-Results` headers.

## Key Changes

- **New module `authentication.py`**: Implements local DKIM/SPF/DMARC verification using the `authheaders` library. Provides:
  - `EmailAuthenticationResult` dataclass with normalized `dkim`, `spf`, `dmarc` status fields
  - `verify_email_authentication()` function that cryptographically verifies DKIM signatures against DNS-published keys and evaluates DMARC policy
  - `DnsResolver` protocol for injectable DNS resolution (enables testability without live DNS)
  - Helper functions to extract client IP and From domain from raw MIME headers

- **Updated `security.py`**: 
  - Removed `SenderAuthentication` dataclass and `extract_sender_authentication()` (which read Mailgun form fields)
  - Added `extract_raw_mime()` to pull the raw RFC 822 message from Mailgun's `body-mime` form field
  - Modified `verify_sender_authorization()` to evaluate DMARC locally when `require_authenticated_sender` is set
  - Simplified authentication policy: now requires DMARC `pass` (aligned DKIM or SPF) when enabled, or skips verification if disabled
  - Removed config options `require_dmarc_pass` and `allow_spf_or_dkim_fallback_when_dmarc_missing`

- **Updated webhook handler (`webhooks.py`)**:
  - Extract raw MIME from form data before authentication checks
  - Pass raw MIME and injectable DNS resolver to `verify_sender_authorization()`
  - Log authentication results (DKIM, SPF, DMARC status and domains)
  - Store authentication results in the database

- **Database schema**: Added columns to `received_emails` table to persist verification outcomes:
  - `dkim_result`, `spf_result`, `dmarc_result` (normalized status strings)
  - `dmarc_policy`, `dkim_domain` (policy and domain details)
  - Index on `dmarc_result` for querying

- **Test infrastructure**:
  - New `tests/mocks/email_auth.py` with helpers to build DKIM-signed test messages and fake DNS resolvers
  - Rewrote `test_mail_webhook_security.py` to use real DKIM signatures and injected DNS instead of mocking form fields
  - Tests now verify cryptographic correctness of signatures and DMARC policy evaluation

- **Configuration & documentation**:
  - Updated `EmailIntakeConfig` docstring to clarify local verification behavior
  - Updated `CONFIGURATION_REFERENCE.md` to remove deprecated options and explain the new MIME forwarding requirement
  - Added design document `local-email-authentication.md` explaining the rationale and implementation

## Implementation Details

- **Mailgun configuration change required**: Routes must use MIME-type forwarding (`forward('url', 'mime')`) to include the raw message in `body-mime`. Without this field, DKIM verification is impossible.

- **Client IP extraction**: Prefers Mailgun-provided `X-Mailgun-Sending-Ip` header, falls back to parsing the topmost `Received:` header for SPF evaluation.

- **SPF evaluation**: Only performed when both `client_ip` and `envelope_from` are available; reported as `"none"` otherwise. DMARC can still pass on aligned DKIM alone.

- **DNS resolution**: Injected via `request.app.state.email_intake_dns_resolver` (set by tests; production uses real DNS via `authheaders`/`dkimpy`).

- **Backward compatibility**: When `require_authenticated_sender` is false and `body-mime` is missing, a warning is logged but processing continues (preserves indexing-only deployments during migration).

https://claude.ai/code/session_01VGFbk6gLbkaTSnZHfsuXo5