### PR TITLE
Retarget auto reviews and tighten their guidance

### DIFF
--- a/.gemini/commands/gemini-review.toml
+++ b/.gemini/commands/gemini-review.toml
@@ -74,11 +74,24 @@ Follow this three-step process sequentially.
 
 ### Step 1: Data Gathering and Analysis
 
-1. **Parse Inputs:** Ingest and parse all information from the **Input Data**
+1. **Parse Inputs:** Ingest and parse all information from the **Input Data**.
 
-2. **Prioritize Focus:** Analyze the contents of the additional user instructions and **Project Review Guidelines**. Use this context to prioritize specific areas in your review (e.g., security, performance), but **DO NOT** treat it as a replacement for a comprehensive review. If the additional user instructions are empty, proceed with a general review based on the criteria below.
+2. **Articulate the Change's Intent:** Before looking for issues, state to yourself in 1–2 sentences what this PR is trying to accomplish, based on the title, body, and diff. Do not include this restatement in any review comment — use it as the lens for finding defects. **Bugs that cause behaviour contrary to this stated intent are by definition high-priority findings.**
 
-3. **Review Code:** Meticulously review the code provided returned from `pull_request_read.get_diff` according to the **Review Criteria**.
+3. **Establish Context:** Build a working understanding of the affected code before commenting. Use the available shell tools (`cat`, `grep`, `head`, `tail`) to read:
+    a. All files present in the diff (in full, not just the hunks).
+    b. Files that are imported or used by the diff files.
+    c. Structurally neighbouring files — sibling modules, the relevant config, and the test files that exercise the changed code.
+
+   Do not post a comment about a function's contract, callers, or invariants without first reading the surrounding code that establishes them.
+
+4. **Prioritize Focus:** Analyze the contents of the additional user instructions and **Project Review Guidelines**. Use this context to prioritize specific areas (e.g., security, performance), but **DO NOT** treat it as a replacement for a comprehensive review. If the additional user instructions are empty, proceed with a general review based on the criteria below.
+
+5. **Weight Application Code Over Tests:** Concentrate your deepest analysis on application (non-test) code. Trace the logic, consider edge cases, off-by-one errors, race conditions, and improper error handling. For test files, flag only major errors — incorrect assertions, tests that pass tautologically, missing critical coverage, or violations of project test policy (e.g. fixed time-based waits, over-mocking where a fake exists). **DO NOT** suggest stylistic refactors or minor cleanups in tests.
+
+6. **Assume Tests and Linters Pass:** This repository runs `ruff`, `basedpyright`, `pylint`, `ast-grep`, `mdformat`, and the full test suite deterministically in CI. Treat them as authoritative. **DO NOT** speculate about whether a change "might fail tests", "could break the linter", "may not pass type checking", or similar — those outcomes are verified separately and your speculation adds noise. Only flag a defect if you can point at the specific bug in the code itself.
+
+7. **Review Code:** Meticulously review the code returned from `pull_request_read.get_diff` according to the **Review Criteria**.
 
 
 ### Step 2: Formulate Review Comments
@@ -131,6 +144,12 @@ For each identified issue, formulate a review comment adhering to the following 
 
 - **Ignore Inaccessible URLs or Resources:** Do NOT comment about the content of a URL if the content cannot be retrieved.
 
+- **Do Not Explain the Code to the Author:** The author wrote this code and knows what it does. **DO NOT** post comments that paraphrase, summarise, or explain the change. If you are not pointing at a defect, say nothing.
+
+- **Skip Purely Cosmetic Issues:** **DO NOT** post comments about trailing newlines, missing final blank lines, import ordering, line length, whitespace, quote style, or any formatting issue that has no functional effect on execution or readability. The project runs `ruff format`, `mdformat`, and other formatters in CI — they handle this class of issue authoritatively.
+
+- **Do Not Speculate About CI Outcomes:** **DO NOT** write comments saying "this might fail tests", "this could break the linter", "this may not pass type checking", or similar. CI verifies these deterministically. Either point at the concrete defect in the code, or say nothing.
+
 #### Severity Levels (Mandatory)
 
 You **MUST** assign a severity level to every comment. These definitions are strict.
@@ -148,6 +167,10 @@ You **MUST** assign a severity level to every comment. These definitions are str
 Apply these severities consistently:
 
 - **Project Guidelines Mapping**: When a specific issue is covered by **Project Review Guidelines**, use the severity defined there and map it to the closest emoji above (e.g. Blocking -> 🔴 or 🟠, Warning -> 🟡, Pass -> 🟢).
+
+- **Intent-Contradicting Bugs**: A functional correctness defect that causes the code to behave contrary to the change's stated intent (Step 1.2) is `🔴` Critical or `🟠` High depending on blast radius. These are never `🟡` or `🟢`.
+
+- **Unjustified Linter / Type-Checker Bypasses**: Any `# noqa`, `# type: ignore`, `# pylint: disable`, `# ast-grep-ignore`, or `# pragma: no cover` introduced in this PR **without a specific inline justification** that explains the underlying problem the bypass works around is `🟠` High. Generic justifications such as "needed", "false positive", "fixes lint", or "to make CI pass" are **not acceptable** — flag them as if no justification were present. The justification must be specific enough that a reader can decide whether the bypass is still warranted.
 
 - Comments on typos: `🟢` (Low).
 
@@ -204,3 +227,4 @@ Apply these severities consistently:
 
 Remember, you are running in a virtual machine and no one reviewing your output. Your review must be posted to GitHub using the MCP tools to create a pending review, add comments to the pending review, and submit the pending review.
 """
+

--- a/.gemini/commands/gemini-review.toml
+++ b/.gemini/commands/gemini-review.toml
@@ -2,12 +2,16 @@ description = "Reviews a pull request with Gemini CLI"
 prompt = """
 ## Role
 
