### PR TITLE
Upgrade pydantic to 2.13.3 and pydantic-monty to 0.0.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ dependencies = [
     # Media download support
     "yt-dlp>=2024.0.0",
     "pydantic-settings>=2.10.1",
-    "pydantic-monty>=0.0.3",
+    "pydantic-monty>=0.0.17",
     "anthropic>=0.40.0",
     "kubernetes-asyncio>=35.0.0",
     "cloudcoil-models-kubernetes>=1.32",

--- a/src/family_assistant/scripting/monty_engine.py
+++ b/src/family_assistant/scripting/monty_engine.py
@@ -175,18 +175,13 @@ class MontyEngine:
             self._wake_llm_contexts.clear()
             self._script_globals = globals_dict or {}
 
-            (
-                ext_fn_names,
-                ext_fn_impls,
-                inputs,
-            ) = await self._build_execution_context_async(
+            ext_fn_impls, inputs = await self._build_execution_context_async(
                 globals_dict, execution_context
             )
 
             m = pydantic_monty.Monty(
                 script,
                 inputs=list(inputs.keys()) if inputs else [],
-                external_functions=ext_fn_names,
             )
 
             limits = self._build_resource_limits()
@@ -206,7 +201,7 @@ class MontyEngine:
 
             # Resume loop: handle external function calls
             while not isinstance(progress, pydantic_monty.MontyComplete):
-                if not isinstance(progress, pydantic_monty.MontySnapshot):
+                if not isinstance(progress, pydantic_monty.FunctionSnapshot):
                     raise ScriptExecutionError(
                         f"Unexpected Monty progress type: {type(progress)}"
                     )
@@ -219,7 +214,11 @@ class MontyEngine:
                         None,
                         partial(
                             progress.resume,
-                            exception=NameError(f"name '{fn_name}' is not defined"),
+                            {
+                                "exception": NameError(
+                                    f"name '{fn_name}' is not defined"
+                                )
+                            },
                         ),
                     )
                     continue
@@ -232,12 +231,12 @@ class MontyEngine:
                 except Exception as e:
                     progress = await loop.run_in_executor(
                         None,
-                        partial(progress.resume, exception=e),
+                        partial(progress.resume, {"exception": e}),
                     )
                 else:
                     progress = await loop.run_in_executor(
                         None,
-                        partial(progress.resume, return_value=result),
+                        partial(progress.resume, {"return_value": result}),
                     )
 
             self._pending_wake_contexts = self._wake_llm_contexts.copy()
@@ -271,9 +270,9 @@ class MontyEngine:
         globals_dict: dict[str, Any] | None,
         execution_context: "ToolExecutionContext | None",
         # ast-grep-ignore: no-dict-any - Inputs dict carries user-provided Python values keyed by name
-    ) -> tuple[list[str], dict[str, Callable[..., Any]], dict[str, Any]]:
+    ) -> tuple[dict[str, Callable[..., Any]], dict[str, Any]]:
         """
-        Build external function names, implementations, and inputs for async evaluation.
+        Build external function implementations and inputs for async evaluation.
 
         Unlike _build_execution_context, this creates async tool wrapper functions
         that directly await the ToolsProvider, bypassing the sync/async bridge
@@ -282,9 +281,8 @@ class MontyEngine:
         execution directly without thread pools or event loop bridging.
 
         Returns:
-            Tuple of (external_function_names, function_implementations, inputs)
+            Tuple of (function_implementations, inputs)
         """
-        ext_fn_names: list[str] = []
         ext_fn_impls: dict[str, Callable[..., Any]] = {}
         # ast-grep-ignore: no-dict-any - Inputs carry user-provided Python values keyed by name
         inputs: dict[str, Any] = {}
@@ -292,40 +290,34 @@ class MontyEngine:
         if globals_dict:
             for key, value in globals_dict.items():
                 if callable(value):
-                    ext_fn_names.append(key)
                     ext_fn_impls[key] = value
                 else:
                     inputs[key] = value
 
-        wake_fn = self._create_wake_llm_function()
-        ext_fn_names.append("wake_llm")
-        ext_fn_impls["wake_llm"] = wake_fn
+        ext_fn_impls["wake_llm"] = self._create_wake_llm_function()
 
         if self.config.enable_json_api:
