### PR TITLE
Add branch review mode to code review script

### DIFF
--- a/.claude/README_HOOKS.md
+++ b/.claude/README_HOOKS.md
@@ -221,5 +221,8 @@ This project was migrated from custom hook scripts to plugins:
 **Kept Scripts**:
 
 - `session-start-hook.sh`: Project-specific workspace setup (not replaced by plugins)
-- `scripts/review-changes.py`: Integrated with guardian plugin's code review workflow
+- `scripts/review-changes.py`: Integrated with guardian plugin's code review workflow.
+  Supports three modes: default (staged changes), `--commit` (last commit),
+  and `--branch [BASE]` (whole branch vs `BASE`, default `origin/main`) for use
+  as a pre-PR review step.
 - `scripts/format-and-lint.sh`: Standalone script for manual use and pre-commit hooks

--- a/scripts/review-changes.py
+++ b/scripts/review-changes.py
@@ -339,49 +339,40 @@ def _diff_command(mode: str, base: str | None, extra: list[str]) -> list[str]:
 
 
 def get_diff(mode: str = "staged", base: str | None = None) -> str:
-    """Get the git diff based on mode."""
-    try:
-        result = subprocess.run(
-            _diff_command(mode, base, []),
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError:
-        return ""
+    """Get the git diff based on mode. Raises CalledProcessError on git failure."""
+    result = subprocess.run(
+        _diff_command(mode, base, []),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
     return result.stdout
 
 
 def get_diff_stat(mode: str = "staged", base: str | None = None) -> str:
-    """Get the git diff statistics."""
-    try:
-        result = subprocess.run(
-            _diff_command(mode, base, ["--stat"]),
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError:
-        return ""
+    """Get the git diff statistics. Raises CalledProcessError on git failure."""
+    result = subprocess.run(
+        _diff_command(mode, base, ["--stat"]),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
     return result.stdout
 
 
 def get_changed_files(mode: str = "staged", base: str | None = None) -> list[str]:
-    """Get list of changed files."""
+    """Get list of changed files. Raises CalledProcessError on git failure."""
     if mode == "commit":
         cmd = ["git", "show", "HEAD", "--name-only", "--pretty=format:"]
     else:
         cmd = _diff_command(mode, base, ["--name-only"])
 
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError:
-        return []
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
     return [f for f in result.stdout.splitlines() if f]
 
 
@@ -808,7 +799,20 @@ def review_changes(
             sys.exit(1)
 
     # Get diff and check if there are changes
-    diff = get_diff(mode, base)
+    try:
+        diff = get_diff(mode, base)
+        diff_stat = get_diff_stat(mode, base)
+        changed_files = get_changed_files(mode, base)
+    except subprocess.CalledProcessError as err:
+        stderr_text = (err.stderr or "").strip()
+        cmd_text = " ".join(err.cmd) if isinstance(err.cmd, list) else str(err.cmd)
+        print(
+            f"Error: git command failed (exit {err.returncode}): {cmd_text}\n{stderr_text}",
+            file=sys.stderr,
+        )
+        if output_json:
+            sys.stdout = original_stdout
+        sys.exit(1)
     if not diff.strip():
         no_changes_label = {
             "staged": "staged",
@@ -830,10 +834,6 @@ def review_changes(
                 })
             )
         return 0, {}
-
-    # Get diff statistics and file list
-    diff_stat = get_diff_stat(mode, base)
-    changed_files = get_changed_files(mode, base)
 
     if mode == "branch":
         print(f"Reviewing branch changes (vs {base})...", file=sys.stderr)

--- a/scripts/review-changes.py
+++ b/scripts/review-changes.py
@@ -325,13 +325,24 @@ class CodeReviewToolbox(llm.Toolbox):
             raise ReviewSubmittedException("Review submitted, exiting tool chain")
 
 
-def get_diff(mode: str = "staged") -> str:
+def _diff_command(mode: str, base: str | None, extra: list[str]) -> list[str]:
+    """Build the git command for the given review mode."""
+    if mode == "staged":
+        return ["git", "diff", "--cached", *extra]
+    if mode == "commit":
+        return ["git", "show", "HEAD", *extra]
+    if mode == "branch":
+        if not base:
+            raise ValueError("branch mode requires a base ref")
+        return ["git", "diff", f"{base}...HEAD", *extra]
+    raise ValueError(f"Unknown review mode: {mode}")
+
+
+def get_diff(mode: str = "staged", base: str | None = None) -> str:
     """Get the git diff based on mode."""
-    cmd = ["git", "diff", "--cached"] if mode == "staged" else ["git", "show", "HEAD"]
-
     try:
         result = subprocess.run(
-            cmd,
+            _diff_command(mode, base, []),
             capture_output=True,
             text=True,
             check=True,
@@ -341,17 +352,11 @@ def get_diff(mode: str = "staged") -> str:
     return result.stdout
 
 
-def get_diff_stat(mode: str = "staged") -> str:
+def get_diff_stat(mode: str = "staged", base: str | None = None) -> str:
     """Get the git diff statistics."""
-    cmd = (
-        ["git", "diff", "--cached", "--stat"]
-        if mode == "staged"
-        else ["git", "show", "HEAD", "--stat"]
-    )
-
     try:
         result = subprocess.run(
-            cmd,
+            _diff_command(mode, base, ["--stat"]),
             capture_output=True,
             text=True,
             check=True,
@@ -361,13 +366,12 @@ def get_diff_stat(mode: str = "staged") -> str:
     return result.stdout
 
 
-def get_changed_files(mode: str = "staged") -> list[str]:
+def get_changed_files(mode: str = "staged", base: str | None = None) -> list[str]:
     """Get list of changed files."""
-    cmd = (
-        ["git", "diff", "--cached", "--name-only"]
-        if mode == "staged"
-        else ["git", "show", "HEAD", "--name-only", "--pretty=format:"]
-    )
+    if mode == "commit":
+        cmd = ["git", "show", "HEAD", "--name-only", "--pretty=format:"]
+    else:
+        cmd = _diff_command(mode, base, ["--name-only"])
 
     try:
         result = subprocess.run(
@@ -521,14 +525,23 @@ def smart_truncate_diff(diff: str, max_chars: int = 50000) -> tuple[str, bool]:
     return "\n".join(result), True
 
 
-def get_baseline_commit(mode: str = "staged") -> str:
+def get_baseline_commit(mode: str = "staged", base: str | None = None) -> str:
     """Get the baseline commit for the diff."""
     if mode == "staged":
         # For staged changes, baseline is HEAD
         cmd = ["git", "rev-parse", "HEAD"]
-    else:
+    elif mode == "commit":
         # For commit mode, baseline is the parent of HEAD
         cmd = ["git", "rev-parse", "HEAD~1"]
+    elif mode == "branch":
+        # For branch mode, baseline is the merge-base with the given base ref.
+        # Using merge-base (not the base tip) keeps the cache key stable when
+        # the base branch advances without affecting our review.
+        if not base:
+            return ""
+        cmd = ["git", "merge-base", base, "HEAD"]
+    else:
+        return ""
 
     try:
         result = subprocess.run(
@@ -720,16 +733,18 @@ def review_changes(
     output_json: bool = False,
     model_name: str | None = None,
     command: str | None = None,
+    base: str | None = None,
     # ast-grep-ignore: no-dict-any - Legacy code - needs structured types
 ) -> tuple[int, dict[str, Any]]:
     """
     Main review function using LLM with tools.
 
     Args:
-        mode: "staged" or "commit"
+        mode: "staged", "commit", or "branch"
         output_json: Whether to output JSON instead of human-readable format
         model_name: Optional model name to use (e.g., 'gpt-4o', 'claude-3.5-sonnet')
         command: Optional git command being executed (for context)
+        base: Base ref for branch mode (e.g., 'origin/main'). Required when mode == 'branch'.
 
     Returns:
         Tuple of (exit_code, review_data)
@@ -769,11 +784,39 @@ def review_changes(
         original_stdout = sys.stdout
         sys.stdout = sys.stderr
 
+    # Validate branch mode has a usable base ref
+    if mode == "branch":
+        if not base:
+            print(
+                "Error: branch mode requires a base ref (e.g. --branch origin/main)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        try:
+            subprocess.run(
+                ["git", "rev-parse", "--verify", base],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            print(
+                f"Error: base ref '{base}' could not be resolved. "
+                "Try fetching it first (e.g. git fetch origin main).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
     # Get diff and check if there are changes
-    diff = get_diff(mode)
+    diff = get_diff(mode, base)
     if not diff.strip():
+        no_changes_label = {
+            "staged": "staged",
+            "commit": "committed",
+            "branch": f"branch (vs {base})",
+        }.get(mode, mode)
         print(
-            f"No {'staged' if mode == 'staged' else 'committed'} changes to review",
+            f"No {no_changes_label} changes to review",
             file=sys.stderr,
         )
         if output_json:
@@ -789,10 +832,13 @@ def review_changes(
         return 0, {}
 
     # Get diff statistics and file list
-    diff_stat = get_diff_stat(mode)
-    changed_files = get_changed_files(mode)
+    diff_stat = get_diff_stat(mode, base)
+    changed_files = get_changed_files(mode, base)
 
-    print(f"Reviewing {mode} changes...", file=sys.stderr)
+    if mode == "branch":
+        print(f"Reviewing branch changes (vs {base})...", file=sys.stderr)
+    else:
+        print(f"Reviewing {mode} changes...", file=sys.stderr)
     print("\nChange Statistics:", file=sys.stderr)
     print(diff_stat, file=sys.stderr)
 
@@ -955,7 +1001,7 @@ submit_review(
 
     # Check cache first
     cache_dir = repo_root / ".review_cache"
-    baseline_commit = get_baseline_commit(mode)
+    baseline_commit = get_baseline_commit(mode, base)
     cache_key = compute_cache_key(diff, baseline_commit)
 
     cached_review = get_cached_review(cache_key, cache_dir)
@@ -1109,10 +1155,22 @@ Exit codes:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-    parser.add_argument(
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
         "--commit",
         action="store_true",
         help="Review the most recent commit (default: review staged changes)",
+    )
+    mode_group.add_argument(
+        "--branch",
+        nargs="?",
+        const="origin/main",
+        default=None,
+        metavar="BASE",
+        help=(
+            "Review the entire current branch versus BASE (default: origin/main). "
+            "Useful as a pre-PR review step covering all commits on the branch."
+        ),
     )
     parser.add_argument(
         "--json",
@@ -1152,13 +1210,23 @@ Exit codes:
             stream=sys.stderr,
         )
 
-    mode = "commit" if args.commit else "staged"
+    if args.commit:
+        mode = "commit"
+        base = None
+    elif args.branch is not None:
+        mode = "branch"
+        base = args.branch
+    else:
+        mode = "staged"
+        base = None
     output_json = args.json
     model_name = args.model
     command = args.command
 
     try:
-        exit_code, _ = review_changes(mode, output_json, model_name, command)
+        exit_code, _ = review_changes(
+            mode, output_json, model_name, command, base=base
+        )
         sys.exit(exit_code)
     except KeyboardInterrupt:
         print("\nReview cancelled by user", file=sys.stderr)


### PR DESCRIPTION
## Summary
Extended the `review-changes.py` script to support reviewing an entire branch versus a base reference, in addition to the existing staged changes and commit modes. This enables using the script as a pre-PR review step to catch all changes on a feature branch.

## Key Changes

- **New branch review mode**: Added `--branch [BASE]` argument (defaults to `origin/main`) to review all commits on the current branch versus a specified base reference
- **Refactored diff command building**: Extracted common git command construction logic into `_diff_command()` helper function to support the new mode and reduce duplication across `get_diff()`, `get_diff_stat()`, and `get_changed_files()`
- **Enhanced baseline commit logic**: Updated `get_baseline_commit()` to use `git merge-base` for branch mode, ensuring stable cache keys when the base branch advances
- **Input validation**: Added validation to ensure branch mode receives a valid base reference that can be resolved in the repository
- **Improved user messaging**: Enhanced output messages to clearly indicate which mode is being used and what comparison is being made (e.g., "Reviewing branch changes (vs origin/main)...")
- **Mutually exclusive mode arguments**: Made `--commit` and `--branch` mutually exclusive to prevent conflicting mode specifications

## Implementation Details

- The `base` parameter is now threaded through all relevant functions: `get_diff()`, `get_diff_stat()`, `get_changed_files()`, `get_baseline_commit()`, and `review_changes()`
- Branch mode validation occurs early in `review_changes()` with helpful error messages if the base ref cannot be resolved
- The merge-base approach for branch mode provides stable caching behavior independent of base branch advancement
- Documentation updated to reflect the three supported modes and their use cases

https://claude.ai/code/session_016kKbkkAhuF1qPGaxMMpjFs