### PR TITLE
Clarify plan-approval guidance in Development Guidelines (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -556,9 +556,11 @@ access, input validation, and defense-in-depth approaches.
 ## Development Guidelines
 
 - ALWAYS make a plan before you make any nontrivial changes.
-- ALWAYS ask the user to approve the plan before you start work. In particular, you MUST stop and
-  ask for approval before doing major rearchitecture or reimplementations, or making technical
-  decisions that may require judgement calls.
+- Ask for plan approval when there are significant decisions, tradeoffs, or ambiguity that require
+  user input (for example: major rearchitecture, reimplementation, or technical decisions that may
+  require judgement calls).
+- If the plan is just restating a clear user request with no meaningful choices to make, do not
+  pause for approval—proceed directly with the requested implementation.
 - Significant changes should have the plan written to docs/design for approval and future
   documentation.
 - When completing a user-visible feature, always update docs/user/USER_GUIDE.md and tell the


### PR DESCRIPTION
### Motivation
- Soften and clarify a previously absolute requirement to always stop for plan approval, to allow pragmatic behavior when a plan merely restates a clear user request while still requiring approval for significant decisions or tradeoffs.

### Description
- Replace the single absolute `ALWAYS ask the user to approve the plan before you start work` line with two concise bullets that require approval for significant decisions, tradeoffs, or ambiguity and allow proceeding when the plan simply restates a clear user request, plus minor formatting adjustments in `AGENTS.md`.

### Testing
- This is a documentation-only change; no code was modified and the existing automated test suite was run with `poe test` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f88aeaa1a88330949cdfa03a094a22)