-            self._add_json_api(ext_fn_names, ext_fn_impls)
-        self._add_base64_api(ext_fn_names, ext_fn_impls)
+            self._add_json_api(ext_fn_impls)
+        self._add_base64_api(ext_fn_impls)
         if self.config.enable_time_api:
-            self._add_time_api(ext_fn_names, ext_fn_impls, inputs, execution_context)
+            self._add_time_api(ext_fn_impls, inputs, execution_context)
         if self.config.enable_llm_api:
-            self._add_llm_api(ext_fn_names, ext_fn_impls)
+            self._add_llm_api(ext_fn_impls)
 
         if execution_context and execution_context.attachment_registry:
             try:
-                self._add_attachment_api_async(
-                    ext_fn_names, ext_fn_impls, execution_context
-                )
+                self._add_attachment_api_async(ext_fn_impls, execution_context)
                 logger.debug("Added async attachment API to Monty engine")
             except Exception as e:
                 logger.warning(f"Failed to add attachment API: {e}")
 
         if self.tools_provider and execution_context:
-            await self._add_tools_async(ext_fn_names, ext_fn_impls, execution_context)
+            await self._add_tools_async(ext_fn_impls, execution_context)
 
-        return ext_fn_names, ext_fn_impls, inputs
+        return ext_fn_impls, inputs
 
     async def _add_tools_async(
         self,
-        names: list[str],
         impls: dict[str, Callable[..., Any]],
         execution_context: "ToolExecutionContext",
     ) -> None:
@@ -347,9 +339,7 @@ class MontyEngine:
             return True
 
         if self.config.deny_all_tools:
-            names.append("tools_list")
             impls["tools_list"] = lambda: []
-            names.append("tools_get")
             impls["tools_get"] = lambda name: None
             logger.debug("All tools denied - added empty tool stubs")
             return
@@ -371,13 +361,11 @@ class MontyEngine:
         def tools_list() -> list[ToolInfo]:
             return list(tool_info_map.values())
 
-        names.append("tools_list")
         impls["tools_list"] = tools_list
 
         def tools_get(tool_name: str) -> ToolInfo | None:
             return tool_info_map.get(tool_name)
 
-        names.append("tools_get")
         impls["tools_get"] = tools_get
 
         raw_definitions = self._get_raw_tool_definitions_sync()
@@ -435,7 +423,6 @@ class MontyEngine:
         ) -> Any:  # noqa: ANN401
             return await execute_tool_async(tool_name, *args, **kwargs)
 
-        names.append("tools_execute")
         impls["tools_execute"] = tools_execute
 
         async def tools_execute_json(
@@ -449,7 +436,6 @@ class MontyEngine:
                 )
             return await execute_tool_async(tool_name, **parsed_args)
 
-        names.append("tools_execute_json")
         impls["tools_execute_json"] = tools_execute_json
 
         for tool_name in tool_info_map:
@@ -465,12 +451,8 @@ class MontyEngine:
 
                 return tool_wrapper
 
-            names.append(tool_name)
             impls[tool_name] = make_async_tool_wrapper(tool_name)
-
-            prefixed = f"tool_{tool_name}"
-            names.append(prefixed)
-            impls[prefixed] = make_async_tool_wrapper(tool_name)
+            impls[f"tool_{tool_name}"] = make_async_tool_wrapper(tool_name)
 
         logger.debug(
             "Added async tools API to Monty engine (allowed_tools=%s, "
@@ -482,7 +464,6 @@ class MontyEngine:
 
     def _add_attachment_api_async(
         self,
-        names: list[str],
         impls: dict[str, Callable[..., Any]],
         execution_context: "ToolExecutionContext",
     ) -> None:
@@ -530,7 +511,6 @@ class MontyEngine:
             ("attachment_read_bytes", attachment_read_bytes),
             ("attachment_create", attachment_create),
         ]:
