### PR TITLE
Add debug API endpoint to dump full profile configuration

### DIFF
--- a/src/family_assistant/web/routers/debug_api.py
+++ b/src/family_assistant/web/routers/debug_api.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
 
-from family_assistant.config_models import ServiceProfile
+from family_assistant.config_models import DefaultProfileSettings, ServiceProfile
 from family_assistant.web.auth import (
     AUTH_ENABLED,
     OIDC_CLIENT_ID,
@@ -79,18 +79,19 @@ def redact_sensitive_config(obj: Any) -> Any:  # noqa: ANN401 - recursive over a
     return obj
 
 
-def _dump_profile(
-    profile: ServiceProfile,
+def _dump_profile_like(
+    profile: ServiceProfile | DefaultProfileSettings,
     # ast-grep-ignore: no-dict-any - Serialized Pydantic model has heterogeneous top-level values
 ) -> dict[str, Any]:
-    """Serialize a ServiceProfile including operator-layer fields that model_dump excludes.
+    """Serialize a ServiceProfile/DefaultProfileSettings including excluded operator fields.
 
-    ``ServiceProfile.operator_tools_policy`` and ``operator_mcp_server_ids`` are
-    declared with ``exclude=True`` so they do not round-trip through the YAML
-    config, but they ARE merged with the profile layer at runtime (see
+    ``operator_tools_policy`` and ``operator_mcp_server_ids`` on both
+    ``ServiceProfile`` and ``DefaultProfileSettings`` are declared with
+    ``exclude=True`` so they do not round-trip through the YAML config, but they
+    ARE merged with the profile/defaults layers at runtime (see
     ``PolicyEngine.from_layers``). For the debug dump we want the caller to see
-    every layer contributing to the effective policy, so we serialize them
-    explicitly.
+    every layer contributing to the effective policy — including any defaults
+    that apply to every profile — so we serialize them explicitly here.
     """
     dumped = profile.model_dump(mode="json")
 
@@ -336,7 +337,7 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
     for profile in config.service_profiles:
         if profile_id is not None and profile.id != profile_id:
             continue
-        profile_dump = redact_sensitive_config(_dump_profile(profile))
+        profile_dump = redact_sensitive_config(_dump_profile_like(profile))
         runtime_info = _runtime_info_for(profile.id, processing_services_registry)
         profiles_info.append({
             "id": profile.id,
@@ -352,7 +353,7 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
         )
 
     default_settings_dump = redact_sensitive_config(
-        config.default_profile_settings.model_dump(mode="json")
+        _dump_profile_like(config.default_profile_settings)
     )
 
     # ast-grep-ignore: no-dict-any - Debug endpoint returns serialized Pydantic config dicts

--- a/src/family_assistant/web/routers/debug_api.py
+++ b/src/family_assistant/web/routers/debug_api.py
@@ -110,24 +110,49 @@ def _dump_profile_like(
     return dumped
 
 
+def _strip_google_prefix(model: str) -> str:
+    prefix = "models/"
+    return model[len(prefix) :] if model.startswith(prefix) else model
+
+
 def resolve_live_llm_model(llm_client: object) -> str | None:
-    """Return the live model identifier from an LLM client, handling shape differences.
+    """Return the live primary model identifier from an LLM client.
 
     Provider clients disagree on where they stash the model identifier:
-    ``OpenAIClient`` and ``AnthropicClient`` set ``self.model``, while
-    ``GoogleGenAIClient`` stores ``self.model_name`` with a leading ``models/``
-    prefix. We read from either location and normalize the prefix so consumers
-    see the same identifier they configured.
+
+    - ``OpenAIClient`` / ``AnthropicClient`` set ``self.model``.
+    - ``GoogleGenAIClient`` stores ``self.model_name`` with a leading
+      ``models/`` prefix.
+    - ``RetryingLLMClient`` (the wrapper created for profiles with
+      ``processing_config.retry_config``) stores the active model on
+      ``self.primary_model`` and does not itself have ``model`` /
+      ``model_name`` attributes.
+
+    We check these in priority order — wrapper's ``primary_model`` first so
+    the dump reflects what the retry wrapper is actually driving — then fall
+    through to the concrete provider attributes. The ``models/`` prefix is
+    normalized away so consumers see the same identifier they configured.
     """
-    raw_model = getattr(llm_client, "model", None) or getattr(
-        llm_client, "model_name", None
+    raw_model = (
+        getattr(llm_client, "primary_model", None)
+        or getattr(llm_client, "model", None)
+        or getattr(llm_client, "model_name", None)
     )
     if not isinstance(raw_model, str):
         return None
-    prefix = "models/"
-    if raw_model.startswith(prefix):
-        return raw_model[len(prefix) :]
-    return raw_model
+    return _strip_google_prefix(raw_model)
+
+
+def resolve_live_llm_fallback_model(llm_client: object) -> str | None:
+    """Return the configured fallback model for ``RetryingLLMClient``, if any.
+
+    Only ``RetryingLLMClient`` exposes a fallback chain; concrete provider
+    clients do not, so this returns ``None`` for them.
+    """
+    fallback = getattr(llm_client, "fallback_model", None)
+    if not isinstance(fallback, str):
+        return None
+    return _strip_google_prefix(fallback)
 
 
 def _runtime_info_for(
@@ -158,6 +183,9 @@ def _runtime_info_for(
     return {
         "kind": kind,
         "llm_model": resolve_live_llm_model(llm_client) if llm_client else None,
+        "llm_fallback_model": (
+            resolve_live_llm_fallback_model(llm_client) if llm_client else None
+        ),
         "llm_client_class": type(llm_client).__name__ if llm_client else None,
         "context_providers": [
             getattr(p, "name", type(p).__name__) for p in context_providers

--- a/src/family_assistant/web/routers/debug_api.py
+++ b/src/family_assistant/web/routers/debug_api.py
@@ -110,13 +110,41 @@ def _dump_profile_like(
     return dumped
 
 
+def resolve_live_llm_model(llm_client: object) -> str | None:
+    """Return the live model identifier from an LLM client, handling shape differences.
+
+    Provider clients disagree on where they stash the model identifier:
+    ``OpenAIClient`` and ``AnthropicClient`` set ``self.model``, while
+    ``GoogleGenAIClient`` stores ``self.model_name`` with a leading ``models/``
+    prefix. We read from either location and normalize the prefix so consumers
+    see the same identifier they configured.
+    """
+    raw_model = getattr(llm_client, "model", None) or getattr(
+        llm_client, "model_name", None
+    )
+    if not isinstance(raw_model, str):
+        return None
+    prefix = "models/"
+    if raw_model.startswith(prefix):
+        return raw_model[len(prefix) :]
+    return raw_model
+
+
 def _runtime_info_for(
     profile_id: str,
     # ast-grep-ignore: no-dict-any - Debug endpoint inspects dynamic runtime registry state
     processing_services_registry: dict[str, Any],
     # ast-grep-ignore: no-dict-any - Debug endpoint returns dynamic runtime introspection data
 ) -> dict[str, Any] | None:
-    """Collect live runtime info for a profile from the services registry."""
+    """Collect live runtime info for a profile from the services registry.
+
+    The configured ``provider`` and ``llm_model`` are already in the profile's
+    ``processing_config`` dump; we intentionally do NOT re-emit ``provider``
+    here because no concrete LLM client exposes a stable ``provider`` attribute
+    (it only appears on exception types). We do expose the live resolved model
+    via :func:`resolve_live_llm_model` so callers can detect drift between the
+    configured value and what the runtime client is actually using.
+    """
     service = processing_services_registry.get(profile_id)
     if service is None:
         return None
@@ -129,8 +157,7 @@ def _runtime_info_for(
     context_providers = getattr(service, "context_providers", []) or []
     return {
         "kind": kind,
-        "llm_model": getattr(llm_client, "model", None) if llm_client else None,
-        "llm_provider": getattr(llm_client, "provider", None) if llm_client else None,
+        "llm_model": resolve_live_llm_model(llm_client) if llm_client else None,
         "llm_client_class": type(llm_client).__name__ if llm_client else None,
         "context_providers": [
             getattr(p, "name", type(p).__name__) for p in context_providers
@@ -310,11 +337,23 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
       model/provider, LLM client class, context provider names).
 
     This endpoint exposes internal configuration (prompts, policy rules, tool
-    enablement). It requires an authenticated user (OIDC session or API token)
-    and is additionally gated through the shared ``is_debug_authorized`` check
-    used by the other ``/api/debug/*`` routes. Secret-bearing fields (tokens,
-    passwords, API keys) are redacted. The response defaults to pretty-printed
-    JSON (``indent=2``); pass ``?format=raw`` for compact JSON.
+    enablement). It is gated in three layers:
+
+    1. ``Depends(get_current_user)`` — requires an OIDC session or API token
+       when ``auth_service.auth_enabled`` is true.
+    2. Fail-closed check — when auth is disabled, the endpoint only responds
+       for deployments that have explicitly opted in by setting
+       ``app_config.dev_mode=true``. This prevents misconfigured prod
+       deployments (auth off, dev_mode off) from silently leaking prompts and
+       policy rules, since ``get_current_user`` otherwise returns a synthetic
+       test user in that configuration.
+    3. Shared ``is_debug_authorized`` check used by the other
+       ``/api/debug/*`` routes, so any future tightening of that gate applies
+       here too.
+
+    Secret-bearing fields (tokens, passwords, API keys) are redacted. The
+    response defaults to pretty-printed JSON (``indent=2``); pass
+    ``?format=raw`` for compact JSON.
     """
     if not is_debug_authorized(request):
         raise HTTPException(
@@ -328,6 +367,22 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Application config not initialized",
+        )
+
+    auth_service = getattr(app.state, "auth_service", None)
+    auth_enabled = bool(auth_service and getattr(auth_service, "auth_enabled", False))
+    dev_mode = bool(getattr(config, "dev_mode", False))
+    if not auth_enabled and not dev_mode:
+        # get_current_user() returned a synthetic test user because auth is
+        # off. Refuse to expose profile internals unless the operator
+        # explicitly set dev_mode=true.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Debug profile dump is disabled: authentication is not enabled "
+                "and dev_mode is false. Enable OIDC auth or set "
+                "app_config.dev_mode=true to access this endpoint."
+            ),
         )
 
     processing_services_registry = getattr(app.state, "processing_services", None) or {}

--- a/src/family_assistant/web/routers/debug_api.py
+++ b/src/family_assistant/web/routers/debug_api.py
@@ -3,10 +3,12 @@ Debug API endpoints for troubleshooting route registration and other issues.
 Protected by debug token for security.
 """
 
+import json
 import logging
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from fastapi.responses import PlainTextResponse, Response
 
 from family_assistant.web.auth import (
     AUTH_ENABLED,
@@ -17,6 +19,67 @@ from family_assistant.web.auth import (
 
 logger = logging.getLogger(__name__)
 debug_api_router = APIRouter()
+
+# Fields whose values may leak secrets or per-user credentials. When a key with
+# one of these names appears anywhere in the serialized config (including nested
+# dicts under e.g. ``camera_config`` or ``home_assistant_*``), its value is
+# replaced with "[REDACTED]" in the response.
+SENSITIVE_FIELD_NAMES: frozenset[str] = frozenset({
+    "home_assistant_token",
+    "password",
+    "client_secret",
+    "mailgun_webhook_signing_key",
+    "gemini_api_key",
+    "openai_api_key",
+    "openrouter_api_key",
+    "telegram_token",
+    "vapid_private_key",
+    "session_secret_key",
+    "token_env",  # name of env var, redacted defensively
+})
+
+
+# ast-grep-ignore: no-dict-any - Recursive config redaction handles arbitrary nested structures
+def _redact_sensitive(obj: Any) -> Any:  # noqa: ANN401 - recursive over arbitrary JSON-like data
+    """Recursively redact sensitive fields in a serialized config structure."""
+    if isinstance(obj, dict):
+        return {
+            key: "[REDACTED]"
+            if key in SENSITIVE_FIELD_NAMES and value
+            else _redact_sensitive(value)
+            for key, value in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_redact_sensitive(item) for item in obj]
+    return obj
+
+
+def _runtime_info_for(
+    profile_id: str,
+    # ast-grep-ignore: no-dict-any - Debug endpoint inspects dynamic runtime registry state
+    processing_services_registry: dict[str, Any],
+    # ast-grep-ignore: no-dict-any - Debug endpoint returns dynamic runtime introspection data
+) -> dict[str, Any] | None:
+    """Collect live runtime info for a profile from the services registry."""
+    service = processing_services_registry.get(profile_id)
+    if service is None:
+        return None
+
+    kind = getattr(service, "kind", "unknown")
+    if kind == "remote":
+        return {"kind": "remote"}
+
+    llm_client = getattr(service, "llm_client", None)
+    context_providers = getattr(service, "context_providers", []) or []
+    return {
+        "kind": kind,
+        "llm_model": getattr(llm_client, "model", None) if llm_client else None,
+        "llm_provider": getattr(llm_client, "provider", None) if llm_client else None,
+        "llm_client_class": type(llm_client).__name__ if llm_client else None,
+        "context_providers": [
+            getattr(p, "name", type(p).__name__) for p in context_providers
+        ],
+    }
 
 
 def is_debug_authorized(request: Request) -> bool:
@@ -151,3 +214,104 @@ async def dump_auth_state(request: Request) -> dict[str, Any]:
         if hasattr(app.state, "config")
         else None,
     }
+
+
+@debug_api_router.get("/profiles")
+async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builtin
+    request: Request,
+    format: Annotated[
+        str,
+        Query(
+            description=(
+                "Output format: 'json' (pretty-printed JSON) or 'raw' (compact JSON)."
+            ),
+            pattern="^(json|raw)$",
+        ),
+    ] = "json",
+    profile_id: Annotated[
+        str | None,
+        Query(description="If set, return only the profile with this id."),
+    ] = None,
+) -> Response:
+    """
+    Dump the full processing profile configuration.
+
+    Shows each resolved service profile (after ``default_profile_settings`` have
+    been merged) including:
+
+    - ``processing_config`` — prompts, LLM model/provider, retry/fallback chain,
+      history limits, timezone, iteration caps, calendar/camera/Home Assistant
+      settings, delegation security level, system-doc includes.
+    - ``tools_config`` — enabled local tools (with eager/on-demand loading mode),
+      enabled MCP servers, tools requiring confirmation, timeouts.
+    - ``tools_policy`` — the full policy matrix: each rule's matcher (names,
+      tags, MCP server ids, argument equality), decision (allow/deny/confirm),
+      priority, and description; plus the default decision.
+    - ``slash_commands``, ``visibility_grants``, and ``remote_a2a`` delegation
+      config if configured.
+    - ``runtime`` info from the live processing services registry (resolved LLM
+      model/provider, LLM client class, context provider names).
+
+    Secret-bearing fields (tokens, passwords, API keys) are redacted. The
+    response defaults to pretty-printed JSON (``indent=2``); pass
+    ``?format=raw`` for compact JSON.
+    """
+    if not is_debug_authorized(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Debug endpoints are not authorized",
+        )
+
+    app = request.app
+    config = getattr(app.state, "config", None)
+    if config is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Application config not initialized",
+        )
+
+    processing_services_registry = getattr(app.state, "processing_services", None) or {}
+
+    # ast-grep-ignore: no-dict-any - Debug endpoint returns serialized Pydantic config dicts
+    profiles_info: list[dict[str, Any]] = []
+    for profile in config.service_profiles:
+        if profile_id is not None and profile.id != profile_id:
+            continue
+        profile_dump = _redact_sensitive(profile.model_dump(mode="json"))
+        runtime_info = _runtime_info_for(profile.id, processing_services_registry)
+        profiles_info.append({
+            "id": profile.id,
+            "description": profile.description,
+            "config": profile_dump,
+            "runtime": runtime_info,
+        })
+
+    if profile_id is not None and not profiles_info:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Profile '{profile_id}' not found",
+        )
+
+    default_settings_dump = _redact_sensitive(
+        config.default_profile_settings.model_dump(mode="json")
+    )
+
+    # ast-grep-ignore: no-dict-any - Debug endpoint returns serialized Pydantic config dicts
+    payload: dict[str, Any] = {
+        "default_service_profile_id": config.default_service_profile_id,
+        "default_profile_settings": default_settings_dump,
+        "profiles": profiles_info,
+        "profile_count": len(profiles_info),
+        "registered_service_ids": sorted(processing_services_registry.keys()),
+    }
+
+    if format == "raw":
+        return Response(
+            content=json.dumps(payload, default=str),
+            media_type="application/json",
+        )
+
+    return PlainTextResponse(
+        content=json.dumps(payload, indent=2, sort_keys=False, default=str),
+        media_type="application/json",
+    )

--- a/src/family_assistant/web/routers/debug_api.py
+++ b/src/family_assistant/web/routers/debug_api.py
@@ -10,6 +10,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
 
+from family_assistant.config_models import ServiceProfile
 from family_assistant.web.auth import (
     AUTH_ENABLED,
     OIDC_CLIENT_ID,
@@ -76,6 +77,36 @@ def redact_sensitive_config(obj: Any) -> Any:  # noqa: ANN401 - recursive over a
     if isinstance(obj, list):
         return [redact_sensitive_config(item) for item in obj]
     return obj
+
+
+def _dump_profile(
+    profile: ServiceProfile,
+    # ast-grep-ignore: no-dict-any - Serialized Pydantic model has heterogeneous top-level values
+) -> dict[str, Any]:
+    """Serialize a ServiceProfile including operator-layer fields that model_dump excludes.
+
+    ``ServiceProfile.operator_tools_policy`` and ``operator_mcp_server_ids`` are
+    declared with ``exclude=True`` so they do not round-trip through the YAML
+    config, but they ARE merged with the profile layer at runtime (see
+    ``PolicyEngine.from_layers``). For the debug dump we want the caller to see
+    every layer contributing to the effective policy, so we serialize them
+    explicitly.
+    """
+    dumped = profile.model_dump(mode="json")
+
+    if profile.operator_tools_policy is not None:
+        dumped["operator_tools_policy"] = profile.operator_tools_policy.model_dump(
+            mode="json"
+        )
+    else:
+        dumped["operator_tools_policy"] = None
+
+    dumped["operator_mcp_server_ids"] = [
+        entry if isinstance(entry, str) else entry.model_dump(mode="json")
+        for entry in profile.operator_mcp_server_ids
+    ]
+
+    return dumped
 
 
 def _runtime_info_for(
@@ -279,10 +310,17 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
 
     This endpoint exposes internal configuration (prompts, policy rules, tool
     enablement). It requires an authenticated user (OIDC session or API token)
-    and redacts secret-bearing fields (tokens, passwords, API keys). The
-    response defaults to pretty-printed JSON (``indent=2``); pass
-    ``?format=raw`` for compact JSON.
+    and is additionally gated through the shared ``is_debug_authorized`` check
+    used by the other ``/api/debug/*`` routes. Secret-bearing fields (tokens,
+    passwords, API keys) are redacted. The response defaults to pretty-printed
+    JSON (``indent=2``); pass ``?format=raw`` for compact JSON.
     """
+    if not is_debug_authorized(request):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Debug endpoints are not authorized",
+        )
+
     app = request.app
     config = getattr(app.state, "config", None)
     if config is None:
@@ -298,7 +336,7 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
     for profile in config.service_profiles:
         if profile_id is not None and profile.id != profile_id:
             continue
-        profile_dump = redact_sensitive_config(profile.model_dump(mode="json"))
+        profile_dump = redact_sensitive_config(_dump_profile(profile))
         runtime_info = _runtime_info_for(profile.id, processing_services_registry)
         profiles_info.append({
             "id": profile.id,

--- a/src/family_assistant/web/routers/debug_api.py
+++ b/src/family_assistant/web/routers/debug_api.py
@@ -7,8 +7,8 @@ import json
 import logging
 from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Query, Request, status
-from fastapi.responses import PlainTextResponse, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import Response
 
 from family_assistant.web.auth import (
     AUTH_ENABLED,
@@ -16,6 +16,7 @@ from family_assistant.web.auth import (
     OIDC_DISCOVERY_URL,
     SESSION_SECRET_KEY,
 )
+from family_assistant.web.dependencies import get_current_user
 
 logger = logging.getLogger(__name__)
 debug_api_router = APIRouter()
@@ -38,19 +39,42 @@ SENSITIVE_FIELD_NAMES: frozenset[str] = frozenset({
     "token_env",  # name of env var, redacted defensively
 })
 
+# Substring patterns used as a defense-in-depth fallback so config fields added
+# in the future with secret-looking names (e.g. ``*_api_key``, ``*_secret``,
+# ``*_token``, ``*_password``) are redacted even if not explicitly allowlisted.
+_SENSITIVE_SUBSTRINGS: tuple[str, ...] = (
+    "api_key",
+    "apikey",
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "private_key",
+)
+
+
+def is_sensitive_field_name(key: object) -> bool:
+    """Return True if the given dict key looks like it carries a secret."""
+    if not isinstance(key, str):
+        return False
+    if key in SENSITIVE_FIELD_NAMES:
+        return True
+    lowered = key.lower()
+    return any(substring in lowered for substring in _SENSITIVE_SUBSTRINGS)
+
 
 # ast-grep-ignore: no-dict-any - Recursive config redaction handles arbitrary nested structures
-def _redact_sensitive(obj: Any) -> Any:  # noqa: ANN401 - recursive over arbitrary JSON-like data
+def redact_sensitive_config(obj: Any) -> Any:  # noqa: ANN401 - recursive over arbitrary JSON-like data
     """Recursively redact sensitive fields in a serialized config structure."""
     if isinstance(obj, dict):
         return {
             key: "[REDACTED]"
-            if key in SENSITIVE_FIELD_NAMES and value
-            else _redact_sensitive(value)
+            if is_sensitive_field_name(key) and value
+            else redact_sensitive_config(value)
             for key, value in obj.items()
         }
     if isinstance(obj, list):
-        return [_redact_sensitive(item) for item in obj]
+        return [redact_sensitive_config(item) for item in obj]
     return obj
 
 
@@ -219,6 +243,7 @@ async def dump_auth_state(request: Request) -> dict[str, Any]:
 @debug_api_router.get("/profiles")
 async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builtin
     request: Request,
+    _user: Annotated[dict, Depends(get_current_user)],
     format: Annotated[
         str,
         Query(
@@ -252,16 +277,12 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
     - ``runtime`` info from the live processing services registry (resolved LLM
       model/provider, LLM client class, context provider names).
 
-    Secret-bearing fields (tokens, passwords, API keys) are redacted. The
+    This endpoint exposes internal configuration (prompts, policy rules, tool
+    enablement). It requires an authenticated user (OIDC session or API token)
+    and redacts secret-bearing fields (tokens, passwords, API keys). The
     response defaults to pretty-printed JSON (``indent=2``); pass
     ``?format=raw`` for compact JSON.
     """
-    if not is_debug_authorized(request):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Debug endpoints are not authorized",
-        )
-
     app = request.app
     config = getattr(app.state, "config", None)
     if config is None:
@@ -277,7 +298,7 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
     for profile in config.service_profiles:
         if profile_id is not None and profile.id != profile_id:
             continue
-        profile_dump = _redact_sensitive(profile.model_dump(mode="json"))
+        profile_dump = redact_sensitive_config(profile.model_dump(mode="json"))
         runtime_info = _runtime_info_for(profile.id, processing_services_registry)
         profiles_info.append({
             "id": profile.id,
@@ -292,7 +313,7 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
             detail=f"Profile '{profile_id}' not found",
         )
 
-    default_settings_dump = _redact_sensitive(
+    default_settings_dump = redact_sensitive_config(
         config.default_profile_settings.model_dump(mode="json")
     )
 
@@ -305,13 +326,8 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
         "registered_service_ids": sorted(processing_services_registry.keys()),
     }
 
-    if format == "raw":
-        return Response(
-            content=json.dumps(payload, default=str),
-            media_type="application/json",
-        )
-
-    return PlainTextResponse(
-        content=json.dumps(payload, indent=2, sort_keys=False, default=str),
+    indent = None if format == "raw" else 2
+    return Response(
+        content=json.dumps(payload, indent=indent, sort_keys=False, default=str),
         media_type="application/json",
     )

--- a/src/family_assistant/web/routers/debug_api.py
+++ b/src/family_assistant/web/routers/debug_api.py
@@ -146,9 +146,21 @@ def resolve_live_llm_model(llm_client: object) -> str | None:
 def resolve_live_llm_fallback_model(llm_client: object) -> str | None:
     """Return the configured fallback model for ``RetryingLLMClient``, if any.
 
-    Only ``RetryingLLMClient`` exposes a fallback chain; concrete provider
-    clients do not, so this returns ``None`` for them.
+    ``RetryingLLMClient.__init__`` sets ``self.fallback_model`` to a hard-coded
+    default string even when the caller passes ``fallback_client=None``, so we
+    MUST gate on the presence of a real ``fallback_client`` — otherwise every
+    primary-only retry profile would falsely appear to have a fallback. We use
+    ``hasattr`` + truthiness of ``fallback_client`` as the "fallback is actually
+    wired" signal, and only then surface ``fallback_model``.
+
+    Concrete provider clients (``OpenAIClient``, ``AnthropicClient``,
+    ``GoogleGenAIClient``) do not expose a fallback chain at all, so this
+    returns ``None`` for them.
     """
+    if not hasattr(llm_client, "fallback_client"):
+        return None
+    if not getattr(llm_client, "fallback_client", None):
+        return None
     fallback = getattr(llm_client, "fallback_model", None)
     if not isinstance(fallback, str):
         return None

--- a/tests/functional/web/api/test_debug_api.py
+++ b/tests/functional/web/api/test_debug_api.py
@@ -330,6 +330,7 @@ async def test_dump_profiles_includes_runtime_info(
         trusted = next(p for p in data["profiles"] if p["id"] == "trusted")
         assert trusted["runtime"]["kind"] == "local"
         assert trusted["runtime"]["llm_model"] == "gpt-5-turbo"
+        assert trusted["runtime"]["llm_fallback_model"] is None
         assert trusted["runtime"]["llm_client_class"] == "_OpenAILikeClient"
         assert trusted["runtime"]["context_providers"] == ["notes"]
         # provider should NOT be in runtime: no concrete client exposes it.
@@ -339,7 +340,56 @@ async def test_dump_profiles_includes_runtime_info(
         # Google-like client: model_name with "models/" prefix is normalized.
         assert readonly["runtime"]["kind"] == "local"
         assert readonly["runtime"]["llm_model"] == "gemini-2.5-pro"
+        assert readonly["runtime"]["llm_fallback_model"] is None
         assert readonly["runtime"]["llm_client_class"] == "_GoogleLikeClient"
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_runtime_info_for_retrying_llm_client(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """RetryingLLMClient exposes model names on primary_model / fallback_model.
+
+    Profiles configured with ``processing_config.retry_config`` get their LLM
+    client wrapped by ``RetryingLLMClient`` in production (see ``assistant.py``).
+    That wrapper does not have ``model`` or ``model_name`` attributes; it stores
+    the active identifier on ``self.primary_model`` and the fallback on
+    ``self.fallback_model``. The endpoint must handle this wrapper shape or
+    ``/api/debug/profiles`` would emit ``"llm_model": null`` for any profile
+    using retry/fallback — a supported production configuration.
+    """
+
+    class _RetryingLikeClient:
+        """Mirrors RetryingLLMClient — wraps primary/fallback clients."""
+
+        def __init__(self) -> None:
+            self.primary_model = "anthropic/claude-sonnet-4"
+            self.fallback_model = "models/gemini-2.5-flash"
+            # Real RetryingLLMClient also has primary_client / fallback_client,
+            # but the endpoint never reads those and we don't need them here.
+
+    class _RetryingLocalService:
+        kind = "local"
+
+        def __init__(self) -> None:
+            self.llm_client = _RetryingLikeClient()
+            self.context_providers: list[object] = []
+
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry({"trusted": _RetryingLocalService()})
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 200
+        trusted = next(p for p in response.json()["profiles"] if p["id"] == "trusted")
+        runtime = trusted["runtime"]
+        assert runtime["kind"] == "local"
+        assert runtime["llm_model"] == "anthropic/claude-sonnet-4"
+        # Fallback's "models/" prefix is normalized too.
+        assert runtime["llm_fallback_model"] == "gemini-2.5-flash"
+        assert runtime["llm_client_class"] == "_RetryingLikeClient"
     finally:
         _restore_registry(original_registry)
         _restore_config(original_config)

--- a/tests/functional/web/api/test_debug_api.py
+++ b/tests/functional/web/api/test_debug_api.py
@@ -98,6 +98,9 @@ def _make_sample_config() -> AppConfig:
     )
 
     return AppConfig(
+        # The endpoint fails closed when auth is disabled unless dev_mode is
+        # explicitly on; these tests run with auth disabled so they opt in here.
+        dev_mode=True,
         default_service_profile_id="trusted",
         service_profiles=[profile_a, profile_b],
         default_profile_settings=DefaultProfileSettings(
@@ -272,26 +275,49 @@ async def test_dump_profiles_raw_format_is_compact(
 async def test_dump_profiles_includes_runtime_info(
     api_client: httpx.AsyncClient,
 ) -> None:
-    """Runtime info from the services registry is included when available."""
+    """Runtime info is extracted using the same attribute shapes the real LLM clients use.
 
-    class _FakeLLM:
-        model = "gemini/gemini-2.5-pro"
-        provider = "google"
+    ``OpenAIClient`` / ``AnthropicClient`` expose ``self.model``, while
+    ``GoogleGenAIClient`` uses ``self.model_name`` with a leading ``models/``
+    prefix. The endpoint must surface the live model for all shapes and must
+    NOT re-emit a configured-only ``provider`` field (no concrete client
+    exposes one). This test uses small classes that mirror those real attribute
+    shapes to catch regressions where the endpoint reads from a
+    non-existent attribute.
+    """
+
+    class _OpenAILikeClient:
+        """Mirrors OpenAIClient/AnthropicClient — sets ``self.model``."""
+
+        def __init__(self) -> None:
+            self.model = "gpt-5-turbo"
+
+    class _GoogleLikeClient:
+        """Mirrors GoogleGenAIClient — sets ``self.model_name`` with ``models/`` prefix."""
+
+        def __init__(self) -> None:
+            self.model_name = "models/gemini-2.5-pro"
 
     class _FakeContextProvider:
         name = "notes"
 
-    class _FakeLocalService:
+    class _OpenAILocalService:
         kind = "local"
-        llm_client = _FakeLLM()
-        context_providers = [_FakeContextProvider()]
 
-    class _FakeRemoteService:
-        kind = "remote"
+        def __init__(self) -> None:
+            self.llm_client = _OpenAILikeClient()
+            self.context_providers = [_FakeContextProvider()]
+
+    class _GoogleLocalService:
+        kind = "local"
+
+        def __init__(self) -> None:
+            self.llm_client = _GoogleLikeClient()
+            self.context_providers = [_FakeContextProvider()]
 
     registry = {
-        "trusted": _FakeLocalService(),
-        "readonly": _FakeRemoteService(),
+        "trusted": _OpenAILocalService(),  # exercises the .model path
+        "readonly": _GoogleLocalService(),  # exercises the .model_name path
     }
 
     original_config = _install_test_config(_make_sample_config())
@@ -303,15 +329,38 @@ async def test_dump_profiles_includes_runtime_info(
 
         trusted = next(p for p in data["profiles"] if p["id"] == "trusted")
         assert trusted["runtime"]["kind"] == "local"
-        assert trusted["runtime"]["llm_model"] == "gemini/gemini-2.5-pro"
-        assert trusted["runtime"]["llm_provider"] == "google"
-        assert trusted["runtime"]["llm_client_class"] == "_FakeLLM"
+        assert trusted["runtime"]["llm_model"] == "gpt-5-turbo"
+        assert trusted["runtime"]["llm_client_class"] == "_OpenAILikeClient"
         assert trusted["runtime"]["context_providers"] == ["notes"]
+        # provider should NOT be in runtime: no concrete client exposes it.
+        assert "llm_provider" not in trusted["runtime"]
 
         readonly = next(p for p in data["profiles"] if p["id"] == "readonly")
-        assert readonly["runtime"] == {"kind": "remote"}
+        # Google-like client: model_name with "models/" prefix is normalized.
+        assert readonly["runtime"]["kind"] == "local"
+        assert readonly["runtime"]["llm_model"] == "gemini-2.5-pro"
+        assert readonly["runtime"]["llm_client_class"] == "_GoogleLikeClient"
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
 
-        assert data["registered_service_ids"] == ["readonly", "trusted"]
+
+@pytest.mark.asyncio
+async def test_dump_profiles_remote_services_have_no_live_llm_fields(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """Remote A2A profiles surface only ``kind`` in runtime info."""
+
+    class _RemoteService:
+        kind = "remote"
+
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry({"trusted": _RemoteService()})
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 200
+        trusted = next(p for p in response.json()["profiles"] if p["id"] == "trusted")
+        assert trusted["runtime"] == {"kind": "remote"}
     finally:
         _restore_registry(original_registry)
         _restore_config(original_config)
@@ -345,6 +394,7 @@ async def test_dump_profiles_includes_operator_layer(
         ),
     )
     config = AppConfig(
+        dev_mode=True,  # opt in to debug dump when auth is disabled
         default_service_profile_id="with_operator_overrides",
         service_profiles=[profile],
         default_profile_settings=DefaultProfileSettings(),
@@ -413,6 +463,7 @@ async def test_dump_profiles_reflects_resolved_defaults(
     this test would catch it.
     """
     config_data = {
+        "dev_mode": True,  # endpoint fails closed without real auth otherwise
         "default_service_profile_id": "inheriting_profile",
         "default_profile_settings": {
             "processing_config": {
@@ -527,6 +578,64 @@ async def test_dump_profiles_returns_503_without_config(
         _restore_registry(original_registry)
         if original_config is not None:
             fastapi_app.state.config = original_config
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_fails_closed_when_auth_disabled_and_dev_mode_off(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """With auth disabled and dev_mode off, the endpoint returns 403.
+
+    ``get_current_user`` returns a synthetic test user when
+    ``auth_service.auth_enabled`` is false, which would otherwise let an
+    unauthenticated caller read prompts / policy / runtime state. The endpoint
+    must refuse to respond in that configuration unless the operator has
+    explicitly set ``dev_mode=true``.
+    """
+    config = _make_sample_config()
+    config.dev_mode = False  # override the default enabled by _make_sample_config
+    original_config = _install_test_config(config)
+    original_registry = _install_registry({})
+    # Ensure no real auth_service is attached — mirrors auth-disabled deployments.
+    original_auth = getattr(fastapi_app.state, "auth_service", None)
+    if hasattr(fastapi_app.state, "auth_service"):
+        del fastapi_app.state.auth_service
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 403
+        # No profile data should leak in the error body.
+        assert "default_service_profile_id" not in response.text
+    finally:
+        if original_auth is not None:
+            fastapi_app.state.auth_service = original_auth
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_dev_mode_bypasses_fail_closed_check(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """With dev_mode=True and no auth service, the endpoint still responds 200.
+
+    This is the explicit opt-in path for local development: the operator sets
+    ``app_config.dev_mode=true`` to accept responsibility for the exposure.
+    """
+    config = _make_sample_config()  # dev_mode=True from the helper
+    original_config = _install_test_config(config)
+    original_registry = _install_registry({})
+    original_auth = getattr(fastapi_app.state, "auth_service", None)
+    if hasattr(fastapi_app.state, "auth_service"):
+        del fastapi_app.state.auth_service
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 200
+        assert response.json()["default_service_profile_id"] == "trusted"
+    finally:
+        if original_auth is not None:
+            fastapi_app.state.auth_service = original_auth
+        _restore_registry(original_registry)
+        _restore_config(original_config)
 
 
 class _FakeAuthService:

--- a/tests/functional/web/api/test_debug_api.py
+++ b/tests/functional/web/api/test_debug_api.py
@@ -331,3 +331,82 @@ async def test_dump_profiles_returns_503_without_config(
         _restore_registry(original_registry)
         if original_config is not None:
             fastapi_app.state.config = original_config
+
+
+class _FakeAuthService:
+    """Minimal stand-in for AuthService with auth enabled and no valid sessions/tokens."""
+
+    auth_enabled = True
+    oauth = None
+
+    async def get_user_from_api_token(
+        self,
+        auth_header: str,  # noqa: ARG002 - protocol requires this parameter
+        request: object,  # noqa: ARG002 - protocol requires this parameter
+    ) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_requires_authentication(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """With auth enabled, unauthenticated requests to /api/debug/profiles return 401."""
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry({})
+    original_auth = getattr(fastapi_app.state, "auth_service", None)
+    fastapi_app.state.auth_service = _FakeAuthService()
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 401
+        # The response must not leak profile data when unauthenticated.
+        assert "default_service_profile_id" not in response.text
+    finally:
+        if original_auth is not None:
+            fastapi_app.state.auth_service = original_auth
+        else:
+            del fastapi_app.state.auth_service
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_accepts_valid_bearer_token(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """With auth enabled, a valid bearer token lets the caller read the dump."""
+
+    class _AcceptingAuthService(_FakeAuthService):
+        async def get_user_from_api_token(
+            self,
+            auth_header: str,
+            request: object,  # noqa: ARG002 - protocol requires this parameter
+        ) -> dict | None:
+            if auth_header == "Bearer good-token":
+                return {"sub": "tester", "source": "api_token"}
+            return None
+
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry({})
+    original_auth = getattr(fastapi_app.state, "auth_service", None)
+    fastapi_app.state.auth_service = _AcceptingAuthService()
+    try:
+        bad = await api_client.get(
+            "/api/debug/profiles",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        assert bad.status_code == 401
+
+        good = await api_client.get(
+            "/api/debug/profiles",
+            headers={"Authorization": "Bearer good-token"},
+        )
+        assert good.status_code == 200
+        assert good.json()["default_service_profile_id"] == "trusted"
+    finally:
+        if original_auth is not None:
+            fastapi_app.state.auth_service = original_auth
+        else:
+            del fastapi_app.state.auth_service
+        _restore_registry(original_registry)
+        _restore_config(original_config)

--- a/tests/functional/web/api/test_debug_api.py
+++ b/tests/functional/web/api/test_debug_api.py
@@ -9,6 +9,7 @@ import pytest
 from family_assistant.config_models import (
     AppConfig,
     DefaultProfileSettings,
+    MCPServerLoadingEntry,
     ProcessingConfig,
     ServiceProfile,
     ToolLoadingEntry,
@@ -310,6 +311,88 @@ async def test_dump_profiles_includes_runtime_info(
         assert readonly["runtime"] == {"kind": "remote"}
 
         assert data["registered_service_ids"] == ["readonly", "trusted"]
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_includes_operator_layer(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """Operator-layer policy/MCP overrides are exposed even though model_dump excludes them.
+
+    ``ServiceProfile.operator_tools_policy`` and ``operator_mcp_server_ids`` are
+    declared with ``exclude=True`` so Pydantic's default ``model_dump()`` leaves
+    them out. At runtime they get merged into the effective policy alongside
+    the profile-layer rules, so the debug endpoint must surface them or it will
+    misrepresent how tools will actually be gated.
+    """
+    profile = ServiceProfile(
+        id="with_operator_overrides",
+        description="Profile with operator-layer policy overrides.",
+        processing_config=ProcessingConfig(llm_model="gemini/gemini-2.5-flash"),
+        tools_policy=ToolPolicyConfig(
+            rules=[
+                PolicyRule(
+                    match=ToolMatcher(names=["profile_*"]),
+                    decision=ToolPolicyDecision.ALLOW,
+                    description="Profile-layer rule",
+                ),
+            ],
+            default_decision=ToolPolicyDecision.CONFIRM,
+        ),
+    )
+    config = AppConfig(
+        default_service_profile_id="with_operator_overrides",
+        service_profiles=[profile],
+        default_profile_settings=DefaultProfileSettings(),
+    )
+    # ServiceProfile declares operator_tools_policy / operator_mcp_server_ids with
+    # exclude=True, so passing them to AppConfig(...) would strip them during
+    # nested re-validation. In production they are set programmatically after
+    # config load, so we mirror that here.
+    config.service_profiles[0].operator_tools_policy = ToolPolicyConfig(
+        rules=[
+            PolicyRule(
+                match=ToolMatcher(names=["operator_*"]),
+                decision=ToolPolicyDecision.DENY,
+                description="Operator-layer override",
+            ),
+        ],
+        default_decision=ToolPolicyDecision.DENY,
+    )
+    config.service_profiles[0].operator_mcp_server_ids = [
+        "operator_eager_mcp",
+        MCPServerLoadingEntry(id="operator_lazy_mcp", loading="on_demand"),
+    ]
+
+    original_config = _install_test_config(config)
+    original_registry = _install_registry({})
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 200
+        dumped = response.json()["profiles"][0]["config"]
+
+        operator_policy = dumped["operator_tools_policy"]
+        assert operator_policy is not None
+        assert operator_policy["default_decision"] == "deny"
+        assert len(operator_policy["rules"]) == 1
+        assert operator_policy["rules"][0]["match"]["names"] == ["operator_*"]
+        assert operator_policy["rules"][0]["decision"] == "deny"
+        assert operator_policy["rules"][0]["description"] == "Operator-layer override"
+
+        # MCP overrides serialize plain strings as strings and loading entries as dicts.
+        assert "operator_eager_mcp" in dumped["operator_mcp_server_ids"]
+        lazy = next(
+            entry
+            for entry in dumped["operator_mcp_server_ids"]
+            if isinstance(entry, dict)
+        )
+        assert lazy == {"id": "operator_lazy_mcp", "loading": "on_demand"}
+
+        # The profile-layer policy is still present alongside the operator layer.
+        assert dumped["tools_policy"]["rules"][0]["match"]["names"] == ["profile_*"]
     finally:
         _restore_registry(original_registry)
         _restore_config(original_config)

--- a/tests/functional/web/api/test_debug_api.py
+++ b/tests/functional/web/api/test_debug_api.py
@@ -6,6 +6,7 @@ from typing import Any
 import httpx
 import pytest
 
+from family_assistant.config_loader import resolve_all_service_profiles
 from family_assistant.config_models import (
     AppConfig,
     DefaultProfileSettings,
@@ -393,6 +394,118 @@ async def test_dump_profiles_includes_operator_layer(
 
         # The profile-layer policy is still present alongside the operator layer.
         assert dumped["tools_policy"]["rules"][0]["match"]["names"] == ["profile_*"]
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_reflects_resolved_defaults(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """Fields inherited from default_profile_settings must appear in each profile's dump.
+
+    Uses ``resolve_all_service_profiles`` — the same resolver
+    ``config_loader.load_config`` runs in production — so the profiles that end
+    up in ``config.service_profiles`` have defaults merged the same way the app
+    sees them at runtime. If the endpoint ever switched to
+    ``model_dump(exclude_defaults=True)`` or otherwise dropped inherited values,
+    this test would catch it.
+    """
+    config_data = {
+        "default_service_profile_id": "inheriting_profile",
+        "default_profile_settings": {
+            "processing_config": {
+                "timezone": "Australia/Sydney",
+                "max_history_messages": 11,
+                "history_max_age_hours": 48.0,
+                "llm_model": "gemini/default-model",
+            },
+            "tools_config": {
+                "confirm_tools": ["delete_note"],
+            },
+        },
+        "service_profiles": [
+            {
+                "id": "inheriting_profile",
+                "description": "Inherits defaults without overriding them.",
+            },
+        ],
+    }
+    resolved = resolve_all_service_profiles(config_data, {})
+    config_data["service_profiles"] = resolved
+    app_config = AppConfig.model_validate(config_data)
+
+    original_config = _install_test_config(app_config)
+    original_registry = _install_registry({})
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 200
+        data = response.json()
+
+        profile_config = data["profiles"][0]["config"]
+        processing = profile_config["processing_config"]
+        # These values come from default_profile_settings, not from the profile
+        # definition, so the endpoint only surfaces them if it emits the
+        # already-merged ServiceProfile (as production does).
+        assert processing["timezone"] == "Australia/Sydney"
+        assert processing["max_history_messages"] == 11
+        assert processing["history_max_age_hours"] == 48.0
+        assert processing["llm_model"] == "gemini/default-model"
+        assert profile_config["tools_config"]["confirm_tools"] == ["delete_note"]
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_default_settings_include_operator_layer(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """default_profile_settings also exposes excluded operator-layer fields.
+
+    ``DefaultProfileSettings.operator_tools_policy`` and
+    ``operator_mcp_server_ids`` have ``exclude=True`` for the same reason the
+    profile-level fields do, and they apply to every profile at runtime. The
+    top-level ``default_profile_settings`` dump must include them too or a
+    consumer reading this endpoint will misjudge the effective policy.
+    """
+    config = _make_sample_config()
+    config.default_profile_settings.operator_tools_policy = ToolPolicyConfig(
+        rules=[
+            PolicyRule(
+                match=ToolMatcher(names=["global_*"]),
+                decision=ToolPolicyDecision.DENY,
+                description="Global operator override",
+            ),
+        ],
+        default_decision=ToolPolicyDecision.DENY,
+    )
+    config.default_profile_settings.operator_mcp_server_ids = [
+        "global_eager_mcp",
+        MCPServerLoadingEntry(id="global_lazy_mcp", loading="on_demand"),
+    ]
+
+    original_config = _install_test_config(config)
+    original_registry = _install_registry({})
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 200
+        defaults = response.json()["default_profile_settings"]
+
+        op_policy = defaults["operator_tools_policy"]
+        assert op_policy is not None
+        assert op_policy["default_decision"] == "deny"
+        assert op_policy["rules"][0]["match"]["names"] == ["global_*"]
+        assert op_policy["rules"][0]["description"] == "Global operator override"
+
+        assert "global_eager_mcp" in defaults["operator_mcp_server_ids"]
+        lazy = next(
+            entry
+            for entry in defaults["operator_mcp_server_ids"]
+            if isinstance(entry, dict)
+        )
+        assert lazy == {"id": "global_lazy_mcp", "loading": "on_demand"}
     finally:
         _restore_registry(original_registry)
         _restore_config(original_config)

--- a/tests/functional/web/api/test_debug_api.py
+++ b/tests/functional/web/api/test_debug_api.py
@@ -1,0 +1,333 @@
+"""Functional tests for debug API endpoints, including the profile config dump."""
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from family_assistant.config_models import (
+    AppConfig,
+    DefaultProfileSettings,
+    ProcessingConfig,
+    ServiceProfile,
+    ToolLoadingEntry,
+    ToolsConfig,
+)
+from family_assistant.tools.metadata import ToolTag
+from family_assistant.tools.policy import (
+    PolicyRule,
+    ToolMatcher,
+    ToolPolicyConfig,
+    ToolPolicyDecision,
+)
+from family_assistant.web.app_creator import app as fastapi_app
+
+
+def _install_test_config(config: AppConfig) -> AppConfig | None:
+    """Swap in a test AppConfig, returning the prior config for restoration."""
+    original = getattr(fastapi_app.state, "config", None)
+    fastapi_app.state.config = config
+    return original
+
+
+def _restore_config(original: AppConfig | None) -> None:
+    if original is not None:
+        fastapi_app.state.config = original
+    elif hasattr(fastapi_app.state, "config"):
+        del fastapi_app.state.config
+
+
+def _make_sample_config() -> AppConfig:
+    """Build an AppConfig with two profiles exercising policies, tools, and prompts."""
+    profile_a = ServiceProfile(
+        id="trusted",
+        description="Trusted profile with full tool access.",
+        processing_config=ProcessingConfig(
+            llm_model="gemini/gemini-2.5-pro",
+            provider="google",
+            max_iterations=7,
+            home_assistant_token="super-secret-ha-token",  # should be redacted
+            prompts={
+                "system_prompt": "You are a helpful assistant for {user_name}.",
+            },
+        ),
+        tools_config=ToolsConfig(
+            enable_local_tools=[
+                "add_or_update_note",
+                ToolLoadingEntry(name="search_documents", loading="on_demand"),
+            ],
+            enable_mcp_server_ids=["time"],
+            confirm_tools=["delete_note"],
+        ),
+        tools_policy=ToolPolicyConfig(
+            rules=[
+                PolicyRule(
+                    match=ToolMatcher(names=["delete_*"]),
+                    decision=ToolPolicyDecision.CONFIRM,
+                    priority=50,
+                    description="Require confirmation for destructive operations.",
+                ),
+                PolicyRule(
+                    match=ToolMatcher(tags_any=[ToolTag.READ_ONLY]),
+                    decision=ToolPolicyDecision.ALLOW,
+                    priority=10,
+                    description="Read-only tools are always allowed.",
+                ),
+            ],
+            default_decision=ToolPolicyDecision.ALLOW,
+        ),
+        slash_commands=["engineer"],
+        visibility_grants=["family"],
+    )
+
+    profile_b = ServiceProfile(
+        id="readonly",
+        description="Read-only analysis profile.",
+        processing_config=ProcessingConfig(
+            llm_model="gemini/gemini-2.5-flash",
+            provider="google",
+            max_iterations=3,
+        ),
+        tools_config=ToolsConfig(
+            enable_local_tools=["search_documents"],
+            confirm_tools=[],
+        ),
+    )
+
+    return AppConfig(
+        default_service_profile_id="trusted",
+        service_profiles=[profile_a, profile_b],
+        default_profile_settings=DefaultProfileSettings(
+            processing_config=ProcessingConfig(
+                timezone="Australia/Sydney",
+                max_iterations=5,
+            ),
+        ),
+    )
+
+
+# ast-grep-ignore: no-dict-any - Test helper wraps the runtime processing services registry
+def _install_registry(registry: dict[str, Any]) -> dict[str, Any] | None:
+    original = getattr(fastapi_app.state, "processing_services", None)
+    fastapi_app.state.processing_services = registry
+    return original
+
+
+# ast-grep-ignore: no-dict-any - Test helper wraps the runtime processing services registry
+def _restore_registry(original: dict[str, Any] | None) -> None:
+    if original is not None:
+        fastapi_app.state.processing_services = original
+    elif hasattr(fastapi_app.state, "processing_services"):
+        del fastapi_app.state.processing_services
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_returns_full_config(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """/api/debug/profiles returns the resolved configs for every profile."""
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry({})
+    try:
+        response = await api_client.get("/api/debug/profiles")
+
+        assert response.status_code == 200
+        assert "application/json" in response.headers["content-type"]
+
+        # Default format is pretty-printed JSON.
+        raw_text = response.text
+        assert "\n" in raw_text, "Expected pretty-printed JSON with newlines"
+        assert "  " in raw_text, "Expected indented JSON output"
+
+        data = response.json()
+        assert data["default_service_profile_id"] == "trusted"
+        assert data["profile_count"] == 2
+
+        profile_ids = [p["id"] for p in data["profiles"]]
+        assert profile_ids == ["trusted", "readonly"]
+
+        trusted = data["profiles"][0]
+        assert trusted["description"] == "Trusted profile with full tool access."
+        processing = trusted["config"]["processing_config"]
+        assert processing["llm_model"] == "gemini/gemini-2.5-pro"
+        assert processing["max_iterations"] == 7
+        assert (
+            processing["prompts"]["system_prompt"]
+            == "You are a helpful assistant for {user_name}."
+        )
+
+        tools_config = trusted["config"]["tools_config"]
+        # Plain strings stay as strings; on-demand entries become dicts.
+        assert "add_or_update_note" in tools_config["enable_local_tools"]
+        on_demand = next(
+            entry
+            for entry in tools_config["enable_local_tools"]
+            if isinstance(entry, dict)
+        )
+        assert on_demand == {"name": "search_documents", "loading": "on_demand"}
+        assert tools_config["enable_mcp_server_ids"] == ["time"]
+        assert tools_config["confirm_tools"] == ["delete_note"]
+
+        # Policy rules are fully serialized.
+        policy = trusted["config"]["tools_policy"]
+        assert policy["default_decision"] == "allow"
+        assert len(policy["rules"]) == 2
+        first_rule = policy["rules"][0]
+        assert first_rule["decision"] == "confirm"
+        assert first_rule["priority"] == 50
+        assert first_rule["description"] == (
+            "Require confirmation for destructive operations."
+        )
+        assert first_rule["match"]["names"] == ["delete_*"]
+
+        # Default profile settings are also exposed.
+        assert (
+            data["default_profile_settings"]["processing_config"]["timezone"]
+            == "Australia/Sydney"
+        )
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_redacts_sensitive_fields(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """Token/password-like fields are replaced with [REDACTED]."""
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry({})
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 200
+        data = response.json()
+
+        trusted = data["profiles"][0]
+        token = trusted["config"]["processing_config"]["home_assistant_token"]
+        assert token == "[REDACTED]"
+        assert "super-secret-ha-token" not in response.text
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_filter_by_id(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """The profile_id query param filters to a single profile."""
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry({})
+    try:
+        response = await api_client.get("/api/debug/profiles?profile_id=readonly")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["profile_count"] == 1
+        assert data["profiles"][0]["id"] == "readonly"
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_filter_unknown_id_returns_404(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """Requesting an unknown profile returns 404."""
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry({})
+    try:
+        response = await api_client.get("/api/debug/profiles?profile_id=does_not_exist")
+        assert response.status_code == 404
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_raw_format_is_compact(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """The raw format returns compact JSON (no indentation)."""
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry({})
+    try:
+        response = await api_client.get("/api/debug/profiles?format=raw")
+
+        assert response.status_code == 200
+        # Compact JSON has no indentation.
+        assert "\n  " not in response.text
+        data = json.loads(response.text)
+        assert data["profile_count"] == 2
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_includes_runtime_info(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """Runtime info from the services registry is included when available."""
+
+    class _FakeLLM:
+        model = "gemini/gemini-2.5-pro"
+        provider = "google"
+
+    class _FakeContextProvider:
+        name = "notes"
+
+    class _FakeLocalService:
+        kind = "local"
+        llm_client = _FakeLLM()
+        context_providers = [_FakeContextProvider()]
+
+    class _FakeRemoteService:
+        kind = "remote"
+
+    registry = {
+        "trusted": _FakeLocalService(),
+        "readonly": _FakeRemoteService(),
+    }
+
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry(registry)
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 200
+        data = response.json()
+
+        trusted = next(p for p in data["profiles"] if p["id"] == "trusted")
+        assert trusted["runtime"]["kind"] == "local"
+        assert trusted["runtime"]["llm_model"] == "gemini/gemini-2.5-pro"
+        assert trusted["runtime"]["llm_provider"] == "google"
+        assert trusted["runtime"]["llm_client_class"] == "_FakeLLM"
+        assert trusted["runtime"]["context_providers"] == ["notes"]
+
+        readonly = next(p for p in data["profiles"] if p["id"] == "readonly")
+        assert readonly["runtime"] == {"kind": "remote"}
+
+        assert data["registered_service_ids"] == ["readonly", "trusted"]
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_returns_503_without_config(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """Without an initialized config, the endpoint reports 503."""
+    original_config = getattr(fastapi_app.state, "config", None)
+    if hasattr(fastapi_app.state, "config"):
+        del fastapi_app.state.config
+    original_registry = _install_registry({})
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 503
+    finally:
+        _restore_registry(original_registry)
+        if original_config is not None:
+            fastapi_app.state.config = original_config

--- a/tests/functional/web/api/test_debug_api.py
+++ b/tests/functional/web/api/test_debug_api.py
@@ -362,14 +362,23 @@ async def test_dump_profiles_runtime_info_for_retrying_llm_client(
     using retry/fallback — a supported production configuration.
     """
 
+    class _InnerClient:
+        """Stand-in for the primary/fallback provider client that RetryingLLMClient wraps."""
+
     class _RetryingLikeClient:
-        """Mirrors RetryingLLMClient — wraps primary/fallback clients."""
+        """Mirrors RetryingLLMClient — wraps primary/fallback clients.
+
+        Sets ``fallback_client`` to a truthy object to signal that a fallback
+        is actually configured. ``RetryingLLMClient.__init__`` always sets
+        ``self.fallback_model`` to a default string, so the endpoint uses
+        ``fallback_client`` as the "fallback is wired" signal.
+        """
 
         def __init__(self) -> None:
+            self.primary_client = _InnerClient()
             self.primary_model = "anthropic/claude-sonnet-4"
+            self.fallback_client = _InnerClient()
             self.fallback_model = "models/gemini-2.5-flash"
-            # Real RetryingLLMClient also has primary_client / fallback_client,
-            # but the endpoint never reads those and we don't need them here.
 
     class _RetryingLocalService:
         kind = "local"
@@ -390,6 +399,53 @@ async def test_dump_profiles_runtime_info_for_retrying_llm_client(
         # Fallback's "models/" prefix is normalized too.
         assert runtime["llm_fallback_model"] == "gemini-2.5-flash"
         assert runtime["llm_client_class"] == "_RetryingLikeClient"
+    finally:
+        _restore_registry(original_registry)
+        _restore_config(original_config)
+
+
+@pytest.mark.asyncio
+async def test_dump_profiles_retrying_llm_client_without_fallback_reports_no_fallback(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """Primary-only retry_config profiles must not falsely advertise a fallback.
+
+    ``RetryingLLMClient.__init__`` always stores a default string on
+    ``self.fallback_model`` (currently ``"openai/gpt-5.2"``) even when
+    ``fallback_client=None``, so a naive read of ``fallback_model`` would
+    misrepresent every primary-only retry profile as having a fallback.
+    """
+
+    class _PrimaryOnlyRetrying:
+        def __init__(self) -> None:
+            self.primary_client = object()
+            self.primary_model = "anthropic/claude-sonnet-4"
+            # Mirrors RetryingLLMClient: fallback_client=None but
+            # fallback_model retains its default string because of the
+            # ``fallback_model or "openai/gpt-5.2"`` constructor logic.
+            self.fallback_client = None
+            self.fallback_model = "openai/gpt-5.2"
+
+    class _PrimaryOnlyService:
+        kind = "local"
+
+        def __init__(self) -> None:
+            self.llm_client = _PrimaryOnlyRetrying()
+            self.context_providers: list[object] = []
+
+    original_config = _install_test_config(_make_sample_config())
+    original_registry = _install_registry({"trusted": _PrimaryOnlyService()})
+    try:
+        response = await api_client.get("/api/debug/profiles")
+        assert response.status_code == 200
+        runtime = next(p for p in response.json()["profiles"] if p["id"] == "trusted")[
+            "runtime"
+        ]
+        assert runtime["llm_model"] == "anthropic/claude-sonnet-4"
+        assert runtime["llm_fallback_model"] is None
+        # Sanity: the default fallback string must not leak into the response
+        # anywhere, since no fallback_client is configured.
+        assert "openai/gpt-5.2" not in response.text
     finally:
         _restore_registry(original_registry)
         _restore_config(original_config)

--- a/tests/unit/web/test_debug_api_helpers.py
+++ b/tests/unit/web/test_debug_api_helpers.py
@@ -8,6 +8,7 @@ from family_assistant.web.routers.debug_api import (
     SENSITIVE_FIELD_NAMES,
     is_sensitive_field_name,
     redact_sensitive_config,
+    resolve_live_llm_fallback_model,
     resolve_live_llm_model,
 )
 
@@ -76,6 +77,66 @@ def test_resolve_live_llm_model_prefers_model_over_model_name() -> None:
         model_name = "models/gemini-2.5-pro"
 
     assert resolve_live_llm_model(_Both()) == "gpt-5-turbo"
+
+
+def test_resolve_live_llm_model_reads_primary_model_on_retrying_client() -> None:
+    """RetryingLLMClient shape: the wrapper sets ``self.primary_model`` only.
+
+    It does NOT expose ``.model`` or ``.model_name`` itself, so the helper
+    must check ``primary_model`` first to correctly report the active model
+    for profiles configured with ``processing_config.retry_config``.
+    """
+
+    class _RetryingLike:
+        primary_model = "anthropic/claude-sonnet-4"
+        fallback_model = "openai/gpt-5.2"
+
+    assert resolve_live_llm_model(_RetryingLike()) == "anthropic/claude-sonnet-4"
+
+
+def test_resolve_live_llm_model_prefers_primary_model_over_plain_model() -> None:
+    """When both are present, primary_model wins — it reflects the wrapper's choice."""
+
+    class _Hybrid:
+        primary_model = "primary-one"
+        model = "concrete-two"
+
+    assert resolve_live_llm_model(_Hybrid()) == "primary-one"
+
+
+def test_resolve_live_llm_model_strips_google_prefix_from_primary_model() -> None:
+    """The ``models/`` prefix normalization also applies to primary_model."""
+
+    class _RetryingGoogle:
+        primary_model = "models/gemini-2.5-pro"
+
+    assert resolve_live_llm_model(_RetryingGoogle()) == "gemini-2.5-pro"
+
+
+def test_resolve_live_llm_fallback_model_returns_configured_fallback() -> None:
+    class _RetryingLike:
+        fallback_model = "openai/gpt-5.2"
+
+    assert resolve_live_llm_fallback_model(_RetryingLike()) == "openai/gpt-5.2"
+
+
+def test_resolve_live_llm_fallback_model_strips_google_prefix() -> None:
+    class _RetryingGoogleFallback:
+        fallback_model = "models/gemini-2.5-flash"
+
+    assert (
+        resolve_live_llm_fallback_model(_RetryingGoogleFallback()) == "gemini-2.5-flash"
+    )
+
+
+def test_resolve_live_llm_fallback_model_returns_none_for_plain_client() -> None:
+    """Concrete provider clients do not have a fallback_model attribute."""
+
+    class _OpenAILike:
+        model = "gpt-5-turbo"
+
+    assert resolve_live_llm_fallback_model(_OpenAILike()) is None
+    assert resolve_live_llm_fallback_model(None) is None
 
 
 def testredact_sensitive_config_walks_nested_structures() -> None:

--- a/tests/unit/web/test_debug_api_helpers.py
+++ b/tests/unit/web/test_debug_api_helpers.py
@@ -8,6 +8,7 @@ from family_assistant.web.routers.debug_api import (
     SENSITIVE_FIELD_NAMES,
     is_sensitive_field_name,
     redact_sensitive_config,
+    resolve_live_llm_model,
 )
 
 
@@ -39,6 +40,42 @@ def test_non_secret_field_names_are_not_redacted() -> None:
         "enable_local_tools",
     ):
         assert not is_sensitive_field_name(name), name
+
+
+def test_resolve_live_llm_model_reads_model_attribute() -> None:
+    """OpenAIClient/AnthropicClient shape: ``self.model``."""
+
+    class _OpenAILike:
+        model = "gpt-5-turbo"
+
+    assert resolve_live_llm_model(_OpenAILike()) == "gpt-5-turbo"
+
+
+def test_resolve_live_llm_model_reads_model_name_and_strips_prefix() -> None:
+    """GoogleGenAIClient shape: ``self.model_name`` with ``models/`` prefix."""
+
+    class _GoogleLike:
+        model_name = "models/gemini-2.5-pro"
+
+    assert resolve_live_llm_model(_GoogleLike()) == "gemini-2.5-pro"
+
+
+def test_resolve_live_llm_model_returns_none_when_no_attribute() -> None:
+    class _BareClient:
+        pass
+
+    assert resolve_live_llm_model(_BareClient()) is None
+    assert resolve_live_llm_model(None) is None
+
+
+def test_resolve_live_llm_model_prefers_model_over_model_name() -> None:
+    """When both attributes are present, ``model`` takes precedence."""
+
+    class _Both:
+        model = "gpt-5-turbo"
+        model_name = "models/gemini-2.5-pro"
+
+    assert resolve_live_llm_model(_Both()) == "gpt-5-turbo"
 
 
 def testredact_sensitive_config_walks_nested_structures() -> None:

--- a/tests/unit/web/test_debug_api_helpers.py
+++ b/tests/unit/web/test_debug_api_helpers.py
@@ -1,0 +1,66 @@
+"""Unit tests for helpers in :mod:`family_assistant.web.routers.debug_api`.
+
+These tests exercise the internal redaction helpers directly. The functional
+endpoint behavior lives in ``tests/functional/web/api/test_debug_api.py``.
+"""
+
+from family_assistant.web.routers.debug_api import (
+    SENSITIVE_FIELD_NAMES,
+    is_sensitive_field_name,
+    redact_sensitive_config,
+)
+
+
+def test_allowlisted_field_names_are_sensitive() -> None:
+    for name in SENSITIVE_FIELD_NAMES:
+        assert is_sensitive_field_name(name), name
+
+
+def test_substring_fallback_catches_future_secret_field_names() -> None:
+    """Field names added later with secret-looking substrings are redacted by fallback."""
+    for name in (
+        "my_custom_api_key",
+        "APIKey",
+        "oauth_secret",
+        "bearer_token",
+        "some_password_hash",
+        "service_private_key",
+    ):
+        assert is_sensitive_field_name(name), name
+
+
+def test_non_secret_field_names_are_not_redacted() -> None:
+    for name in (
+        "llm_model",
+        "provider",
+        "description",
+        "timezone",
+        "max_iterations",
+        "enable_local_tools",
+    ):
+        assert not is_sensitive_field_name(name), name
+
+
+def testredact_sensitive_config_walks_nested_structures() -> None:
+    input_payload = {
+        "home_assistant_token": "ha-123",
+        "nested": {
+            "my_custom_api_key": "hunter2",
+            "camera": {"password": "p4ss"},
+            "list_of_dicts": [
+                {"oauth_secret": "shh"},
+                {"unrelated_value": "visible"},
+            ],
+        },
+        "empty_token": "",  # empty/falsy secrets are left as-is
+        "unrelated": "visible",
+    }
+    redacted = redact_sensitive_config(input_payload)
+    assert redacted["home_assistant_token"] == "[REDACTED]"
+    assert redacted["nested"]["my_custom_api_key"] == "[REDACTED]"
+    assert redacted["nested"]["camera"]["password"] == "[REDACTED]"
+    assert redacted["nested"]["list_of_dicts"][0]["oauth_secret"] == "[REDACTED]"
+    assert redacted["nested"]["list_of_dicts"][1]["unrelated_value"] == "visible"
+    # Falsy secret values stay falsy (no "[REDACTED]") since there's nothing to leak.
+    assert not redacted["empty_token"]
+    assert redacted["unrelated"] == "visible"

--- a/tests/unit/web/test_debug_api_helpers.py
+++ b/tests/unit/web/test_debug_api_helpers.py
@@ -114,7 +114,10 @@ def test_resolve_live_llm_model_strips_google_prefix_from_primary_model() -> Non
 
 
 def test_resolve_live_llm_fallback_model_returns_configured_fallback() -> None:
+    """Fallback is reported only when a ``fallback_client`` is actually wired."""
+
     class _RetryingLike:
+        fallback_client = object()  # truthy = fallback is real
         fallback_model = "openai/gpt-5.2"
 
     assert resolve_live_llm_fallback_model(_RetryingLike()) == "openai/gpt-5.2"
@@ -122,6 +125,7 @@ def test_resolve_live_llm_fallback_model_returns_configured_fallback() -> None:
 
 def test_resolve_live_llm_fallback_model_strips_google_prefix() -> None:
     class _RetryingGoogleFallback:
+        fallback_client = object()
         fallback_model = "models/gemini-2.5-flash"
 
     assert (
@@ -129,8 +133,19 @@ def test_resolve_live_llm_fallback_model_strips_google_prefix() -> None:
     )
 
 
+def test_resolve_live_llm_fallback_model_returns_none_when_no_fallback_client() -> None:
+    """RetryingLLMClient sets ``fallback_model`` to a default string even when no
+    ``fallback_client`` is configured, so the default would otherwise leak."""
+
+    class _PrimaryOnlyRetrying:
+        fallback_client = None  # no real fallback is wired
+        fallback_model = "openai/gpt-5.2"  # default from RetryingLLMClient.__init__
+
+    assert resolve_live_llm_fallback_model(_PrimaryOnlyRetrying()) is None
+
+
 def test_resolve_live_llm_fallback_model_returns_none_for_plain_client() -> None:
-    """Concrete provider clients do not have a fallback_model attribute."""
+    """Concrete provider clients do not have fallback_client / fallback_model."""
 
     class _OpenAILike:
         model = "gpt-5-turbo"


### PR DESCRIPTION
## Summary
Add a new `/api/debug/profiles` endpoint that exposes the complete resolved service profile configuration for debugging and introspection purposes. The endpoint includes processing config, tools config, policy rules, and live runtime information from the processing services registry, with automatic redaction of sensitive fields.

## Key Changes

- **New debug endpoint `/api/debug/profiles`**: Returns full configuration for all service profiles or a single profile filtered by `profile_id` query parameter
  - Supports `format` query parameter: `json` (pretty-printed, default) or `raw` (compact)
  - Returns 404 if requested profile doesn't exist
  - Returns 503 if application config is not initialized
  - Includes runtime information (LLM model/provider, context providers) from the live processing services registry

- **Sensitive field redaction**: Implemented `_redact_sensitive()` function that recursively redacts values for security-sensitive field names including:
  - Token fields: `home_assistant_token`, `telegram_token`, `token_env`
  - API keys: `gemini_api_key`, `openai_api_key`, `openrouter_api_key`
  - Credentials: `password`, `client_secret`, `mailgun_webhook_signing_key`
  - Encryption keys: `vapid_private_key`, `session_secret_key`

- **Runtime introspection**: Added `_runtime_info_for()` function that extracts live service information:
  - Service kind (local/remote)
  - Resolved LLM model and provider from the live client
  - LLM client class name
  - Context provider names

- **Comprehensive test coverage**: Added 333 lines of functional tests covering:
  - Full config dump with all nested structures
  - Sensitive field redaction verification
  - Profile filtering by ID
  - 404 handling for unknown profiles
  - JSON format variations (pretty vs. compact)
  - Runtime info extraction from services registry
  - 503 handling when config is uninitialized

## Implementation Details

- Uses Pydantic's `model_dump(mode="json")` for consistent serialization
- Recursive redaction handles arbitrary nested dict/list structures
- Runtime info gracefully handles missing attributes with `getattr()` defaults
- Response uses `PlainTextResponse` for pretty-printed JSON to preserve formatting
- All debug endpoints remain protected by existing debug authorization checks

https://claude.ai/code/session_01475GJiVcwf5bHUfY3fPbwn