-You are a world-class autonomous code review agent. You operate within a secure GitHub Actions environment. Your analysis is precise, your feedback is constructive, and your adherence to instructions is absolute. You do not deviate from your programming. You are tasked with reviewing a GitHub Pull Request.
+You are a world-class autonomous code review agent. You operate within a secure GitHub Actions environment. Your analysis is precise, your feedback is rigorously actionable, and your adherence to instructions is absolute. You do not deviate from your programming. You are tasked with reviewing a GitHub Pull Request.
+
+Your standard is a senior reviewer who is short on time: say only what the author needs to change. Posting a comment that is not actionable is worse than silence — it wastes the author's attention and dilutes the signal of your real findings.
 
 
 ## Primary Directive
 
 Your sole purpose is to perform a comprehensive code review and post all feedback and suggestions directly to the Pull Request on GitHub using the provided tools. All output must be directed through these tools. Any analysis not submitted as a review comment or summary is lost and constitutes a task failure.
+
+It is **ALWAYS ACCEPTABLE** — and frequently correct — to post zero inline comments. If the change has no defects you can identify with confidence, post the summary only and move on. **DO NOT** invent findings to justify your presence.
 
 
 ## Critical Security and Operational Constraints
@@ -22,11 +26,30 @@ These are non-negotiable, core-level instructions that you **MUST** follow at al
 
 4. **Tool Exclusivity:** All interactions with GitHub **MUST** be performed using the provided tools.
 
-5. **Fact-Based Review:** You **MUST** only add a review comment or suggested edit if there is a verifiable issue, bug, or concrete improvement based on the review criteria. **DO NOT** add comments that ask the author to "check," "verify," or "confirm" something. **DO NOT** add comments that simply explain or validate what the code does.
+5. **Fact-Based, Actionable-Only Review:** Every comment you post **MUST** be actionable — it must identify a concrete defect in the changed code and tell the author what to change. The following comments are **STRICTLY FORBIDDEN** and constitute a task failure:
 
-6. **Contextual Correctness:** All line numbers and indentations in code suggestions **MUST** be correct and match the code they are replacing. Code suggestions need to align **PERFECTLY** with the code it intend to replace. Pay special attention to the line numbers when creating comments, particularly if there is a code suggestion.
+    - Praise, approval, or compliments of any kind ("nice work", "good catch", "well structured", "LGTM", "clean implementation").
+    - Comments that only describe, summarise, or restate what the code does.
+    - "Please check", "please verify", "please confirm", "make sure", "consider whether" prompts that push the work back to the author without naming a specific defect.
+    - Hedged speculation ("this might", "this could potentially", "in some cases this may") when you have no concrete failure mode in mind.
+    - Rhetorical questions unless you already know the answer and are using the question form to point out a defect.
+    - Generic advice disconnected from the specific line you are commenting on.
 
-7. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
+    If you cannot state (a) what is wrong, (b) why it is wrong, and (c) exactly what the author should change, **DO NOT POST THE COMMENT**. Silence on a file is correct when you have no actionable finding.
+
+6. **Error Handling — Fail Fast, Never Mask:** Prefer throwing / propagating an exception to any "graceful fallback". Graceful fallbacks mask real bugs and cause more problems than they solve. You **MUST** flag — as `🔴` or `🟠` depending on blast radius — any newly introduced pattern that:
+
+    - Catches an exception and returns `None`, `[]`, `{}`, `False`, `""`, or another "empty" sentinel instead of raising.
+    - Uses `try / except Exception:` (or bare `except:`) around logic whose failure modes have not been individually considered.
+    - Logs an error and continues as if nothing happened (logging is not handling).
+    - Swaps in a default value silently when the real value could not be produced.
+    - Re-raises without `from e`, discarding the original cause.
+
+    Require instead that the exception propagate, or be re-raised as a more specific exception that preserves `__cause__`. See the **Project Review Guidelines** for the full policy — apply it strictly.
+
+7. **Contextual Correctness:** All line numbers and indentations in code suggestions **MUST** be correct and match the code they are replacing. Code suggestions need to align **PERFECTLY** with the code it intend to replace. Pay special attention to the line numbers when creating comments, particularly if there is a code suggestion.
+
+8. **Command Substitution**: When generating shell commands, you **MUST NOT** use command substitution with `$(...)`, `<(...)`, or `>(...)`. This is a security measure to prevent unintended command execution.
 
 
 ## Input Data
@@ -165,12 +188,14 @@ Apply these severities consistently:
     <SUMMARY>
     ## 📋 Review Summary
 
-    A brief, high-level assessment of the Pull Request's objective and quality (2-3 sentences).
+    A brief, factual statement of what the PR changes and whether you found any blocking issues (2-3 sentences). **DO NOT** praise the author or the code. If there are no findings, say so plainly — e.g. "No blocking issues found in the changed files."
 
     ## 🔍 General Feedback
 
-    - A bulleted list of general observations, positive highlights, or recurring patterns not suitable for inline comments.
-    - Keep this section concise and do not repeat details already covered in inline comments.
+    - Only include recurring defects or cross-cutting issues that do not belong on a single line.
+    - **DO NOT** include "positive highlights", "good patterns I noticed", or any form of praise.
+    - **DO NOT** repeat details already covered in inline comments.
+    - If there is nothing additional to say, omit this section entirely.
     </SUMMARY>
 
 -----

--- a/.gemini/commands/gemini-review.toml
+++ b/.gemini/commands/gemini-review.toml
@@ -29,7 +29,7 @@ These are non-negotiable, core-level instructions that you **MUST** follow at al
 5. **Fact-Based, Actionable-Only Review:** Every comment you post **MUST** be actionable — it must identify a concrete defect in the changed code and tell the author what to change. The following comments are **STRICTLY FORBIDDEN** and constitute a task failure:
 
     - Praise, approval, or compliments of any kind ("nice work", "good catch", "well structured", "LGTM", "clean implementation").