-            names.append(name)
             impls[name] = fn
 
     async def _format_tool_result_async(
@@ -679,7 +659,6 @@ class MontyEngine:
 
     def _add_json_api(
         self,
-        names: list[str],
         impls: dict[str, Callable[..., Any]],
     ) -> None:
         """Add JSON encode/decode functions."""
@@ -687,12 +666,10 @@ class MontyEngine:
             ("json_encode", json.dumps),
             ("json_decode", _safe_json_decode),
         ]:
-            names.append(name)
             impls[name] = fn
 
     def _add_base64_api(
         self,
-        names: list[str],
         impls: dict[str, Callable[..., Any]],
     ) -> None:
         """Add base64 encode/decode functions."""
@@ -701,12 +678,10 @@ class MontyEngine:
             ("base64_decode", _base64_decode),
             ("base64_decode_bytes", _base64_decode_bytes),
         ]:
-            names.append(name)
             impls[name] = fn
 
     def _add_time_api(
         self,
-        names: list[str],
         impls: dict[str, Callable[..., Any]],
         # ast-grep-ignore: no-dict-any - Inputs carry user-provided Python values keyed by name
         inputs: dict[str, Any],
@@ -819,7 +794,6 @@ class MontyEngine:
         ]
 
         for name, fn in time_functions:
-            names.append(name)
             impls[name] = fn
 
         # Duration constants as inputs
@@ -836,15 +810,12 @@ class MontyEngine:
 
     def _add_llm_api(
         self,
-        names: list[str],
         impls: dict[str, Callable[..., Any]],
     ) -> None:
         """Add LLM API functions (llm, llm_json)."""
         from .apis.llm import llm_call_async, llm_call_json_async  # noqa: PLC0415
 
-        names.append("llm")
         impls["llm"] = llm_call_async
-        names.append("llm_json")
         impls["llm_json"] = llm_call_json_async
 
     def _build_resource_limits(self) -> pydantic_monty.ResourceLimits:

