### PR TITLE
Add Deep Research Max tier and visualization support

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -568,11 +568,10 @@ service_profiles:
     slash_commands:
       - "/browse"
   - id: "research"
-    description: "Assistant profile for deep research, utilizing the Google Gemini Deep Research agent. Ideal for comprehensive information gathering and analysis when web browsing or specific tool execution is not required."
+    description: "Assistant profile for deep research, utilizing the Google Gemini Deep Research agent (regular tier). Faster turnaround; ideal for everyday research questions that benefit from web-grounded synthesis."
     processing_config:
-      # Updated to use Google Gemini Deep Research agent
       provider: "google"
-      llm_model: "deep-research-pro-preview-12-2025"
+      llm_model: "deep-research-preview-04-2026"
       prompts:
         system_prompt: "You are a research assistant interacting with {user_name}. Please focus on providing comprehensive and accurate information. After any tool calls you make, your final text response will be sent directly to {user_name}. Do NOT use the 'send_message_to_user' tool to respond to {user_name} - that tool is only for sending messages to OTHER users."
         # Inherits default timezone, history settings.
@@ -585,6 +584,21 @@ service_profiles:
       default_decision: "deny"
     slash_commands:
       - "/research"
+  - id: "research_max"
+    description: "Assistant profile for in-depth deep research, utilizing the Google Gemini Deep Research Max agent. Slower but most comprehensive; ideal for longer, multi-source investigations where thoroughness matters more than latency."
+    processing_config:
+      provider: "google"
+      llm_model: "deep-research-max-preview-04-2026"
+      prompts:
+        system_prompt: "You are a research assistant interacting with {user_name}. Please focus on providing comprehensive and accurate information. After any tool calls you make, your final text response will be sent directly to {user_name}. Do NOT use the 'send_message_to_user' tool to respond to {user_name} - that tool is only for sending messages to OTHER users."
+    tools_config:
+      enable_local_tools: []
+      enable_mcp_server_ids: []
+      confirm_tools: []
+    tools_policy:
+      default_decision: "deny"
+    slash_commands:
+      - "/research_max"
   - id: "data_visualization"
     description: "Assistant profile optimized for creating data visualizations and charts. Uses Vega/Vega-Lite to generate professional charts from user data."
     processing_config:

