### PR TITLE
Decouple on-demand tool gating from the shared tools provider chain

### DIFF
--- a/src/family_assistant/assistant.py
+++ b/src/family_assistant/assistant.py
@@ -89,7 +89,7 @@ from family_assistant.tools import (
     LocalToolsProvider,
     MCPServerConfig,
     MCPToolsProvider,
-    OnDemandAwareToolsProvider,
+    OnDemandToolsView,
     PolicyEnforcingToolsProvider,
     PolicyEngine,
     PolicyRule,
@@ -804,25 +804,26 @@ class Assistant:
             # Get confirmation timeout from config, default to 3600 seconds (1 hour)
             confirmation_timeout = profile_tools_conf.confirmation_timeout_seconds
 
-            # Build provider chain: OnDemand (optional) → Policy → root.
-            # OnDemand wraps Policy so that the synthetic ``activate_tools``
-            # meta-tool it injects is not filtered out by policy descriptor
-            # filtering (which only sees real wrapped descriptors).
+            # Build provider chain: Policy → root. The provider chain is
+            # shared by all consumers (LLM loop, scripts, web UI listings),
+            # so it must reflect the full set of tools the profile is allowed
+            # to use. On-demand gating is an LLM-loop concern only and lives
+            # in a sibling ``OnDemandToolsView`` below.
             policy_provider = PolicyEnforcingToolsProvider(
                 wrapped_provider=self.root_tools_provider,
                 policy_engine=policy_engine,
                 confirmation_timeout=confirmation_timeout,
             )
+            profile_tools_provider = policy_provider
             on_demand_tool_names = profile_tools_conf.get_on_demand_tool_names()
             on_demand_mcp_ids = set(profile_tools_conf.get_on_demand_mcp_server_ids())
+            profile_on_demand_view: OnDemandToolsView | None = None
             if on_demand_tool_names or on_demand_mcp_ids:
-                profile_tools_provider = OnDemandAwareToolsProvider(
+                profile_on_demand_view = OnDemandToolsView(
                     wrapped_provider=policy_provider,
                     on_demand_tool_names=on_demand_tool_names,
                     on_demand_mcp_server_ids=on_demand_mcp_ids,
                 )
-            else:
-                profile_tools_provider = policy_provider
             await profile_tools_provider.get_tool_definitions()
 
             profile_grants = (
@@ -1006,6 +1007,7 @@ class Assistant:
                 processing_services_registry=self.processing_services_registry,
                 home_assistant_client=home_assistant_client_for_profile,
                 camera_backend=camera_backend_for_profile,
+                on_demand_view=profile_on_demand_view,
             )
 
             self.processing_services_registry[profile_id] = processing_service_instance

--- a/src/family_assistant/processing/llm_loop.py
+++ b/src/family_assistant/processing/llm_loop.py
@@ -17,9 +17,7 @@ from family_assistant.llm.messages import (
     UserMessage,
 )
 from family_assistant.tools import (
-    OnDemandAwareToolsProvider,
     collect_system_prompt_addition,
-    find_provider_by_type,
     get_tool_definitions_for_advertisement,
 )
 
@@ -238,11 +236,13 @@ class LLMStreamingLoop:
 
         can_confirm = request_confirmation_callback is not None
 
-        # The on-demand provider is long-lived per profile and shared across
+        # The on-demand view is long-lived per profile and shared across
         # concurrent turns, so all activation state is kept turn-local here.
         tools_provider = self.tool_executor.tools_provider
-        on_demand_provider = find_provider_by_type(
-            tools_provider, OnDemandAwareToolsProvider
+        on_demand_view = (
+            processing_service.on_demand_view
+            if processing_service is not None
+            else None
         )
         activated_on_demand: frozenset[str] = frozenset()
 
@@ -250,14 +250,13 @@ class LLMStreamingLoop:
             """Re-compute the tool list and system prompt addition for this turn.
 
             On-demand tool definitions are sourced directly from the on-demand
-            provider (when present) so the activate_tools meta-tool and the
+            view (when present) so the activate_tools meta-tool and the
             turn-local activation set are honored. The system prompt addition
-            always goes through the generic ``collect_system_prompt_addition``
-            walker so contributions from any other ``SystemPromptContributingProvider``
-            in the chain are preserved alongside the on-demand catalog.
+            walks the provider chain for any ``SystemPromptContributingProvider``
+            contributions and appends the on-demand catalog from the view.
             """
-            if on_demand_provider is not None:
-                defs = await on_demand_provider.get_tool_definitions(
+            if on_demand_view is not None:
+                defs = await on_demand_view.get_tool_definitions(
                     can_confirm=can_confirm, activated=activated_on_demand
                 )
             else:
@@ -265,11 +264,22 @@ class LLMStreamingLoop:
                     tools_provider,
                     can_confirm=can_confirm,
                 )
-            addition = await collect_system_prompt_addition(
+            additions: list[str] = []
+            chain_addition = await collect_system_prompt_addition(
                 tools_provider,
                 can_confirm=can_confirm,
                 activated=activated_on_demand,
             )
+            if chain_addition:
+                additions.append(chain_addition)
+            if on_demand_view is not None:
+                view_addition = await on_demand_view.get_system_prompt_addition(
+                    can_confirm=can_confirm,
+                    activated=activated_on_demand,
+                )
+                if view_addition:
+                    additions.append(view_addition)
+            addition = "\n\n".join(additions) if additions else None
             return defs, addition
 
         tools_for_llm, system_prompt_addition = await refresh_on_demand_tools()
@@ -599,7 +609,7 @@ class LLMStreamingLoop:
 
             # Handle activate_tools meta-tool calls before regular execution
             regular_tool_calls = tool_calls_from_stream
-            if on_demand_provider:
+            if on_demand_view:
                 activate_calls = [
                     tc
                     for tc in tool_calls_from_stream
@@ -623,7 +633,7 @@ class LLMStreamingLoop:
                     requested_names = args.get("tool_names")
                     requested_search = args.get("search")
                     requested_mcp = args.get("mcp_server_ids")
-                    activation = await on_demand_provider.activate_tools(
+                    activation = await on_demand_view.activate_tools(
                         names=requested_names
                         if isinstance(requested_names, list)
                         else None,
@@ -716,14 +726,14 @@ class LLMStreamingLoop:
             # Auto-activate tools / MCP servers from skill results (e.g.,
             # get_note returning a skill with activate_tools or
             # activate_mcp_servers in its frontmatter).
-            if on_demand_provider:
+            if on_demand_view:
                 for tool_msg in tool_response_messages_for_llm:
                     auto_names, auto_mcp_servers = _extract_activations_from_result(
                         tool_msg
                     )
                     if not auto_names and not auto_mcp_servers:
                         continue
-                    activation = await on_demand_provider.activate_tools(
+                    activation = await on_demand_view.activate_tools(
                         names=auto_names or None,
                         mcp_server_ids=auto_mcp_servers or None,
                         can_confirm=can_confirm,

--- a/src/family_assistant/processing/service.py
+++ b/src/family_assistant/processing/service.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from family_assistant.processing.protocol import DelegatableService
     from family_assistant.services.attachment_registry import AttachmentRegistry
     from family_assistant.storage.context import DatabaseContext
-    from family_assistant.tools import ToolsProvider
+    from family_assistant.tools import OnDemandToolsView, ToolsProvider
     from family_assistant.tools.types import EventSourcesById
 
 logger = logging.getLogger(__name__)
@@ -81,9 +81,11 @@ class ProcessingService:
         processing_services_registry: Mapping[str, DelegatableService] | None = None,
         home_assistant_client: HomeAssistantClientWrapper | None = None,
         camera_backend: CameraBackend | None = None,
+        on_demand_view: OnDemandToolsView | None = None,
     ) -> None:
         self._llm_client = llm_client
         self.tools_provider = tools_provider
+        self.on_demand_view = on_demand_view
         self.service_config = service_config
         self.context_providers = context_providers
         self.server_url = server_url or "http://localhost:8000"

--- a/src/family_assistant/tools/__init__.py
+++ b/src/family_assistant/tools/__init__.py
@@ -183,9 +183,9 @@ from family_assistant.tools.notes import (
 )
 from family_assistant.tools.on_demand import (
     ACTIVATE_TOOLS_DEFINITION,
-    OnDemandAwareToolsProvider,
     OnDemandCatalogEntry,
     OnDemandToolCatalog,
+    OnDemandToolsView,
 )
 from family_assistant.tools.policy import (
     DEFAULT_POLICY_PRIORITY_OFFSET,
@@ -415,9 +415,9 @@ __all__ = [
     "get_llm_request_history",
     # On-demand tool activation
     "ACTIVATE_TOOLS_DEFINITION",
-    "OnDemandAwareToolsProvider",
     "OnDemandCatalogEntry",
     "OnDemandToolCatalog",
+    "OnDemandToolsView",
     # Stored scripts
     "STORED_SCRIPTS_TOOLS_DEFINITION",
     "save_script_tool",

--- a/src/family_assistant/tools/on_demand.py
+++ b/src/family_assistant/tools/on_demand.py
@@ -1,11 +1,19 @@
 """On-demand tool activation support.
 
-Provides the ``OnDemandAwareToolsProvider`` wrapper that splits tools into
-eager (always-loaded) and on-demand (catalog-only until activated) sets, plus
-the ``activate_tools`` meta-tool definition handled by the LLM loop.
+Provides the ``OnDemandToolsView``: an LLM-loop-only view over a real
+``ToolsProvider`` that:
 
-Activation state is *not* stored on the provider. The provider is long-lived
-per profile and shared across concurrent conversations, so mutable activation
+* hides on-demand tools from ``get_tool_definitions`` until the LLM activates
+  them via the synthetic ``activate_tools`` meta-tool, and
+* renders an on-demand catalog into the system prompt.
+
+The view is not itself a ``ToolsProvider``. On-demand gating is a concern of
+the LLM loop (which has a context window to protect); other consumers — most
+notably the script engine — talk to the underlying provider directly and see
+all tools that pass policy.
+
+Activation state is *not* stored on the view. The view is long-lived per
+profile and shared across concurrent conversations, so mutable activation
 state would race between turns. Callers (the LLM loop) keep a turn-local
 ``activated`` set and pass it in to every method that needs to know which
 tools are currently unlocked.
@@ -27,11 +35,7 @@ from family_assistant.tools.metadata import ToolDescriptor, extract_tool_summary
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from family_assistant.tools.types import (
-        ToolDefinition,
-        ToolExecutionContext,
-        ToolResult,
-    )
+    from family_assistant.tools.types import ToolDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -126,23 +130,23 @@ ACTIVATE_TOOLS_DEFINITION: ToolDefinition = {
 
 
 # ---------------------------------------------------------------------------
-# OnDemandAwareToolsProvider
+# OnDemandToolsView
 # ---------------------------------------------------------------------------
 
 
-class OnDemandAwareToolsProvider:
-    """Wraps a provider to split tools into eager (always-loaded) and on-demand sets.
+class OnDemandToolsView:
+    """LLM-loop view that hides on-demand tools from the LLM until activated.
 
-    On-demand tools are fully executable at all times — activation only controls
-    whether their full JSON schema is included in the LLM tool list. This keeps
-    context usage low while allowing the agent to activate tools when needed.
+    Not a ``ToolsProvider``. Holds a reference to a real provider — typically
+    a ``PolicyEnforcingToolsProvider`` — and exposes only the LLM-loop-facing
+    operations: filtered tool-definition listing, system-prompt catalog
+    rendering, and ``activate_tools``. Tool execution and descriptor access
+    go through the underlying provider directly; on-demand gating only
+    controls what the LLM sees in its tool list.
 
-    The provider itself holds no activation state. The LLM loop keeps a
+    The view itself holds no activation state. The LLM loop keeps a
     turn-local ``activated`` set and threads it through every call; that way
-    concurrent turns on a shared provider do not race on a common mutable set.
-
-    This provider implements ``ToolDescriptorProvider`` so it can be wrapped by
-    ``PolicyEnforcingToolsProvider``.
+    concurrent turns on a shared view do not race on a common mutable set.
     """
 
     def __init__(
@@ -153,7 +157,7 @@ class OnDemandAwareToolsProvider:
     ) -> None:
         if not isinstance(wrapped_provider, ToolDescriptorProvider):
             msg = (
-                "OnDemandAwareToolsProvider requires a wrapped provider that "
+                "OnDemandToolsView requires a wrapped provider that "
                 "supports tool descriptors."
             )
             raise ValueError(msg)
@@ -176,7 +180,7 @@ class OnDemandAwareToolsProvider:
 
     @property
     def wrapped_provider(self) -> ToolsProvider:
-        """Return the wrapped provider."""
+        """Return the underlying provider this view filters."""
         return self._wrapped_provider
 
     def has_on_demand_tools(self) -> bool:
@@ -198,7 +202,7 @@ class OnDemandAwareToolsProvider:
             collisions = [d for d in descriptors if d.name == "activate_tools"]
             if collisions:
                 msg = (
-                    "OnDemandAwareToolsProvider cannot wrap a provider that "
+                    "OnDemandToolsView cannot wrap a provider that "
                     "already exposes a tool named 'activate_tools'; this name "
                     "is reserved for the on-demand meta-tool."
                 )
@@ -240,7 +244,7 @@ class OnDemandAwareToolsProvider:
             return activated
         return frozenset(activated)
 
-    # --- ToolsProvider interface ---
+    # --- LLM-loop-facing API ---
 
     async def get_tool_definitions(
         self,
@@ -303,35 +307,6 @@ class OnDemandAwareToolsProvider:
             return None
         return catalog.render_for_system_prompt()
 
-    async def execute_tool(
-        self,
-        name: str,
-        # ast-grep-ignore: no-dict-any - Tool arguments are dynamic JSON from LLM
-        arguments: dict[str, Any],
-        context: ToolExecutionContext,
-        call_id: str | None = None,
-    ) -> str | ToolResult:
-        """Execute any tool (eager or on-demand). On-demand tools work without activation."""
-        return await self._wrapped_provider.execute_tool(
-            name, arguments, context, call_id
-        )
-
-    async def close(self) -> None:
-        """Clean up resources."""
-        await self._wrapped_provider.close()
-
-    # --- ToolDescriptorProvider interface ---
-
-    async def get_tool_descriptors(self) -> list[ToolDescriptor]:
-        """Return ALL tool descriptors (eager + on-demand). Policy layer uses these."""
-        return await self._ensure_descriptors()
-
-    async def get_tool_descriptor(self, name: str) -> ToolDescriptor | None:
-        """Return descriptor by name."""
-        return await self._descriptor_provider.get_tool_descriptor(name)
-
-    # --- On-demand specific ---
-
     async def get_on_demand_catalog(
         self,
         *,
@@ -380,7 +355,7 @@ class OnDemandAwareToolsProvider:
         """Activate on-demand tools by name, search keyword, or MCP server id.
 
         Returns the set of newly activated names and the corresponding tool
-        definitions, without mutating provider state. Only descriptors that
+        definitions, without mutating view state. Only descriptors that
         are currently on-demand (relative to the caller's ``activated`` set)
         AND that the wrapped policy provider would actually advertise for
         ``can_confirm`` are eligible. This avoids marking a tool as activated

--- a/tests/unit/processing/test_llm_loop_tool_advertisement.py
+++ b/tests/unit/processing/test_llm_loop_tool_advertisement.py
@@ -23,7 +23,7 @@ from family_assistant.tools.metadata import (
     ToolTag,
     make_local_tool_metadata,
 )
-from family_assistant.tools.on_demand import OnDemandAwareToolsProvider
+from family_assistant.tools.on_demand import OnDemandToolsView
 from family_assistant.tools.types import ToolResult
 from tests.mocks.mock_llm import (  # pylint: disable=no-name-in-module - note: pylint cannot resolve the implicit `tests` namespace package
     MatcherArgs,
@@ -202,8 +202,9 @@ async def test_llm_loop_executes_activate_tools_call_end_to_end(
     ``function.arguments`` (which may be a JSON string from the model) before
     reading ``tool_names``/``search``.
     """
-    on_demand_provider = OnDemandAwareToolsProvider(
-        wrapped_provider=_make_local_provider(["eager_a", "lazy_b"]),
+    local_provider = _make_local_provider(["eager_a", "lazy_b"])
+    on_demand_view = OnDemandToolsView(
+        wrapped_provider=local_provider,
         on_demand_tool_names={"lazy_b"},
     )
 
@@ -236,7 +237,7 @@ async def test_llm_loop_executes_activate_tools_call_end_to_end(
     )
     service = ProcessingService(
         llm_client=llm_client,
-        tools_provider=on_demand_provider,
+        tools_provider=local_provider,
         service_config=ProcessingServiceConfig(
             prompts={"system_prompt": "You are a test assistant."},
             timezone=ZoneInfo("UTC"),
@@ -249,6 +250,7 @@ async def test_llm_loop_executes_activate_tools_call_end_to_end(
         context_providers=[],
         server_url="http://testserver",
         app_config=AppConfig(),
+        on_demand_view=on_demand_view,
     )
 
     async with get_db_context(db_engine) as db_context:
@@ -297,8 +299,9 @@ async def test_llm_loop_auto_activates_tools_from_get_note_result(
         _build_registration("lazy_b", _noop_tool),
         _build_registration("get_note", _get_note_with_skill),
     ]
-    on_demand_provider = OnDemandAwareToolsProvider(
-        wrapped_provider=LocalToolsProvider(registrations=registrations),
+    local_provider = LocalToolsProvider(registrations=registrations)
+    on_demand_view = OnDemandToolsView(
+        wrapped_provider=local_provider,
         on_demand_tool_names={"lazy_b"},
     )
 
@@ -331,7 +334,7 @@ async def test_llm_loop_auto_activates_tools_from_get_note_result(
     )
     service = ProcessingService(
         llm_client=llm_client,
-        tools_provider=on_demand_provider,
+        tools_provider=local_provider,
         service_config=ProcessingServiceConfig(
             prompts={"system_prompt": "You are a test assistant."},
             timezone=ZoneInfo("UTC"),
@@ -344,6 +347,7 @@ async def test_llm_loop_auto_activates_tools_from_get_note_result(
         context_providers=[],
         server_url="http://testserver",
         app_config=AppConfig(),
+        on_demand_view=on_demand_view,
     )
 
     async with get_db_context(db_engine) as db_context:
@@ -382,8 +386,9 @@ async def test_llm_loop_ignores_activate_tools_key_from_non_get_note_tools(
         _build_registration("lazy_b", _noop_tool),
         _build_registration("untrusted_tool", _untrusted_tool),
     ]
-    on_demand_provider = OnDemandAwareToolsProvider(
-        wrapped_provider=LocalToolsProvider(registrations=registrations),
+    local_provider = LocalToolsProvider(registrations=registrations)
+    on_demand_view = OnDemandToolsView(
+        wrapped_provider=local_provider,
         on_demand_tool_names={"lazy_b"},
     )
 
@@ -416,7 +421,7 @@ async def test_llm_loop_ignores_activate_tools_key_from_non_get_note_tools(
     )
     service = ProcessingService(
         llm_client=llm_client,
-        tools_provider=on_demand_provider,
+        tools_provider=local_provider,
         service_config=ProcessingServiceConfig(
             prompts={"system_prompt": "You are a test assistant."},
             timezone=ZoneInfo("UTC"),
@@ -429,6 +434,7 @@ async def test_llm_loop_ignores_activate_tools_key_from_non_get_note_tools(
         context_providers=[],
         server_url="http://testserver",
         app_config=AppConfig(),
+        on_demand_view=on_demand_view,
     )
 
     async with get_db_context(db_engine) as db_context:

--- a/tests/unit/processing/test_on_demand_view_decoupling.py
+++ b/tests/unit/processing/test_on_demand_view_decoupling.py
@@ -1,0 +1,140 @@
+"""Regression tests for on-demand decoupling from the shared tools provider.
+
+On-demand gating is an LLM-context-window concern only. Before the
+``OnDemandToolsView`` refactor, the on-demand wrapper sat in the shared
+``ProcessingService.tools_provider`` chain, so non-LLM consumers — most
+importantly the script engine driving event-triggered automations — also saw
+on-demand tools filtered out of ``get_tool_definitions()`` and lost the
+ability to call them. These tests pin the new shape: ``tools_provider``
+returns the full policy-filtered set; the on-demand view is a sibling
+referenced only by the LLM loop.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from family_assistant.config_models import AppConfig, ToolsConfig
+from family_assistant.delegation_security import DelegationSecurityLevel
+from family_assistant.llm import LLMOutput
+from family_assistant.processing import ProcessingService, ProcessingServiceConfig
+from family_assistant.tools.infrastructure import LocalToolsProvider
+from family_assistant.tools.metadata import (
+    ToolRegistration,
+    ToolTag,
+    make_local_tool_metadata,
+)
+from family_assistant.tools.on_demand import OnDemandToolsView
+from tests.mocks.mock_llm import (  # pylint: disable=no-name-in-module - note: pylint cannot resolve the implicit `tests` namespace package
+    RuleBasedMockLLMClient,
+)
+
+if TYPE_CHECKING:
+    from family_assistant.tools.types import ToolDefinition
+
+
+async def _noop_tool(**_kwargs: object) -> str:
+    return "ok"
+
+
+def _registration(name: str) -> ToolRegistration:
+    return ToolRegistration(
+        definition=cast(
+            "ToolDefinition",
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": f"Description of {name}.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ),
+        implementation=_noop_tool,
+        metadata=make_local_tool_metadata([
+            ToolTag.READ_ONLY,
+            ToolTag.OUTPUT_TRUSTED,
+        ]),
+    )
+
+
+def _build_service(
+    *, with_on_demand: bool
+) -> tuple[ProcessingService, LocalToolsProvider, OnDemandToolsView | None]:
+    local_provider = LocalToolsProvider(
+        registrations=[_registration("eager_a"), _registration("lazy_b")]
+    )
+    on_demand_view: OnDemandToolsView | None = None
+    if with_on_demand:
+        on_demand_view = OnDemandToolsView(
+            wrapped_provider=local_provider,
+            on_demand_tool_names={"lazy_b"},
+        )
+    service = ProcessingService(
+        llm_client=RuleBasedMockLLMClient(
+            rules=[],
+            default_response=LLMOutput(content="ok", tool_calls=None),
+        ),
+        tools_provider=local_provider,
+        service_config=ProcessingServiceConfig(
+            prompts={"system_prompt": "test"},
+            timezone=ZoneInfo("UTC"),
+            max_history_messages=1,
+            history_max_age_hours=1,
+            tools_config=ToolsConfig(),
+            delegation_security_level=DelegationSecurityLevel.CONFIRM,
+            id="on-demand-decoupling",
+        ),
+        context_providers=[],
+        server_url="http://testserver",
+        app_config=AppConfig(),
+        on_demand_view=on_demand_view,
+    )
+    return service, local_provider, on_demand_view
+
+
+@pytest.mark.asyncio
+async def test_tools_provider_includes_on_demand_tools_for_non_llm_consumers() -> None:
+    """Scripts read ``service.tools_provider``; it must return ALL tools.
+
+    Regression: when on-demand was wrapped around the policy provider in the
+    shared chain, scripts (which call ``get_tool_definitions()`` without an
+    activation set) only saw eager tools, so HA tools that had been moved
+    behind a skill became invisible to automations.
+    """
+    service, _, on_demand_view = _build_service(with_on_demand=True)
+    assert on_demand_view is not None
+
+    defs = await service.tools_provider.get_tool_definitions()
+    names = {d["function"]["name"] for d in defs}
+
+    assert names == {"eager_a", "lazy_b"}
+
+
+@pytest.mark.asyncio
+async def test_on_demand_view_still_hides_unactivated_tools_from_llm() -> None:
+    """The LLM-facing view must still gate on-demand tools until activated."""
+    service, _, on_demand_view = _build_service(with_on_demand=True)
+    assert service.on_demand_view is on_demand_view
+    assert on_demand_view is not None
+
+    defs = await on_demand_view.get_tool_definitions()
+    names = {d["function"]["name"] for d in defs}
+
+    # Eager tool plus the synthetic activate_tools meta-tool; lazy_b is hidden.
+    assert names == {"eager_a", "activate_tools"}
+
+
+@pytest.mark.asyncio
+async def test_processing_service_without_on_demand_has_no_view() -> None:
+    """Profiles with no on-demand entries get a ``None`` view, not a wrapper."""
+    service, _, on_demand_view = _build_service(with_on_demand=False)
+
+    assert on_demand_view is None
+    assert service.on_demand_view is None
+    defs = await service.tools_provider.get_tool_definitions()
+    names = {d["function"]["name"] for d in defs}
+    assert names == {"eager_a", "lazy_b"}

--- a/tests/unit/tools/test_on_demand.py
+++ b/tests/unit/tools/test_on_demand.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
-from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -13,7 +11,6 @@ from family_assistant.config_models import (
     ToolLoadingEntry,
     ToolsConfig,
 )
-from family_assistant.storage.context import DatabaseContext
 from family_assistant.tools.infrastructure import LocalToolsProvider
 from family_assistant.tools.metadata import (
     ToolDescriptor,
@@ -23,14 +20,13 @@ from family_assistant.tools.metadata import (
     make_local_tool_metadata,
 )
 from family_assistant.tools.on_demand import (
-    OnDemandAwareToolsProvider,
     OnDemandCatalogEntry,
     OnDemandToolCatalog,
+    OnDemandToolsView,
 )
-from family_assistant.tools.types import ToolExecutionContext
 
 if TYPE_CHECKING:
-    from family_assistant.tools.types import ToolDefinition
+    from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 
 def _make_tool_def(name: str, description: str = "A test tool.") -> ToolDefinition:
@@ -175,13 +171,13 @@ class TestOnDemandToolCatalog:
         assert "activate_tools" in text
 
 
-class TestOnDemandAwareToolsProvider:
-    """Test OnDemandAwareToolsProvider behavior."""
+class TestOnDemandToolsView:
+    """Test OnDemandToolsView behavior."""
 
     @pytest.mark.asyncio
     async def test_eager_tools_returned_on_demand_excluded(self) -> None:
         provider = _make_provider(["eager_a", "eager_b", "lazy_c", "lazy_d"])
-        on_demand = OnDemandAwareToolsProvider(
+        on_demand = OnDemandToolsView(
             wrapped_provider=provider,
             on_demand_tool_names={"lazy_c", "lazy_d"},
         )
@@ -193,7 +189,7 @@ class TestOnDemandAwareToolsProvider:
     @pytest.mark.asyncio
     async def test_on_demand_catalog_contains_only_on_demand(self) -> None:
         provider = _make_provider(["eager_a", "lazy_b"])
-        on_demand = OnDemandAwareToolsProvider(
+        on_demand = OnDemandToolsView(
             wrapped_provider=provider,
             on_demand_tool_names={"lazy_b"},
         )
@@ -205,7 +201,7 @@ class TestOnDemandAwareToolsProvider:
     @pytest.mark.asyncio
     async def test_activate_by_name(self) -> None:
         provider = _make_provider(["eager_a", "lazy_b", "lazy_c"])
-        on_demand = OnDemandAwareToolsProvider(
+        on_demand = OnDemandToolsView(
             wrapped_provider=provider,
             on_demand_tool_names={"lazy_b", "lazy_c"},
         )
@@ -229,7 +225,7 @@ class TestOnDemandAwareToolsProvider:
     @pytest.mark.asyncio
     async def test_activate_by_search(self) -> None:
         provider = _make_provider(["notes_tool", "camera_tool", "automation_tool"])
-        on_demand = OnDemandAwareToolsProvider(
+        on_demand = OnDemandToolsView(
             wrapped_provider=provider,
             on_demand_tool_names={"camera_tool", "automation_tool"},
         )
@@ -240,42 +236,13 @@ class TestOnDemandAwareToolsProvider:
         assert result.definitions[0]["function"]["name"] == "camera_tool"
 
     @pytest.mark.asyncio
-    async def test_on_demand_tools_still_executable(self) -> None:
-        """On-demand tools should be executable even before activation."""
-
-        provider = _make_provider(["eager_a", "lazy_b"])
-        on_demand = OnDemandAwareToolsProvider(
-            wrapped_provider=provider,
-            on_demand_tool_names={"lazy_b"},
-        )
-
-        mock_db = MagicMock(spec=DatabaseContext)
-        context = ToolExecutionContext(
-            conversation_id="test",
-            user_name="test",
-            turn_id=None,
-            interface_type="test",
-            db_context=mock_db,
-            processing_service=MagicMock(),
-            clock=MagicMock(),
-            home_assistant_client=MagicMock(),
-            event_sources={},
-            attachment_registry=MagicMock(),
-            camera_backend=MagicMock(),
-            timezone=ZoneInfo("UTC"),
-        )
-
-        result = await on_demand.execute_tool("lazy_b", {}, context)
-        assert result == "ok"
-
-    @pytest.mark.asyncio
     async def test_has_on_demand_tools(self) -> None:
         provider = _make_provider(["a"])
-        on_demand_yes = OnDemandAwareToolsProvider(
+        on_demand_yes = OnDemandToolsView(
             wrapped_provider=provider,
             on_demand_tool_names={"a"},
         )
-        on_demand_no = OnDemandAwareToolsProvider(
+        on_demand_no = OnDemandToolsView(
             wrapped_provider=provider,
             on_demand_tool_names=set(),
         )
@@ -283,23 +250,10 @@ class TestOnDemandAwareToolsProvider:
         assert on_demand_no.has_on_demand_tools() is False
 
     @pytest.mark.asyncio
-    async def test_all_descriptors_returned(self) -> None:
-        """get_tool_descriptors should return ALL descriptors (eager + on-demand)."""
-        provider = _make_provider(["eager_a", "lazy_b"])
-        on_demand = OnDemandAwareToolsProvider(
-            wrapped_provider=provider,
-            on_demand_tool_names={"lazy_b"},
-        )
-
-        descriptors = await on_demand.get_tool_descriptors()
-        names = {d.name for d in descriptors}
-        assert names == {"eager_a", "lazy_b"}
-
-    @pytest.mark.asyncio
     async def test_activation_state_is_turn_local(self) -> None:
         """Provider holds no activation state; callers pass activated per turn."""
         provider = _make_provider(["eager_a", "lazy_b"])
-        on_demand = OnDemandAwareToolsProvider(
+        on_demand = OnDemandToolsView(
             wrapped_provider=provider,
             on_demand_tool_names={"lazy_b"},
         )
@@ -325,7 +279,7 @@ class TestOnDemandAwareToolsProvider:
 class _StubMCPDescriptorProvider:
     """Minimal ToolsProvider whose descriptors carry mcp_server_id values.
 
-    Used to exercise the OnDemandAwareToolsProvider's MCP server expansion
+    Used to exercise the OnDemandToolsView's MCP server expansion
     behavior, which the LocalToolsProvider helper does not cover because
     LocalToolsProvider produces local-origin descriptors with no server id.
     """
@@ -387,7 +341,7 @@ class TestOnDemandMCPServerExpansion:
             _make_mcp_descriptor("brave_search", "brave"),
         ]
         wrapped = _StubMCPDescriptorProvider(descriptors)
-        on_demand = OnDemandAwareToolsProvider(
+        on_demand = OnDemandToolsView(
             wrapped_provider=wrapped,
             on_demand_tool_names=set(),
             on_demand_mcp_server_ids={"homeassistant"},
@@ -419,7 +373,7 @@ class TestOnDemandMCPServerExpansion:
             _make_mcp_descriptor("ha_eager", "homeassistant"),
         ]
         wrapped = _StubMCPDescriptorProvider(descriptors)
-        on_demand = OnDemandAwareToolsProvider(
+        on_demand = OnDemandToolsView(
             wrapped_provider=wrapped,
             # Only ha_lazy_one and ha_lazy_two are on-demand. ha_eager lives on
             # the same MCP server but is eager — server-id-based on-demand is
@@ -450,7 +404,7 @@ class TestOnDemandActivateToolsCollision:
             _make_mcp_descriptor("activate_tools", "homeassistant"),
         ]
         wrapped = _StubMCPDescriptorProvider(descriptors)
-        on_demand = OnDemandAwareToolsProvider(
+        on_demand = OnDemandToolsView(
             wrapped_provider=wrapped,
             on_demand_tool_names=set(),
             on_demand_mcp_server_ids={"homeassistant"},


### PR DESCRIPTION
OnDemandAwareToolsProvider was a ToolsProvider in name only — the LLM loop
needed three method shapes for context-window gating, and we made it a
provider so it could be wedged into the chain. That dragged on-demand
filtering into every consumer of `ProcessingService.tools_provider`,
including the script engine, which has no LLM context to protect. After
HA tools moved behind a skill (loaded on demand), event-triggered
automations stopped seeing them at all because `MontyEngine` calls
`get_tool_definitions()` with no activation set.

Reshape it as `OnDemandToolsView` — an LLM-loop view, not a provider.
ProcessingService now stores it alongside `tools_provider`. The provider
chain stops at the policy layer and exposes the full set of allowed tools
to scripts, the web UI listing, and any other non-LLM consumer.
The LLM loop reads `processing_service.on_demand_view` directly instead
of fishing for it via `find_provider_by_type`.

Net: scripts see HA tools again; the LLM still gets the on-demand catalog
and `activate_tools` meta-tool exactly as before.

https://claude.ai/code/session_01HEX26jhsCVsxM3Lddmkcj3