--- a/src/family_assistant/scripting/validator.py
+++ b/src/family_assistant/scripting/validator.py
@@ -407,20 +407,11 @@ class ScriptValidator:
         """
         diagnostics: list[ValidationDiagnostic] = []
 
-        # Collect all external function names for Monty
-        ext_fn_names = self._collect_external_function_names(
-            input_names,
-            extra_external_functions,
-            include_tools_api=include_tools_api,
-            include_attachment_api=include_attachment_api,
-        )
-
         # Build the Monty instance (catches syntax errors)
         try:
             m = pydantic_monty.Monty(
                 script,
                 inputs=input_names or [],
-                external_functions=ext_fn_names,
             )
         except pydantic_monty.MontySyntaxError as e:
             line = None
@@ -450,7 +441,7 @@ class ScriptValidator:
 
         # Run type checking — let infrastructure errors (RuntimeError) propagate
         try:
-            m.type_check(prefix_code=prefix_code)
+            m.type_check(type_check_stubs=prefix_code)
         except pydantic_monty.MontyTypingError as e:
             diagnostics.extend(_parse_typing_error(e))
             return ValidationResult(is_valid=False, diagnostics=diagnostics)
@@ -469,84 +460,6 @@ class ScriptValidator:
             )
 
         return ValidationResult(is_valid=True, diagnostics=diagnostics)
-
-    def _collect_external_function_names(
-        self,
-        input_names: list[str] | None,
-        extra_external_functions: list[str] | None = None,
-        include_tools_api: bool = True,
-        include_attachment_api: bool = True,
-    ) -> list[str]:
-        """Collect all external function names that Monty should know about."""
-        names: list[str] = []
-
-        # wake_llm is always available
-        names.append("wake_llm")
-
-        if self.config.enable_json_api:
-            names.extend(["json_encode", "json_decode"])
-        names.extend(["base64_encode", "base64_decode", "base64_decode_bytes"])
-        if self.config.enable_llm_api:
-            names.extend(["llm", "llm_json"])
-        if self.config.enable_time_api:
-            names.extend([
-                "time_now",
-                "time_now_utc",
-                "time_create",
-                "time_from_timestamp",
-                "time_parse",
-                "time_in_location",
-                "time_format",
-                "time_add",
-                "time_add_duration",
-                "time_year",
-                "time_month",
-                "time_day",
-                "time_hour",
-                "time_minute",
-                "time_second",
-                "time_weekday",
-                "time_before",
-                "time_after",
-                "time_equal",
-                "time_diff",
-                "duration_parse",
-                "duration_human",
-                "timezone_is_valid",
-                "timezone_offset",
-                "is_between",
-                "is_weekend",
-            ])
-        if include_attachment_api:
-            names.extend([
-                "attachment_get",
-                "attachment_read",
-                "attachment_read_bytes",
-                "attachment_create",
-            ])
-        if include_tools_api:
-            names.extend([
-                "tools_list",
-                "tools_get",
-                "tools_execute",
-                "tools_execute_json",
-            ])
-
-        # Tool names (direct and tool_-prefixed)
-        if self.tool_definitions:
-            for tool_def in self.tool_definitions:
-                name = tool_def.get("function", {}).get("name", "")
-                if name:
-                    names.append(name)
-                    names.append(f"tool_{name}")
-
-        # Extra callable names provided by the caller (e.g. callable globals)
-        if extra_external_functions:
-            names.extend(extra_external_functions)
-
-        # Filter out any input names (they're inputs, not functions)
-        input_set = set(input_names or [])
-        return [n for n in names if n not in input_set]
 
 
 def _parse_typing_error(

--- a/tests/functional/web/ui/test_events_list.py
+++ b/tests/functional/web/ui/test_events_list.py
@@ -71,6 +71,7 @@ async def test_events_page_basic_loading(
     assert not critical_errors, f"Critical console errors detected: {critical_errors}"
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_events_list_page_loads(

--- a/tests/functional/web/ui/test_history_basic.py
+++ b/tests/functional/web/ui/test_history_basic.py
@@ -394,6 +394,7 @@ async def test_history_pagination_interface(
             assert await pagination.is_visible()
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.playwright
 @pytest.mark.asyncio
 async def test_history_responsive_design(

--- a/uv.lock
+++ b/uv.lock
@@ -1897,7 +1897,7 @@ requires-dist = [
     { name = "psycopg-binary", marker = "extra == 'dev'", specifier = ">=3.1.0" },
     { name = "py-vapid", specifier = ">=1.9.2" },
     { name = "pycares", specifier = ">=4.4.0,<5.0.0" },
-    { name = "pydantic-monty", specifier = ">=0.0.3" },
+    { name = "pydantic-monty", specifier = ">=0.0.17" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pyspf", specifier = ">=2.0.14" },
@@ -4807,7 +4807,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.12.5"
+version = "2.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -4815,9 +4815,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
 ]
 
 [package.optional-dependencies]
@@ -4827,61 +4827,65 @@ email = [
 
 [[package]]
 name = "pydantic-core"
-version = "2.41.5"
+version = "2.46.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
-    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
-    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
-    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
 ]
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.3"
+version = "0.0.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/06/cf1d7b2f72fab8a7c4ed95cf48b76069f51100332c826790c3caeb568547/pydantic_monty-0.0.3.tar.gz", hash = "sha256:c5a10893b2e4632c250641a2564e303a0672683327281ef73df27c45e33f1112", size = 641703, upload-time = "2026-02-04T19:18:19.995Z" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/f8/431ba0b79d02922811392c4e3d283d6508f7052ceaa1936cc34878703ecc/pydantic_monty-0.0.17.tar.gz", hash = "sha256:9c4904a8fbc63282793f3afd2d180124494c7fc371783f365e5691c9586360af", size = 1007724, upload-time = "2026-04-22T20:13:48.915Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/d4/e5197e9ee3f267b566c8c1d1f1d850f4e1fd08f80944e3664e28ad36cb03/pydantic_monty-0.0.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:edb55efbf15a17e784ed49fadd32d97f048d70159b30a92705c7e00b6efa5865", size = 5443118, upload-time = "2026-02-04T19:19:08.155Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/fd/90edf50b9d432d799035ab9e56f0a006e0868691bca512a55c61c097e481/pydantic_monty-0.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4c597a33761079ae197424371908b11eeb5491799ff5e8bc7413a1920c2cc56d", size = 5520739, upload-time = "2026-02-04T19:18:13.83Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/510aeb35fa2f74ebe7927a71e926a4eb6ae5ed069ef63124d61701fa8136/pydantic_monty-0.0.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c6f781cbd460ac600987710b3ebe395e61eddcccbf48bc383ecbe2b9bf6daaf", size = 5248841, upload-time = "2026-02-04T19:17:42.31Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/29/6d2b45491949a6e610e2e15c421a24ee4329ae1ded77d039e54de77639f7/pydantic_monty-0.0.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6165193c347b766d0093104d2635517873110d942effe527b50e57d422280aab", size = 5522125, upload-time = "2026-02-04T19:17:43.689Z" },
-    { url = "https://files.pythonhosted.org/packages/06/7c/cd156f7dc28880ba96f5823ef4922883c48980aab44d3bbda953041dd732/pydantic_monty-0.0.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53538ba095fde39f903f842fd873418e6d64f8d7244fcb141c881de1435a8b5d", size = 5917472, upload-time = "2026-02-04T19:18:12.545Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/16/28ad55181c8ce5dcab01b7f863e451cce8c0b0d40e25aeb19b223df87639/pydantic_monty-0.0.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a2b446392bf2e6698ed39d05676996cd60994d06c14a757bc7ef71c99afa348", size = 6097064, upload-time = "2026-02-04T19:18:55.196Z" },
-    { url = "https://files.pythonhosted.org/packages/04/47/b67a2a3c59243dd1a97fc123449b3eaaf43f3439fc65978711203dd56765/pydantic_monty-0.0.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6755897973d085a7e02d667c37540cd619b78a4f477390697512a19a45109c8", size = 5930888, upload-time = "2026-02-04T19:19:02.14Z" },
-    { url = "https://files.pythonhosted.org/packages/36/f4/ac04587819224c2715f72c232cafa7dac03f4d7849710e9062ae0c7b5bd9/pydantic_monty-0.0.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:917dce8f0d7aa4244d9107ac010af8f26614fd338f60d55fe84fd2490c4390e1", size = 5831322, upload-time = "2026-02-04T19:17:44.919Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ab/133242ff9adb84fdc5d2b049f0920b5f56a470957540ff6cb31be65de9d2/pydantic_monty-0.0.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:9471b898682e5a50838aa2fd982b8f158db0fd4a72683d53963deda9322760f8", size = 5426475, upload-time = "2026-02-04T19:17:59.385Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/28/ce7421b80224b24613abdfa3691f1d1465dbdce26d86d90a474334756a53/pydantic_monty-0.0.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:cb33377a410ce51758e7540403be21976a6e0dd2f0bc48e1651e1b5fd1eed3d0", size = 5805560, upload-time = "2026-02-04T19:18:15.146Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/de/9a608e2990ce7d066391671fa5a96c4a8db38576ad1630813fb17684a3e1/pydantic_monty-0.0.3-cp313-cp313-win32.whl", hash = "sha256:1310e87618101182f31eee41fbca976966d41633f01c5dea08ae8db4f16269d1", size = 5394890, upload-time = "2026-02-04T19:17:40.515Z" },
-    { url = "https://files.pythonhosted.org/packages/34/8c/ee509efe060d592ae6c3f4f25882db7632396932af24ec8b8f8654b3b6cd/pydantic_monty-0.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:2244226fd67f7cf4357525c44284503a13fcdee01ba19b506598c137bdd69f6a", size = 6001485, upload-time = "2026-02-04T19:19:11.021Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/44/0e106b8b27eb93b66e4f3d279486464e05ba5ee31088848e58b5f506f879/pydantic_monty-0.0.17-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e0cdac8c3c16477596bc96ee1cec4f2fbaccd089e2daa1e7b9f227cc89f97cb1", size = 7341507, upload-time = "2026-04-22T20:14:41.717Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/88/a0315fa08e62e2d1ef00c03d8202d7bef3f1f71543bebfb916fea265c0a2/pydantic_monty-0.0.17-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:37290d6a1c35aba5cfb8b490bb31c0d822e8ddca8f3ca9ea068e30930d80dd1e", size = 7311916, upload-time = "2026-04-22T20:13:34.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e5/e4da6acb408594cbfbfb8dd3c0491b9b2ee54e9183e7ebc5f584baa07af9/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:49f252b2fb918686d3e8f76cb30245e782d1560a7fa68dbc0f6940d83c12bd41", size = 7867465, upload-time = "2026-04-22T20:13:31.466Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d4/64c2f8eb708a743b0944ea8f71dfd51bc655285b4be28d55577dafbb29fa/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2254d25c34463d67069f5f1567157bde9311654cd5371f8933b8ea9815bfa26a", size = 7139262, upload-time = "2026-04-22T20:14:10.715Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/67/5d766f9cd304e871a5dfe5f0a85eaa533538ef07e9b2858fdf9f37f83694/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0688a1fa5dc045ac7b7e996d7269b94f74f116d7b1e352c7b5bb5ad53d4fe03", size = 7450119, upload-time = "2026-04-22T20:13:44.515Z" },
+    { url = "https://files.pythonhosted.org/packages/33/98/fa16779021d93edb19807e87cdba56bbec6adfad21f10b41a212572ce513/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b35121ac555ed201405c69d531e4cb916da6984b8cd2e15c8a319117349faf6", size = 7967398, upload-time = "2026-04-22T20:13:55.576Z" },
+    { url = "https://files.pythonhosted.org/packages/92/64/287a42720bc9e975ab5b52625aa9fc6bcef8298dd821022cc45c6ee1808d/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c97dc44af25d4392b474902fc40f78f09fe8f44ba791364670334fe12abc077", size = 8198835, upload-time = "2026-04-22T20:15:02.072Z" },
+    { url = "https://files.pythonhosted.org/packages/97/37/03edb1fd582b79b2b462afc3fea5e1c8fea73afefc4870dc35fc3c7c492e/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ed2fb365ef9ca921de9a17786ecfa2efe06e65678e6ca57be51658a2a880f31", size = 7739241, upload-time = "2026-04-22T20:13:46.925Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0b/b765c9ca2ae27def1caa07345aba073ae1239fc2d9cca7a375f3dc2195f7/pydantic_monty-0.0.17-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5bf9f07b38dd12747e3c95b169a5afb3e2e9107622e01e548246c84d19a69c99", size = 7316719, upload-time = "2026-04-22T20:14:13.058Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3b/64fe872cd575ab5262e1ba2959554ead198c939cfaa425f7f8e9b1ad2694/pydantic_monty-0.0.17-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a5e9bafd4b5acbc0a8e12ee8403a3ce37281c3b0fa5909d3f412bee76c69003c", size = 7769150, upload-time = "2026-04-22T20:13:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b4/b6a0bb41f39bac2e11e6a2fd42ca0886893fafa6344fb17c3f0a94e22e83/pydantic_monty-0.0.17-cp313-cp313-win32.whl", hash = "sha256:1c239ae3e610d3f39cd1609285209a4e2d046b465ac1bfed0d4374c615eed0fa", size = 7227705, upload-time = "2026-04-22T20:15:12.262Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e7/d8cd62f537f7ab17714ee19ea221a0e341dab407215376ab1c41d79794c9/pydantic_monty-0.0.17-cp313-cp313-win_amd64.whl", hash = "sha256:1886c3590b02f359ae991f1e76691064f167330eda4fbf22762127ce17d0eb48", size = 8043469, upload-time = "2026-04-22T20:14:24.86Z" },
 ]
 
 [[package]]
 name = "pydantic-settings"
-version = "2.10.1"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrates the Monty scripting engine to the 0.0.17 API: external
functions are no longer declared in `Monty(...)`, `MontySnapshot` is
renamed to `FunctionSnapshot`, `FunctionSnapshot.resume()` takes a
positional dict (`{"return_value": x}` / `{"exception": e}`), and
`Monty.type_check()` parameter `prefix_code` is renamed to
`type_check_stubs`.

The unused name-collection plumbing in MontyEngine and the now-dead
`_collect_external_function_names` helper in ScriptValidator are
removed (per AGENTS.md: delete migrated implementations rather than
keep compat shims).

Marks two pre-existing flaky Playwright UI tests with reruns=2 to
match the convention used elsewhere in tests/functional/web/ui/.

https://claude.ai/code/session_01UkoJB5WZwPtSZn7uYvqP4c