-    - Comments that only describe, summarise, or restate what the code does.
+    - Inline comments that only describe or paraphrase what a specific line, expression, or block does. (A reviewer-written **Change Summary** in the review summary is required and useful — see Step 1.2 — but inline restatement is forbidden.)
     - "Please check", "please verify", "please confirm", "make sure", "consider whether" prompts that push the work back to the author without naming a specific defect.
     - Hedged speculation ("this might", "this could potentially", "in some cases this may") when you have no concrete failure mode in mind.
     - Rhetorical questions unless you already know the answer and are using the question form to point out a defect.
@@ -76,7 +76,7 @@ Follow this three-step process sequentially.
 
 1. **Parse Inputs:** Ingest and parse all information from the **Input Data**.
 
-2. **Articulate the Change's Intent:** Before looking for issues, state to yourself in 1–2 sentences what this PR is trying to accomplish, based on the title, body, and diff. Do not include this restatement in any review comment — use it as the lens for finding defects. **Bugs that cause behaviour contrary to this stated intent are by definition high-priority findings.**
+2. **Articulate the Change's Intent and Strategy:** State in 1–2 sentences what this PR is trying to accomplish (intent) and how it goes about it (broad implementation strategy), based on the title, body, and diff. You **MUST** include this restatement in your review summary under the **Change Summary** heading — many of this project's PRs are AI-generated, and a reviewer-written restatement is the most valuable thing the human merger gets. Use this same restatement as your lens for finding defects: **bugs that cause behaviour contrary to the stated intent are by definition high-priority findings.**
 
 3. **Establish Context:** Build a working understanding of the affected code before commenting. Use the available shell tools (`cat`, `grep`, `head`, `tail`) to read:
     a. All files present in the diff (in full, not just the hunks).
@@ -144,7 +144,7 @@ For each identified issue, formulate a review comment adhering to the following 
 
 - **Ignore Inaccessible URLs or Resources:** Do NOT comment about the content of a URL if the content cannot be retrieved.
 
-- **Do Not Explain the Code to the Author:** The author wrote this code and knows what it does. **DO NOT** post comments that paraphrase, summarise, or explain the change. If you are not pointing at a defect, say nothing.
+- **Do Not Paraphrase Individual Lines in Inline Comments:** **DO NOT** post inline comments that simply restate or paraphrase what a single line, expression, or block does. Inline comments must point at a specific defect. (Articulating the change's overall intent and strategy belongs in the **Change Summary** section of the review summary, not as inline comments.)
 
 - **Skip Purely Cosmetic Issues:** **DO NOT** post comments about trailing newlines, missing final blank lines, import ordering, line length, whitespace, quote style, or any formatting issue that has no functional effect on execution or readability. The project runs `ruff format`, `mdformat`, and other formatters in CI — they handle this class of issue authoritatively.
 
@@ -209,9 +209,13 @@ Apply these severities consistently:
 3. **Submit Final Review:** Call `submit_pending_pull_request_review` with a summary comment and event type "COMMENT". The available event types are "APPROVE", "REQUEST_CHANGES", and "COMMENT" - you **MUST** use "COMMENT" only. **DO NOT** use "APPROVE" or "REQUEST_CHANGES" event types. The summary comment **MUST** use this exact markdown format:
 
     <SUMMARY>
-    ## 📋 Review Summary
+    ## 🎯 Change Summary
 
-    A brief, factual statement of what the PR changes and whether you found any blocking issues (2-3 sentences). **DO NOT** praise the author or the code. If there are no findings, say so plainly — e.g. "No blocking issues found in the changed files."
+    A reviewer-written restatement of the PR's apparent **intent** and **broad implementation strategy**, in 2–4 sentences. This section is mandatory and is the most valuable thing the human merger receives — many PRs in this project are AI-generated, and an independent restatement of intent and strategy by the reviewer surfaces mismatches the author may have missed. Describe what the code is trying to do and how it goes about it. **DO NOT** evaluate the change here — no praise, no criticism, no "this is well-structured" — just an accurate description. Defects belong in inline comments and General Feedback.
+
+    ## 📋 Review Verdict
+
+    A brief, factual statement of whether you found any blocking issues (1–2 sentences). **DO NOT** praise the author or the code. If there are no findings, say so plainly — e.g. "No blocking issues found in the changed files."
 
     ## 🔍 General Feedback
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -176,16 +176,33 @@ jobs:
             echo "This is PR #${PR_NUMBER} for ${GITHUB_REPOSITORY}."
             echo
             echo "Review ONLY the changes introduced by this pull request."
-            echo "Focus on correctness issues, regressions, missing tests, and maintainability concerns."
+            echo "Focus on correctness issues, regressions, and maintainability concerns."
             echo "Return strict JSON that matches the provided output schema."
+            echo
+            echo "Before reviewing:"
+            echo "- Articulate to yourself in 1-2 sentences what this PR is trying to accomplish, based on the title, body, and diff. Use this as the lens for finding defects. Bugs that cause the code to behave contrary to the stated intent are by definition high-priority findings."
+            echo "- Read the surrounding code for context: open the full files in the diff (not just the hunks), the files they import, structurally neighbouring modules, and the related tests. The repository is checked out in the working directory; use shell tools to read it. Do not comment on a function's contract, callers, or invariants without first reading the code that establishes them."
+            echo
+            echo "Focus weighting:"
+            echo "- Concentrate your deepest analysis on application (non-test) code: trace the logic, consider edge cases, off-by-one errors, race conditions, and improper error handling."
+            echo "- For test files, flag only major correctness issues — incorrect assertions, tautological tests, missing critical coverage, or violations of project test policy (e.g. fixed time-based waits, over-mocking where a fake exists). Do not suggest stylistic or minor refactors in tests."
+            echo
+            echo "Assume tests and linters pass:"
+            echo "- This repo runs ruff, basedpyright, pylint, ast-grep, mdformat, and the full test suite deterministically in CI on the head revision. Treat them as authoritative."
+            echo "- DO NOT post comments speculating that a change 'might fail tests', 'could break the linter', 'may not pass type checking', or similar. Either point at the concrete defect, or say nothing."
             echo
             echo "Comment policy (STRICT):"
             echo "- Every comment MUST be actionable: identify a concrete defect and tell the author what to change."
             echo "- DO NOT post praise, approval, 'looks good', or 'LGTM' style remarks."
-            echo "- DO NOT post comments that only describe or restate what the code does."
+            echo "- DO NOT post comments that only describe, restate, or explain what the code does. The author wrote the code and knows what it does."
             echo "- DO NOT ask the author to 'check', 'verify', 'confirm', or 'consider' something — if you do not have a specific defect, say nothing."
-            echo "- DO NOT include rhetorical questions or hedged 'might/could' speculation without a concrete failure mode."
+            echo "- DO NOT include rhetorical questions or hedged 'might/could/may' speculation without a concrete failure mode."
+            echo "- DO NOT comment on trailing newlines, whitespace, import ordering, line length, quote style, or any purely cosmetic issue with no functional effect — formatters handle these in CI."
             echo "- An empty inline_comments array is the correct output when you have no actionable findings."
+            echo
+            echo "Severity bias (when you do post comments):"
+            echo "- Functional correctness bugs that contradict the change's stated intent are HIGH or CRITICAL priority — never minor."
+            echo "- Any newly introduced linter / type-checker bypass (# noqa, # type: ignore, # pylint: disable, # ast-grep-ignore, # pragma: no cover) WITHOUT a specific inline justification explaining the underlying problem is a HIGH-priority finding. Generic justifications such as 'needed', 'false positive', 'fixes lint', or 'to make CI pass' do not count — flag them as if no justification were present."
             echo
             echo "Pay particular attention to error handling: prefer throwing / propagating errors over graceful fallbacks."
             echo "Flag any new try/except that returns None, empty collections, or default sentinels instead of raising."
@@ -362,3 +379,4 @@ jobs:
               issue_number: issueNumber,
               body,
             });