--- a/docs/design/gemini-deep-research-tiers.md
+++ b/docs/design/gemini-deep-research-tiers.md
@@ -1,0 +1,68 @@
+# Gemini Deep Research Tiers
+
+## Context
+
+Google published the Gemini Deep Research API as a generally documented feature in April 2026. The
+public docs (https://ai.google.dev/gemini-api/docs/deep-research) expose two tiers:
+
+- `deep-research-preview-04-2026` — regular tier, optimised for faster turnaround.
+- `deep-research-max-preview-04-2026` — max tier, optimised for the most comprehensive, multi-source
+  investigations at the cost of longer run times.
+
+Both models ride the same `client.interactions.create()` transport we were already using for the
+earlier `deep-research-pro-preview-12-2025` preview. The stream event shape (`interaction.start`,
+`content.delta` with `text | thought_summary | image`, `interaction.status_update`,
+`interaction.complete`, `error`) is unchanged.
+
+## Decision
+
+Expose the two tiers as separate service profiles rather than adding argument parsing to
+`/research`:
+
+- `research` → `deep-research-preview-04-2026`, slash command `/research`.
+- `research_max` → `deep-research-max-preview-04-2026`, slash command `/research_max` (underscore,
+  not hyphen — Telegram's BotFather only accepts `[a-z0-9_]{1,32}` for command names).
+
+This mirrors the existing `default_assistant` vs `complex_tasks` split and keeps the slash command
+surface flat. The old `deep-research-pro-preview-12-2025` model ID is retired; the `research`
+profile now targets the documented regular tier.
+
+## Implementation
+
+1. `defaults.yaml` — retarget `research` at the new regular model and add a sibling `research_max`
+   profile with the max model. Both profiles keep the same tools/policy stance (no local tools, no
+   MCP, deny-by-default) since deep research handles its own web grounding server-side.
+2. `src/family_assistant/llm/providers/google_genai_client.py` —
+   - `_is_deep_research_model` stays as a substring match on `"deep-research"`, so both new model
+     IDs route through the same code path automatically.
+   - `agent_config` now includes `visualization: "auto"` alongside `thinking_summaries: "auto"`.
+     This is the Google-recommended default and enables charts/diagrams for reports that benefit
+     from them.
+   - `content.delta` handler now has an explicit branch for `delta.type == "image"` that logs at
+     debug level and skips. Surfacing visualisation images as attachments is deferred until we have
+     a concrete UI requirement for them.
+3. `src/family_assistant/web/routers/chat_api.py` — fallback description branch for the new
+   `research_max` profile.
+4. Tests in `tests/llm/test_google_deep_research.py` cover:
+   - `_is_deep_research_model` matching both 04-2026 model IDs (plus the legacy preview for
+     compatibility).
+   - `agent_config` including `visualization: "auto"` on the max profile.
+   - An `image` delta in the stream being ignored without breaking the stream.
+
+## Non-goals
+
+- **Image attachment plumbing.** Visualisation images from deep research are not yet surfaced to
+  users. If demand materialises, the follow-up is to convert `image` deltas into `AttachmentPart`
+  values on the streamed message.
+- **collaborative_planning flag.** The Google API accepts `collaborative_planning: true` in
+  `agent_config`, but our current chat surfaces aren't set up for the "plan review" turn that mode
+  introduces. Left off for now.
+- **Per-profile `agent_config` overrides.** Both profiles share the same `visualization: "auto"`
+  default. If future tuning requires divergence, the natural next step is to plumb `agent_config`
+  through `processing_config` rather than hardcoding it in the client.
+
+## Open questions
+
+- Telegram and email-intake surfaces do not yet route to `/research_max`. They will pick it up
+  automatically via slash-command matching, but we haven't audited whether the longer latency is
+  acceptable on the Telegram bot's response deadlines.

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -21,7 +21,9 @@ services to respond or perform actions.
   tell you its name). \*Start a chat and simply send messages with your questions or requests. \*You
   can also use **slash commands** to activate specialized modes for certain tasks. For example,
   typing `/browse` before your query activates a powerful web browsing mode for complex web tasks or
-  research, while `/research` focuses the assistant on in-depth research questions.
+  research, while `/research` focuses the assistant on in-depth research questions. For
+  investigations that need the most thorough, multi-source synthesis (at the cost of longer
+  latency), use `/research_max` instead.
 
 - **Web Interface (Secondary):** \*There's also a web interface for various tasks: \*Chat directly
   with the assistant with real-time streaming responses. \*Managing notes. \*Viewing and filtering
@@ -525,10 +527,13 @@ various tasks with dark mode support and mobile optimization.
 
 - **Use Slash Commands:** For specialized tasks like complex web browsing (e.g.,
   `/browse find travel options to Paris for next June`), in-depth research (e.g.,
-  `/research Tell me about the history of Python`), complex multi-step reasoning or planning (e.g.,
+  `/research Tell me about the history of Python`), the most comprehensive deep research (e.g.,
+  `/research_max Compare the regulatory landscape for autonomous vehicles across the EU, US, and Japan`),
+  complex multi-step reasoning or planning (e.g.,
   `/complex Plan a detailed family vacation considering everyone's schedules and preferences`), or
   engineering diagnostics (e.g., `/engineer Why isn't my daily brief automation triggering?`), using
-  the appropriate slash command can provide more focused and effective responses.
+  the appropriate slash command can provide more focused and effective responses. Use `/research`
+  for most questions and reach for `/research_max` when thoroughness matters more than turnaround.
 
 - **Mobile Experience:** The web interface is fully optimized for mobile devices. All features are
   accessible on phones and tablets with responsive design that adapts to your screen size.

--- a/src/family_assistant/llm/providers/google_genai_client.py
+++ b/src/family_assistant/llm/providers/google_genai_client.py
@@ -1503,7 +1503,11 @@ class GoogleGenAIClient(BaseLLMClient):
                 "agent": agent_name,
                 "background": True,
                 "stream": True,
-                "agent_config": {"type": "deep-research", "thinking_summaries": "auto"},
+                "agent_config": {
+                    "type": "deep-research",
+                    "thinking_summaries": "auto",
+                    "visualization": "auto",
+                },
             }
             if previous_interaction_id:
                 create_kwargs["previous_interaction_id"] = previous_interaction_id
@@ -1536,6 +1540,12 @@ class GoogleGenAIClient(BaseLLMClient):
                             type="content", content=f"\n*Thinking: {thought_text}*\n"
                         )
                         content_yielded = True
