### PR TITLE
Let OpenAI choose image dimensions via size="auto"

### DIFF
--- a/src/family_assistant/tools/image_backends.py
+++ b/src/family_assistant/tools/image_backends.py
@@ -508,7 +508,7 @@ class OpenAIImageBackend:
         response = await self.client.images.generate(
             model="gpt-image-2",
             prompt=full_prompt,
-            size="1024x1024",
+            size="auto",
             quality="high",
             output_format="png",
             n=1,
@@ -544,7 +544,7 @@ class OpenAIImageBackend:
             model="gpt-image-2",
             image=image_file,
             prompt=instruction,
-            size="1024x1024",
+            size="auto",
             n=1,
         )
 


### PR DESCRIPTION
Both generate and edit calls were hard-coded to 1024x1024. Passing
"auto" lets gpt-image-2 pick an appropriate aspect ratio based on the
prompt instead.

https://claude.ai/code/session_016u1Nj3zZaC7RjGYVsbY1Ss