### PR TITLE
Type-annotate ExternalException payloads in MontyEngine

### DIFF
--- a/src/family_assistant/scripting/monty_engine.py
+++ b/src/family_assistant/scripting/monty_engine.py
@@ -210,16 +210,12 @@ class MontyEngine:
                 fn = ext_fn_impls.get(fn_name)
 
                 if fn is None:
+                    undefined_function: pydantic_monty.ExternalException = {
+                        "exception": NameError(f"name '{fn_name}' is not defined")
+                    }
                     progress = await loop.run_in_executor(
                         None,
-                        partial(
-                            progress.resume,
-                            {
-                                "exception": NameError(
-                                    f"name '{fn_name}' is not defined"
-                                )
-                            },
-                        ),
+                        partial(progress.resume, undefined_function),
                     )
                     continue
 
@@ -229,9 +225,12 @@ class MontyEngine:
                     else:
                         result = fn(*progress.args, **progress.kwargs)
                 except Exception as e:
+                    exception_result: pydantic_monty.ExternalException = {
+                        "exception": e
+                    }
                     progress = await loop.run_in_executor(
                         None,
-                        partial(progress.resume, {"exception": e}),
+                        partial(progress.resume, exception_result),
                     )
                 else:
                     progress = await loop.run_in_executor(


### PR DESCRIPTION
### Motivation
- Ensure the values passed into `progress.resume` for error cases are explicitly typed as `pydantic_monty.ExternalException` to satisfy static/type expectations and make intent clear.  

### Description
- Create `undefined_function: pydantic_monty.ExternalException` and `exception_result: pydantic_monty.ExternalException` variables and pass them to `partial(progress.resume, ...)` for missing external functions and caught exceptions, with no change to runtime behavior.  

### Testing
- Ran unit tests and type checks using `pytest` and `mypy`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f889f9e2f08330afe8bddba92c4fb0)