+                    elif chunk.delta.type == "image":
+                        # Image deltas (e.g. visualization charts) are not yet surfaced as
+                        # attachments; skip them so text output is unaffected.
+                        logger.debug(
+                            "Ignoring Deep Research image delta (visualization not yet wired)"
+                        )
 
                 elif chunk.event_type == "interaction.complete":
                     logger.info("Deep Research interaction complete")

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -1530,6 +1530,8 @@ async def get_available_profiles(
                 description = "Web browsing assistant with internet search and page interaction capabilities"
             elif profile_id == "research":
                 description = "Research specialist using advanced models for deep information gathering"
+            elif profile_id == "research_max":
+                description = "Research specialist using the Deep Research Max tier for the most comprehensive multi-source investigations"
             elif profile_id == "event_handler":
                 description = (
                     "Automated event handler for script and system integration"

--- a/tests/llm/test_google_deep_research.py
+++ b/tests/llm/test_google_deep_research.py
@@ -498,3 +498,101 @@ async def test_deep_research_unknown_error_code_yields_generic(
     with pytest.raises(LLMProviderError, match="Something went wrong"):
         async for _ in client.generate_response_stream(messages):
             pass
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "deep-research-pro-preview-12-2025",
+        "deep-research-preview-04-2026",
+        "deep-research-max-preview-04-2026",
+    ],
+)
+def test_is_deep_research_model_matches_all_tiers(model_id: str) -> None:
+    """Both the legacy preview and the 04-2026 regular/max tiers should route to deep research."""
+    client = GoogleGenAIClient(api_key="test", model=model_id)
+    assert client._is_deep_research_model(model_id) is True
+
+
+@pytest.mark.asyncio
+async def test_deep_research_agent_config_includes_visualization(
+    mock_genai_client: MagicMock,
+) -> None:
+    """agent_config should request visualizations alongside thought summaries."""
+    client = GoogleGenAIClient(
+        api_key="test", model="deep-research-max-preview-04-2026"
+    )
+
+    async def mock_stream_generator() -> AsyncGenerator[MagicMock]:
+        mock_start = MagicMock()
+        mock_start.event_type = "interaction.start"
+        mock_start.interaction.id = "inter_viz"
+        mock_start.event_id = "evt_0"
+        yield mock_start
+
+        mock_complete = MagicMock()
+        mock_complete.event_type = "interaction.complete"
+        mock_complete.event_id = "evt_1"
+        yield mock_complete
+
+    mock_genai_client.aio.interactions.create = AsyncMock(
+        return_value=mock_stream_generator()
+    )
+
+    async for _ in client.generate_response_stream([UserMessage(content="Test")]):
+        pass
+
+    call_kwargs = mock_genai_client.aio.interactions.create.call_args.kwargs
+    assert call_kwargs["agent"] == "deep-research-max-preview-04-2026"
+    assert call_kwargs["agent_config"] == {
+        "type": "deep-research",
+        "thinking_summaries": "auto",
+        "visualization": "auto",
+    }
+
+
+@pytest.mark.asyncio
+async def test_deep_research_image_delta_is_skipped(
+    mock_genai_client: MagicMock,
+) -> None:
+    """Image deltas should be ignored cleanly without breaking the stream."""
+    client = GoogleGenAIClient(api_key="test", model="deep-research-preview-04-2026")
+
+    async def mock_stream_generator() -> AsyncGenerator[MagicMock]:
+        mock_start = MagicMock()
+        mock_start.event_type = "interaction.start"
+        mock_start.interaction.id = "inter_img"
+        mock_start.event_id = "evt_0"
+        yield mock_start
+
+        mock_image = MagicMock()
+        mock_image.event_type = "content.delta"
+        mock_image.delta.type = "image"
+        mock_image.event_id = "evt_1"
+        yield mock_image
+
+        mock_text = MagicMock()
+        mock_text.event_type = "content.delta"
+        mock_text.delta.type = "text"
+        mock_text.delta.text = "After image"
+        mock_text.event_id = "evt_2"
+        yield mock_text
+
+        mock_complete = MagicMock()
+        mock_complete.event_type = "interaction.complete"
+        mock_complete.event_id = "evt_3"
+        yield mock_complete
+
+    mock_genai_client.aio.interactions.create = AsyncMock(
+        return_value=mock_stream_generator()
+    )
+
+    events = []
+    async for event in client.generate_response_stream([UserMessage(content="Test")]):
+        events.append(event)
+
+    content_events = [e for e in events if e.type == "content"]
+    assert len(content_events) == 1
+    assert content_events[0].content == "After image"
+    done_events = [e for e in events if e.type == "done"]
+    assert len(done_events) == 1


### PR DESCRIPTION
## Summary
Adds support for Google's new Gemini Deep Research Max tier (`deep-research-max-preview-04-2026`) alongside the regular tier (`deep-research-preview-04-2026`), and enables visualization support in deep research responses.

## Key Changes

- **New service profile**: Added `research_max` profile targeting the Deep Research Max model for comprehensive multi-source investigations with longer latency tolerance
- **Updated research profile**: Retargeted existing `research` profile from legacy `deep-research-pro-preview-12-2025` to the new regular tier `deep-research-preview-04-2026`
- **Visualization support**: Updated `agent_config` in deep research requests to include `visualization: "auto"` alongside `thinking_summaries: "auto"`, enabling charts and diagrams in research outputs
- **Image delta handling**: Added explicit handling for `image` type deltas in the stream to skip visualization images (logged at debug level) without breaking the text stream
- **Documentation**: Added design document explaining the tier strategy and implementation rationale
- **User guide updates**: Documented the new `/research_max` slash command and guidance on when to use each tier

## Implementation Details

- `_is_deep_research_model()` continues to use substring matching on `"deep-research"`, automatically routing both new model IDs through the existing deep research code path
- Both profiles maintain the same tools/policy stance (no local tools, no MCP, deny-by-default) since deep research handles web grounding server-side
- Image visualization surfacing as attachments is deferred pending concrete UI requirements
- Tests added to verify model detection, agent config structure, and image delta skipping behavior

https://claude.ai/code/session_01VaFwxArjzR3QzZuGHrr3qn