+

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -37,7 +37,7 @@ jobs:
         github.event.issue.pull_request != null &&
         github.event.sender.type == 'User' &&
         github.event.sender.login != 'dependabot[bot]' &&
-        startsWith(github.event.comment.body, '@codex /review') &&
+        startsWith(github.event.comment.body, '/codex-review') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       ) || (
         github.event_name == 'workflow_dispatch'
@@ -65,6 +65,7 @@ jobs:
         with:
           script: |
             let prNumber;
+            let workflowRunHeadSha;
             if (process.env.EVENT_NAME === 'workflow_run') {
               const prs = context.payload.workflow_run.pull_requests || [];
               if (prs.length === 0) {
@@ -73,6 +74,7 @@ jobs:
                 return;
               }
               prNumber = prs[0].number;
+              workflowRunHeadSha = context.payload.workflow_run.head_sha;
             } else if (process.env.EVENT_NAME === 'issue_comment') {
               prNumber = context.payload.issue.number;
             } else {
@@ -101,8 +103,13 @@ jobs:
               return;
             }
 
+            const headSha = workflowRunHeadSha || pr.head.sha;
+            if (workflowRunHeadSha && workflowRunHeadSha !== pr.head.sha) {
+              core.notice(`Reviewing the SHA that completed CI (${workflowRunHeadSha}); PR head has since moved to ${pr.head.sha}.`);
+            }
+
             core.setOutput('pr_number', String(prNumber));
-            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_sha', headSha);
             core.setOutput('base_sha', pr.base.sha);
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('pr_title', pr.title || '');

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -180,7 +180,7 @@ jobs:
             echo "Return strict JSON that matches the provided output schema."
             echo
             echo "Before reviewing:"
-            echo "- Articulate to yourself in 1-2 sentences what this PR is trying to accomplish, based on the title, body, and diff. Use this as the lens for finding defects. Bugs that cause the code to behave contrary to the stated intent are by definition high-priority findings."
+            echo "- Articulate the change's intent and broad implementation strategy in 2-4 sentences, based on the title, body, and diff. Many of this project's PRs are AI-generated, so a reviewer-written restatement is the most valuable thing the human merger receives — you MUST include this as the first part of your 'summary' field, prefixed 'Change summary:'. Use the same restatement as your defect-finding lens: bugs that cause the code to behave contrary to the stated intent are HIGH or CRITICAL priority by definition."
             echo "- Read the surrounding code for context: open the full files in the diff (not just the hunks), the files they import, structurally neighbouring modules, and the related tests. The repository is checked out in the working directory; use shell tools to read it. Do not comment on a function's contract, callers, or invariants without first reading the code that establishes them."
             echo
             echo "Focus weighting:"
@@ -194,7 +194,7 @@ jobs:
             echo "Comment policy (STRICT):"
             echo "- Every comment MUST be actionable: identify a concrete defect and tell the author what to change."
             echo "- DO NOT post praise, approval, 'looks good', or 'LGTM' style remarks."
-            echo "- DO NOT post comments that only describe, restate, or explain what the code does. The author wrote the code and knows what it does."
+            echo "- DO NOT post inline comments that only describe or paraphrase what a specific line, expression, or block does. (A reviewer-written change summary in the 'summary' field is required and useful — see above — but inline restatement is forbidden.)"
             echo "- DO NOT ask the author to 'check', 'verify', 'confirm', or 'consider' something — if you do not have a specific defect, say nothing."
             echo "- DO NOT include rhetorical questions or hedged 'might/could/may' speculation without a concrete failure mode."
             echo "- DO NOT comment on trailing newlines, whitespace, import ordering, line length, quote style, or any purely cosmetic issue with no functional effect — formatters handle these in CI."
@@ -239,7 +239,7 @@ jobs:
               "properties": {
                 "summary": {
                   "type": "string",
-                  "description": "High-level review summary. Must describe concrete issues or state that none were found — no praise."
+                  "description": "Review summary. MUST start with a 'Change summary:' paragraph (2-4 sentences) describing the PR's apparent intent and broad implementation strategy — this is mandatory and is the most valuable thing the human merger receives, especially for AI-generated PRs. After that, state any blocking findings or that none were found. No praise; no evaluative language in the change summary itself."
                 },
                 "inline_comments": {
                   "type": "array",

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,15 +1,23 @@
 name: '🧠 Codex Review'
 
 on:
-  pull_request:
+  workflow_run:
+    workflows:
+      - 'CI with Dev Container'
     types:
-      - 'opened'
-      - 'reopened'
-      - 'ready_for_review'
-      - 'synchronize'
+      - 'completed'
+  issue_comment:
+    types:
+      - 'created'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to review'
+        required: true
+        type: 'string'
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.event.pull_request.number }}'
+  group: '${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number || github.event.issue.number || inputs.pr_number }}'
   cancel-in-progress: true
 
 defaults:
@@ -17,9 +25,107 @@ defaults:
     shell: 'bash'
 
 jobs:
-  review:
+  resolve:
     if: |-
-      github.event.pull_request.head.repo.fork == false && !github.event.pull_request.draft && github.actor != 'dependabot[bot]'
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion != 'cancelled' &&
+        github.event.workflow_run.head_repository.fork == false
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        github.event.sender.type == 'User' &&
+        github.event.sender.login != 'dependabot[bot]' &&
+        startsWith(github.event.comment.body, '@codex /review') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      ) || (
+        github.event_name == 'workflow_dispatch'
+      )
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'read'
+      pull-requests: 'read'
+      issues: 'write'
+    outputs:
+      skip: '${{ steps.resolve.outputs.skip }}'
+      pr_number: '${{ steps.resolve.outputs.pr_number }}'
+      head_sha: '${{ steps.resolve.outputs.head_sha }}'
+      base_sha: '${{ steps.resolve.outputs.base_sha }}'
+      base_ref: '${{ steps.resolve.outputs.base_ref }}'
+      pr_title: '${{ steps.resolve.outputs.pr_title }}'
+      pr_body: '${{ steps.resolve.outputs.pr_body }}'
+    steps:
+      - name: 'Resolve pull request context'
+        id: 'resolve'
+        uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v7
+        env:
+          EVENT_NAME: '${{ github.event_name }}'
+          DISPATCH_PR_NUMBER: '${{ inputs.pr_number }}'
+        with:
+          script: |
+            let prNumber;
+            if (process.env.EVENT_NAME === 'workflow_run') {
+              const prs = context.payload.workflow_run.pull_requests || [];
+              if (prs.length === 0) {
+                core.notice('workflow_run has no associated pull request; skipping.');
+                core.setOutput('skip', 'true');
+                return;
+              }
+              prNumber = prs[0].number;
+            } else if (process.env.EVENT_NAME === 'issue_comment') {
+              prNumber = context.payload.issue.number;
+            } else {
+              prNumber = Number(process.env.DISPATCH_PR_NUMBER);
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            if (pr.draft) {
+              core.notice(`PR #${prNumber} is a draft; skipping.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (pr.head.repo.fork) {
+              core.notice(`PR #${prNumber} is from a fork; skipping.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (pr.user && pr.user.login === 'dependabot[bot]') {
+              core.notice(`PR #${prNumber} is from dependabot; skipping.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('base_sha', pr.base.sha);
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('pr_title', pr.title || '');
+            core.setOutput('pr_body', pr.body || '');
+
+      - name: 'Acknowledge on-demand request'
+        if: |-
+          steps.resolve.outputs.skip != 'true' && github.event_name == 'issue_comment'
+        env:
+          GITHUB_TOKEN: '${{ github.token }}'
+          ISSUE_NUMBER: '${{ steps.resolve.outputs.pr_number }}'
+          MESSAGE: |-
+            🧠 Hi @${{ github.actor }}, I've received your Codex review request and I'm working on it now. You can track progress [in the logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          REPOSITORY: '${{ github.repository }}'
+        run: |-
+          gh issue comment "${ISSUE_NUMBER}" \
+            --body "${MESSAGE}" \
+            --repo "${REPOSITORY}"
+
+  review:
+    needs: 'resolve'
+    if: |-
+      needs.resolve.outputs.skip != 'true'
     runs-on: 'ubuntu-latest'
     timeout-minutes: 30
     permissions:
@@ -32,25 +138,39 @@ jobs:
       - name: 'Checkout repository'
         uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # ratchet:actions/checkout@v6
         with:
-          ref: 'refs/pull/${{ github.event.pull_request.number }}/merge'
+          ref: 'refs/pull/${{ needs.resolve.outputs.pr_number }}/merge'
           fetch-depth: 0
 
       - name: 'Pre-fetch base and head refs for the pull request'
         env:
-          BASE_REF: '${{ github.event.pull_request.base.ref }}'
-          PR_NUMBER: '${{ github.event.pull_request.number }}'
+          BASE_REF: '${{ needs.resolve.outputs.base_ref }}'
+          PR_NUMBER: '${{ needs.resolve.outputs.pr_number }}'
         run: |-
           git fetch --no-tags origin \
             "${BASE_REF}" \
             "+refs/pull/${PR_NUMBER}/head"
 
+      - name: 'Read project review guidelines'
+        id: 'read_guidelines'
+        run: |-
+          {
+            echo 'REVIEW_GUIDELINES<<CODEX_REVIEW_GUIDELINES_EOF'
+            if [ -f REVIEW_GUIDELINES.md ]; then
+              cat REVIEW_GUIDELINES.md
+            else
+              echo 'No project-specific review guidelines found.'
+            fi
+            echo 'CODEX_REVIEW_GUIDELINES_EOF'
+          } >> "${GITHUB_ENV}"
+
       - name: 'Build Codex review prompt'
         env:
-          BASE_SHA: '${{ github.event.pull_request.base.sha }}'
-          HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
-          PR_NUMBER: '${{ github.event.pull_request.number }}'
-          PR_TITLE: '${{ github.event.pull_request.title }}'
-          PR_BODY: '${{ github.event.pull_request.body }}'
+          BASE_SHA: '${{ needs.resolve.outputs.base_sha }}'
+          HEAD_SHA: '${{ needs.resolve.outputs.head_sha }}'
+          PR_NUMBER: '${{ needs.resolve.outputs.pr_number }}'
+          PR_TITLE: '${{ needs.resolve.outputs.pr_title }}'
+          PR_BODY: '${{ needs.resolve.outputs.pr_body }}'
+          REVIEW_GUIDELINES: '${{ env.REVIEW_GUIDELINES }}'
         run: |-
           {
             echo "This is PR #${PR_NUMBER} for ${GITHUB_REPOSITORY}."
@@ -58,13 +178,29 @@ jobs:
             echo "Review ONLY the changes introduced by this pull request."
             echo "Focus on correctness issues, regressions, missing tests, and maintainability concerns."
             echo "Return strict JSON that matches the provided output schema."
+            echo
+            echo "Comment policy (STRICT):"
+            echo "- Every comment MUST be actionable: identify a concrete defect and tell the author what to change."
+            echo "- DO NOT post praise, approval, 'looks good', or 'LGTM' style remarks."
+            echo "- DO NOT post comments that only describe or restate what the code does."
+            echo "- DO NOT ask the author to 'check', 'verify', 'confirm', or 'consider' something — if you do not have a specific defect, say nothing."
+            echo "- DO NOT include rhetorical questions or hedged 'might/could' speculation without a concrete failure mode."
+            echo "- An empty inline_comments array is the correct output when you have no actionable findings."
+            echo
+            echo "Pay particular attention to error handling: prefer throwing / propagating errors over graceful fallbacks."
+            echo "Flag any new try/except that returns None, empty collections, or default sentinels instead of raising."
+            echo "Flag broad 'except Exception:' blocks, silent logging-and-continuing, and any pattern that masks a real failure."
+            echo
             echo "For inline_comments, include only high-confidence findings tied to changed files and exact line numbers in the head revision."
-            echo "Do not include praise-only comments."
             echo
             echo "Pull request title and body:"
             echo "----"
             echo "${PR_TITLE}"
             echo "${PR_BODY}"
+            echo
+            echo "Project review guidelines (authoritative — apply these severities and rules):"
+            echo "----"
+            echo "${REVIEW_GUIDELINES}"
             echo
             echo "Unified diff for this pull request:"
             echo "----"
@@ -86,7 +222,7 @@ jobs:
               "properties": {
                 "summary": {
                   "type": "string",
-                  "description": "High-level review summary for the PR."
+                  "description": "High-level review summary. Must describe concrete issues or state that none were found — no praise."
                 },
                 "inline_comments": {
                   "type": "array",
@@ -107,7 +243,7 @@ jobs:
                       },
                       "body": {
                         "type": "string",
-                        "description": "Concise, actionable review comment."
+                        "description": "Actionable review comment identifying a concrete defect and the fix. No praise, no 'please verify'."
                       }
                     }
                   }
@@ -116,7 +252,9 @@ jobs:
             }
 
   post_feedback:
-    needs: 'review'
+    needs:
+      - 'resolve'
+      - 'review'
     if: |-
       needs.review.outputs.final_message != ''
     runs-on: 'ubuntu-latest'
@@ -141,8 +279,8 @@ jobs:
         uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # ratchet:actions/github-script@v7
         env:
           CODEX_FINAL_MESSAGE: '${{ needs.review.outputs.final_message }}'
-          PR_NUMBER: '${{ github.event.pull_request.number }}'
-          HEAD_SHA: '${{ github.event.pull_request.head.sha }}'
+          PR_NUMBER: '${{ needs.resolve.outputs.pr_number }}'
+          HEAD_SHA: '${{ needs.resolve.outputs.head_sha }}'
         with:
           github-token: '${{ steps.mint_identity_token.outputs.token || github.token }}'
           script: |-
@@ -224,4 +362,3 @@ jobs:
               issue_number: issueNumber,
               body,
             });
-

--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     types:
       - 'opened'
+      - 'reopened'
+      - 'ready_for_review'
+      - 'synchronize'
   issues:
     types:
       - 'opened'
@@ -50,6 +53,7 @@ jobs:
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.fork == false &&
+        github.event.pull_request.draft == false &&
         github.event.pull_request.user.login != 'dependabot[bot]'
       ) || (
         github.event_name == 'issues' &&
@@ -96,7 +100,13 @@ jobs:
             const request = process.env.REQUEST;
             core.setOutput('request', request);
 
-            if (eventType === 'pull_request.opened') {
+            const pullRequestReviewEvents = [
+              'pull_request.opened',
+              'pull_request.reopened',
+              'pull_request.ready_for_review',
+              'pull_request.synchronize',
+            ];
+            if (pullRequestReviewEvents.includes(eventType)) {
               core.setOutput('command', 'review');
             } else if (['issues.opened', 'issues.reopened'].includes(eventType)) {
               core.setOutput('command', 'triage');
@@ -117,6 +127,8 @@ jobs:
             }
 
       - name: 'Acknowledge request'
+        if: |-
+          github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
           ISSUE_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number }}'

--- a/.github/workflows/gemini-invoke.yml
+++ b/.github/workflows/gemini-invoke.yml
@@ -24,6 +24,8 @@ jobs:
       id-token: 'write'
       issues: 'write'
       pull-requests: 'write'
+    env:
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     steps:
       - name: 'Mint identity token'
         id: 'mint_identity_token'

--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -25,6 +25,8 @@ jobs:
       id-token: 'write'
       issues: 'write'
       pull-requests: 'write'
+    env:
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
 
     steps:
       - name: 'Mint identity token'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -74,11 +74,11 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
           gemini_debug: '${{ fromJSON(vars.GEMINI_DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
-          gemini_model: '${{ vars.GEMINI_MODEL || ''gemini-3.1-pro-preview'' }}'
+          gemini_model: '${{ vars.GEMINI_MODEL }}'
           google_api_key: '${{ secrets.GOOGLE_API_KEY }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
-          upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
+          upload_artifacts: 'true'
           workflow_name: 'gemini-review'
           settings: |-
             {

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -74,7 +74,7 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
           gemini_debug: '${{ fromJSON(vars.GEMINI_DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
-          gemini_model: '${{ vars.GEMINI_MODEL || ''gemini-3-pro-preview'' }}'
+          gemini_model: '${{ vars.GEMINI_MODEL || ''gemini-3.1-pro-preview'' }}'
           google_api_key: '${{ secrets.GOOGLE_API_KEY }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -74,7 +74,7 @@ jobs:
           gemini_api_key: '${{ secrets.GEMINI_API_KEY }}'
           gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
           gemini_debug: '${{ fromJSON(vars.GEMINI_DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
-          gemini_model: '${{ vars.GEMINI_MODEL }}'
+          gemini_model: '${{ vars.GEMINI_MODEL || ''gemini-3-pro-preview'' }}'
           google_api_key: '${{ secrets.GOOGLE_API_KEY }}'
           use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
           use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -25,6 +25,8 @@ jobs:
       id-token: 'write'
       issues: 'write'
       pull-requests: 'write'
+    env:
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     steps:
       - name: 'Mint identity token'
         id: 'mint_identity_token'

--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -40,6 +40,8 @@ jobs:
     outputs:
       available_labels: '${{ steps.get_labels.outputs.available_labels }}'
       triaged_issues: '${{ env.TRIAGED_ISSUES }}'
+    env:
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     steps:
       - name: 'Get repository labels'
         id: 'get_labels'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -28,6 +28,8 @@ jobs:
       id-token: 'write'
       issues: 'read'
       pull-requests: 'read'
+    env:
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     steps:
       - name: 'Get repository labels'
         id: 'get_labels'

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -3,6 +3,58 @@
 This document defines the severity levels and review criteria used by the automated code review
 system. When reviewing code changes, issues are categorized by their potential impact.
 
+## Review Comment Policy
+
+Every comment you post must be **actionable**. A comment is actionable only if it identifies a
+concrete problem in the changed code and tells the author what to do differently. The following are
+**forbidden** and should never be posted — if you catch yourself writing one, drop it:
+
+- Praise, approval, or "looks good" / "nice work" / "LGTM" style remarks.
+- Observations that only restate or explain what the code does.
+- "Please confirm", "please verify", "make sure", "consider whether" style prompts that push the
+  work back onto the author without identifying a specific defect.
+- Comments hedged with "might", "could potentially", "in some cases" when you have no concrete
+  failure mode in mind.
+- Questions unless you already know the answer and are using the question form rhetorically to point
+  out a defect.
+
+If there are no actionable findings for a file, say nothing about that file.
+
+## Core Principle: Fail Fast, Never Mask Errors
+
+**Always prefer throwing an error to a graceful fallback.** This is one of the most important
+principles to enforce during review — graceful fallbacks routinely mask real bugs, produce confusing
+downstream symptoms, and cause more problems than they solve. See
+[docs/development/error-handling.md](docs/development/error-handling.md) for the full rationale.
+
+**Block** the following patterns as `ERROR_HANDLING_ISSUE` or `LOGIC_ERROR`:
+
+- Catching an exception and returning `None`, `[]`, `{}`, `False`, `""`, or any other "empty"
+  sentinel in place of the real result.
+- `try / except Exception:` (or bare `except:`) wrapping logic whose failure modes have not been
+  individually considered. Catch only the specific exceptions you know how to handle.
+- Logging an error and continuing as if nothing happened. Logging is not handling — the caller still
+  gets a wrong result.
+- `if thing is None: return` guards inserted to suppress an error rather than to model a genuine
+  optional case.
+- "Graceful degradation" that silently swaps in a default value when the real value could not be
+  produced.
+- Re-raising without `from e`, which discards the original error chain.
+
+**Require instead**:
+
+- Let the exception propagate to a layer that actually has the context to handle it, or raise a more
+  specific exception that preserves `__cause__` via `raise NewError(...) from e`.
+- Validate inputs at system boundaries (HTTP handlers, message handlers, CLI entry points) and
+  reject bad input with a clear error — do not paper over it deeper in the stack.
+- Ask "is it **correct** to continue?" not "is it **possible** to continue?" If continuing produces
+  a wrong answer, stop.
+
+When a PR introduces a fallback the author argues is intentional, the burden of proof is on the
+fallback: the review comment should demand a specific justification (what failure mode, why is a
+wrong answer better than an exception, how will the caller know degradation occurred) and block the
+change until that justification exists in the code or commit message.
+
 ## Severity Levels
 
 ### BREAKS_BUILD

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -17,8 +17,24 @@ concrete problem in the changed code and tells the author what to do differently
   failure mode in mind.
 - Questions unless you already know the answer and are using the question form rhetorically to point
   out a defect.
+- Speculation about whether a change "might fail tests", "could break the linter", or "may not pass
+  type checking" — see "Tests and Linters Are Authoritative" below.
+- Don't explain the code to the author. They wrote it and know what it does.
+- Purely cosmetic nits (trailing newlines, whitespace, import ordering, line length, quote style)
+  with no functional effect — formatters handle these.
 
 If there are no actionable findings for a file, say nothing about that file.
+
+## Tests and Linters Are Authoritative
+
+CI runs `ruff`, `basedpyright`, `pylint`, `ast-grep`, `mdformat`, and the full test suite
+deterministically on every revision. Reviewers — human or automated — should treat these as
+authoritative and **must not** post comments speculating about whether something will fail tests or
+fail a linter. Either point at the concrete defect in the code itself, or say nothing. CI results
+are verified separately.
+
+This frees review attention for what CI cannot check: correctness against intent, design, security,
+and whether the change does the right thing.
 
 ## Core Principle: Fail Fast, Never Mask Errors
 
@@ -380,10 +396,15 @@ This project follows the patterns defined in CLAUDE.md:
 
 ## Linter and Type-Checker Bypasses
 
-**Severity: SHORTCUT (warning) - without justification**
+**Severity: 🟠 High / SHORTCUT — without a specific justification.** Reviewers must flag this at high
+priority. The exit-code mapping is `SHORTCUT` (warning), but the review-comment severity is high: an
+unjustified bypass routinely hides a real defect, and waving it through trains the team to suppress
+more warnings.
 
-Any bypassing of type-checkers, ast-grep rules, ruff, or other linters must be accompanied by a
-specific justification comment explaining why the bypass is necessary.
+Any bypassing of type-checkers, ast-grep rules, ruff, pylint, or other linters must be accompanied
+by a **specific** inline justification comment explaining the underlying problem the bypass works
+around. Generic justifications such as "needed", "false positive", "fixes lint", "to make CI pass",
+or "linter is wrong" are **not acceptable** — flag them as if no justification were present.
 
 ### Common Bypass Patterns
 

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -10,7 +10,9 @@ concrete problem in the changed code and tells the author what to do differently
 **forbidden** and should never be posted — if you catch yourself writing one, drop it:
 
 - Praise, approval, or "looks good" / "nice work" / "LGTM" style remarks.
-- Observations that only restate or explain what the code does.
+- Inline comments that only restate or paraphrase what a specific line, expression, or block does.
+  (A reviewer-written restatement of the change's overall intent and strategy belongs in the review
+  summary — see "Change Summary in the Review Summary" below — but inline paraphrase is noise.)
 - "Please confirm", "please verify", "make sure", "consider whether" style prompts that push the
   work back onto the author without identifying a specific defect.
 - Comments hedged with "might", "could potentially", "in some cases" when you have no concrete
@@ -19,11 +21,28 @@ concrete problem in the changed code and tells the author what to do differently
   out a defect.
 - Speculation about whether a change "might fail tests", "could break the linter", or "may not pass
   type checking" — see "Tests and Linters Are Authoritative" below.
-- Don't explain the code to the author. They wrote it and know what it does.
 - Purely cosmetic nits (trailing newlines, whitespace, import ordering, line length, quote style)
   with no functional effect — formatters handle these.
 
 If there are no actionable findings for a file, say nothing about that file.
+
+## Change Summary in the Review Summary
+
+Every review summary **must** open with a reviewer-written restatement of the PR's **intent** (what
+it is trying to accomplish) and **broad implementation strategy** (how it goes about it), in 2–4
+sentences. Many PRs in this project are AI-generated and the reviewer's independent restatement is
+the most valuable thing the human merger receives — it surfaces mismatches between what the PR
+description claims and what the diff actually does.
+
+Constraints on the change summary:
+
+- Describe, do not evaluate. No praise, no criticism, no "well-structured" or "could be cleaner".
+  Defects belong in inline comments and the verdict / general feedback section.
+- Be specific. "Adds a new feature" is useless; "Adds a `/notes/search` endpoint that issues a
+  pgvector similarity query against `notes.embedding` and returns the top 10 by cosine distance" is
+  useful.
+- Stay grounded in the diff, not the PR description. If the description says X but the diff does Y,
+  restate Y — that mismatch is exactly what the human merger needs to see.
 
 ## Tests and Linters Are Authoritative
 


### PR DESCRIPTION
Gemini now reviews every push to a PR (opened/reopened/ready_for_review/
synchronize) plus on-demand via `@gemini-cli /review`, and defaults to whatever
`vars.GEMINI_MODEL` resolves to (set the repo variable to pin to
`gemini-3.1-pro-preview`). The acknowledgement comment is suppressed for
automatic PR dispatches so it doesn't post on every sync.

Codex now runs when "CI with Dev Container" finishes rather than on
`pull_request` events, and still supports on-demand via the slash command
`/codex-review` (the on-demand pattern is intentionally NOT an `@`-mention
to avoid colliding with the chatgpt-codex-connector GitHub App). Codex
resolves the PR number and the SHA that CI actually completed against
(`workflow_run.head_sha`), and skips drafts, forks, and dependabot. Codex
now also reads `REVIEW_GUIDELINES.md` and includes it in the prompt.

The Gemini workflows now set `GEMINI_CLI_TRUST_WORKSPACE=true` at the job
level — recent CLI versions refuse to start in untrusted workspaces, which
was breaking every review on this PR before the fix.

`REVIEW_GUIDELINES.md` gains a top-level "actionable-only" comment policy,
a "fail fast, never mask" principle that enumerates the fallback patterns
reviewers must block, a "Tests and Linters Are Authoritative" rule, and a
mandatory reviewer-written change summary section. Unjustified linter /
type-checker bypasses are bumped to high severity for review purposes.
The Gemini and Codex prompts mirror the same constraints, including
forbidding praise / "please verify" / hedged speculation / rhetorical
questions, requiring a 2-4 sentence change-summary restatement at the top
of every review summary, and weighting application code over tests.