### PR TITLE
[codex] Add unified user identity mapping

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -14,6 +14,26 @@
 # 4. Environment variables
 # 5. CLI arguments
 
+# --- Users ---
+# Canonical application users. Configure this when the same human can use more
+# than one interface (for example Telegram plus the web UI) so durable
+# confirmations, API tokens, push subscriptions, and email ownership use the
+# same user identifier everywhere.
+#
+# Use the stable Keycloak/OIDC email as `id` unless you have a stronger local
+# convention. Telegram `user_ids` are Telegram user IDs, not chat IDs.
+# users:
+#   - id: "alice@example.com"
+#     oidc:
+#       emails: ["alice@example.com"]
+#       subjects: []  # Optional Keycloak/OIDC subject IDs.
+#     telegram:
+#       user_ids: [123456789]
+#       developer: true
+#     email_intake:
+#       sender_addresses: ["alice@gmail.com"]
+#       recipient_addresses: ["assistant+alice@mg.example.com"]
+
 # --- Timezone ---
 # Override the default timezone for the application
 # default_profile_settings:

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1,4 +1,9 @@
 # Configuration for Family Assistant
+# Canonical application users. Leave empty for legacy single-interface local
+# development; production deployments should configure one entry per human user
+# so Telegram, web/OIDC, and email all resolve to the same user id.
+users: []
+
 # LLM Provider Configuration
 # Each service profile can specify a 'provider' in its processing_config.
 # Available providers: 'openai', 'google', 'anthropic'
@@ -242,7 +247,7 @@ email_intake:
   require_authenticated_sender: false
   # Require accepted emails to resolve to exactly one configured application user.
   require_user_mapping: false
-  # Map authorized forwarding senders and/or Mailgun inbound aliases to app users.
+  # Legacy email-only mappings. Prefer top-level users[].email_intake for new deployments.
   user_mappings: []
   # Application-level limits in bytes, independent of any reverse proxy limits.
   max_raw_request_bytes: 26214400
@@ -1822,4 +1827,3 @@ otel:
 
 # Secrets (telegram_token, api_keys, database_url) are primarily from env.
 # Model, embedding_model, server_url, storage_paths are also top-level or env.
-

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -63,6 +63,17 @@ For programmatic access, use Bearer token authentication:
 Authorization: Bearer <your-api-token>
 ```
 
+**Check the resolved application user:**
+
+```bash
+curl "https://your-domain.com/api/me" \
+  -H "Authorization: Bearer <your-api-token>"
+```
+
+`/api/auth/me` returns the same payload for clients that are already using the auth API namespace.
+The response includes `user_identifier`, the canonical application user id after OIDC/API-token
+identity mapping.
+
 #### Obtaining API Tokens
 
 API tokens can be created through:

--- a/docs/design/unified-user-identities.md
+++ b/docs/design/unified-user-identities.md
@@ -1,0 +1,89 @@
+# Unified User Identities
+
+## Problem
+
+Durable tool confirmations are authorized by `target_user_id`, but each interface currently chooses
+that value independently:
+
+- Web auth uses the OIDC subject or API token owner.
+- Telegram uses the numeric Telegram user id.
+- Email intake has a separate sender/recipient mapping.
+
+That means a confirmation created from Telegram is invisible in the web UI unless the OIDC user id
+happens to equal the Telegram id. It also leaves operators configuring the same human user in
+several places.
+
+## Design
+
+Add a top-level `users` config block as the source of truth for application users:
+
+```yaml
+users:
+  - id: "andrew@example.com"
+    oidc:
+      emails: ["andrew@example.com"]
+      subjects: []
+    telegram:
+      user_ids: [123456789]
+      developer: true
+    email_intake:
+      sender_addresses: ["andrew@gmail.com"]
+      recipient_addresses: ["assistant+andrew@example.net"]
+```
+
+The `id` is the canonical user identifier stored on durable confirmations, API tokens, push
+subscriptions, conversation ownership fields, and other user-scoped rows. For the current single
+installation, using the normalized Keycloak email as the canonical id is the lowest-friction
+operator model and aligns with existing OIDC/email allowlists.
+
+When `users` is configured:
+
+- OIDC sessions resolve by configured email or subject.
+- Telegram messages resolve by configured Telegram user id.
+- Email intake resolves by configured sender or recipient addresses.
+- Unknown OIDC, Telegram, or email identities are rejected at the interface boundary.
+
+When `users` is empty, legacy behavior remains for local development and existing tests:
+
+- OIDC/API tokens keep using the existing subject/email value.
+- Telegram uses `allowed_user_ids` and numeric Telegram ids.
+- Email intake uses `email_intake.user_mappings`.
+
+This keeps the migration incremental without preserving two production identity systems once
+operators move to `users`.
+
+## Confirmation Flow
+
+Durable confirmations continue to use the existing `confirmation_requests.target_user_id` column.
+The important change is only which value is written:
+
+1. Telegram receives an authorized update from Telegram user `123456789`.
+2. The identity resolver maps it to canonical user `andrew@example.com`.
+3. Tool confirmation is stored with `target_user_id = "andrew@example.com"`.
+4. Web auth maps the Keycloak session for `andrew@example.com` to the same canonical user.
+5. The web pending-confirmations endpoint lists and approves the Telegram-created confirmation.
+
+No new confirmation entity is introduced.
+
+## Operator Migration
+
+Operators should move values from the old scattered fields into `users`:
+
+- `allowed_user_ids` -> `users[].telegram.user_ids`
+- `developer_chat_id` -> `users[].telegram.developer: true`
+- `email_intake.user_mappings` -> `users[].email_intake`
+
+Existing email sender and recipient allowlists remain available as security policy. User mapping
+answers "which application user owns this email"; allowlists answer "which inbound addresses are
+accepted at all".
+
+## Tests
+
+The implementation should verify:
+
+- OIDC email and Telegram id resolve to the same canonical user.
+- A Telegram-created durable confirmation appears in the web pending-confirmations endpoint for the
+  matching OIDC user.
+- Web approval/rejection of that Telegram-created confirmation is authorized.
+- Email intake maps sender/recipient identities through the same canonical user config.
+- Unknown Telegram users and ambiguous email mappings are rejected.

--- a/docs/operations/CONFIGURATION_REFERENCE.md
+++ b/docs/operations/CONFIGURATION_REFERENCE.md
@@ -134,6 +134,51 @@ Directory containing user documentation files.
 
 ______________________________________________________________________
 
+## User Identities
+
+Use top-level `users` to map each human to a canonical application user id across web/OIDC,
+Telegram, and email intake. This is the id stored on durable confirmations and other user-scoped
+records.
+
+```yaml
+users:
+  - id: "alice@example.com"
+    oidc:
+      emails:
+        - "alice@example.com"
+      subjects: []
+    telegram:
+      user_ids:
+        - 123456789
+      developer: true
+    email_intake:
+      sender_addresses:
+        - "alice@gmail.com"
+      recipient_addresses:
+        - "assistant+alice@mg.example.com"
+```
+
+Use the stable Keycloak/OIDC email as `id` unless you have a stronger local convention. Telegram
+`user_ids` are Telegram user IDs, not chat IDs.
+
+When `users` is configured, unknown OIDC users, Telegram users, and required email mappings are
+rejected at the interface boundary. When it is empty, the app keeps the legacy behavior:
+`allowed_user_ids`, `developer_chat_id`, and `email_intake.user_mappings`.
+
+### Migration From Legacy Identity Settings
+
+| Legacy field                                       | New field                                  |
+| -------------------------------------------------- | ------------------------------------------ |
+| `allowed_user_ids`                                 | `users[].telegram.user_ids`                |
+| `developer_chat_id`                                | `users[].telegram.developer: true`         |
+| `email_intake.user_mappings[].user_id`             | `users[].id`                               |
+| `email_intake.user_mappings[].sender_addresses`    | `users[].email_intake.sender_addresses`    |
+| `email_intake.user_mappings[].recipient_addresses` | `users[].email_intake.recipient_addresses` |
+
+`email_intake.allowed_sender_addresses` and `allowed_recipient_addresses` are still security
+allowlists. They answer "which inbound addresses are accepted at all"; `users[].email_intake`
+answers "which canonical user owns this accepted email".
+
 ## Email Intake Security
 
 The `/webhook/mail` endpoint accepts Mailgun inbound email webhooks. Use this configuration when
@@ -156,17 +201,6 @@ email_intake:
   require_authenticated_sender: true
 
   require_user_mapping: true
-  user_mappings:
-    - user_id: "alice"
-      sender_addresses:
-        - "alice@gmail.com"
-      recipient_addresses:
-        - "assistant+alice@mg.example.com"
-    - user_id: "bob"
-      sender_addresses:
-        - "bob@gmail.com"
-      recipient_addresses:
-        - "assistant+bob@mg.example.com"
 
   max_raw_request_bytes: 26214400
   max_attachment_bytes: 10485760
@@ -235,25 +269,28 @@ If this list is non-empty, the Mailgun signing key must also be set.
 
 ### User Mapping
 
-`user_mappings` resolve accepted inbound email to an application `user_id`. The resolved value is
-stored on the received email as `target_user_id`, so later action-processing and confirmation flows
-can deterministically choose the right user context.
+`users[].email_intake` resolves accepted inbound email to a canonical application user id. The
+resolved value is stored on the received email as `target_user_id`, so later action-processing and
+confirmation flows can deterministically choose the right user context.
 
 Mappings can match by authorized forwarding sender, by Mailgun recipient alias, or by both:
 
 ```yaml
-email_intake:
-  require_user_mapping: true
-  user_mappings:
-    - user_id: "alice"
+users:
+  - id: "alice@example.com"
+    oidc:
+      emails: ["alice@example.com"]
+    email_intake:
       sender_addresses: ["alice@gmail.com"]
       recipient_addresses: ["assistant+alice@mg.example.com"]
+
+email_intake:
+  require_user_mapping: true
 ```
 
 When `require_user_mapping` is true, accepted email must map to exactly one configured user. If no
 mapping matches, the webhook returns `401`. If sender and recipient mappings point to different
-users, the webhook also returns `401` rather than guessing. If multiple mapping entries match the
-same `user_id`, that is accepted.
+users, the webhook also returns `401` rather than guessing.
 
 For the least operational friction, map each user's stable forwarding address in `sender_addresses`.
 For stronger routing and clearer confirmation behavior, also give each user a Mailgun inbound alias
@@ -262,10 +299,10 @@ and include it in `recipient_addresses`.
 | Option                 | Default | Recommended for actions |
 | ---------------------- | ------- | ----------------------- |
 | `require_user_mapping` | `false` | `true`                  |
-| `user_mappings`        | `[]`    | One entry per user      |
+| `users[].email_intake` | `[]`    | One entry per user      |
 
-If `require_user_mapping` is true or `user_mappings` is non-empty, the Mailgun signing key must also
-be set.
+If `require_user_mapping` is true or `users[].email_intake` is non-empty, the Mailgun signing key
+must also be set.
 
 ### Sender Authentication Policy
 

--- a/docs/operations/CONFIGURATION_REFERENCE.md
+++ b/docs/operations/CONFIGURATION_REFERENCE.md
@@ -165,6 +165,40 @@ When `users` is configured, unknown OIDC users, Telegram users, and required ema
 rejected at the interface boundary. When it is empty, the app keeps the legacy behavior:
 `allowed_user_ids`, `developer_chat_id`, and `email_intake.user_mappings`.
 
+If you do not want Telegram identifiers in `config.yaml`, keep the non-sensitive user shape in YAML
+and inject sensitive identity details with `USER_IDENTITIES_FILE`:
+
+```yaml
+users:
+  - id: "alice@example.com"
+    oidc:
+      emails:
+        - "alice@example.com"
+    email_intake:
+      sender_addresses:
+        - "alice@gmail.com"
+```
+
+```yaml
+# /run/secrets/family-assistant-users.yaml
+users:
+  - id: "alice@example.com"
+    telegram:
+      user_ids:
+        - 123456789
+      developer: true
+```
+
+```bash
+USER_IDENTITIES_FILE=/run/secrets/family-assistant-users.yaml
+CHAT_ID_TO_NAME_MAP='123456789:Alice'
+```
+
+The file can contain either a top-level `users:` list or a bare user list. Entries are merged into
+`config.yaml` by `id`, so secret-backed files can add only the sensitive fields. This is useful for
+GitOps deployments that keep numeric Telegram IDs and display names in a Kubernetes Secret or
+SealedSecret while leaving email/OIDC mappings editable in the normal config.
+
 ### Migration From Legacy Identity Settings
 
 | Legacy field                                       | New field                                  |
@@ -178,6 +212,8 @@ rejected at the interface boundary. When it is empty, the app keeps the legacy b
 `email_intake.allowed_sender_addresses` and `allowed_recipient_addresses` are still security
 allowlists. They answer "which inbound addresses are accepted at all"; `users[].email_intake`
 answers "which canonical user owns this accepted email".
+
+______________________________________________________________________
 
 ## Email Intake Security
 
@@ -402,6 +438,39 @@ Mapping of Telegram chat IDs to display names.
 | Example   | `123:Alice,456:Bob` |
 
 Format: comma-separated `chat_id:name` pairs.
+
+______________________________________________________________________
+
+### USER_IDENTITIES_FILE
+
+Path to a YAML file containing user identity entries to merge into top-level `users`.
+
+| Property  | Value                                                    |
+| --------- | -------------------------------------------------------- |
+| Required  | No                                                       |
+| Default   | Unset                                                    |
+| Sensitive | Yes, if the file contains sensitive identity identifiers |
+| Example   | `/run/secrets/family-assistant-users.yaml`               |
+
+The file can contain either:
+
+```yaml
+users:
+  - id: "alice@example.com"
+    telegram:
+      user_ids: [123]
+```
+
+or:
+
+```yaml
+- id: "alice@example.com"
+  telegram:
+    user_ids: [123]
+```
+
+Entries are merged with configured users by `id`. Nested objects are deep-merged; lists follow
+normal YAML config semantics and are replaced by the overlay value.
 
 ______________________________________________________________________
 

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -395,6 +395,8 @@ When the assistant needs to perform important actions, you'll be asked to confir
   - Pending web approvals are stored durably. If you reload the page or the assistant process
     restarts, the web interface can show the pending approval again and your approval still uses the
     background task queue for execution.
+  - If the operator has linked your Telegram and web login to the same account, an action requested
+    from Telegram can also appear in the web interface for approval.
   - The assistant will wait for your response before proceeding
 - **Why this matters:** This gives you full control over what the assistant does and prevents
   unintended actions

--- a/src/family_assistant/assistant.py
+++ b/src/family_assistant/assistant.py
@@ -60,6 +60,7 @@ from family_assistant.services.confirmation_waiters import (
     ConfirmationResultWaiterRegistry,
 )
 from family_assistant.services.push_notification import PushNotificationService
+from family_assistant.services.user_identity import UserIdentityResolver
 from family_assistant.services.worker_backend import get_worker_backend
 from family_assistant.skills import NoteRegistry, load_skills_from_directory
 from family_assistant.storage import init_db
@@ -388,6 +389,9 @@ class Assistant:
 
         # Store config in FastAPI app state for access by routes
         self.fastapi_app.state.config = self.config
+        self.fastapi_app.state.user_identity_resolver = UserIdentityResolver(
+            self.config
+        )
         logger.info("Stored configuration in FastAPI app state.")
 
         # Create MessageNotifier for live message updates
@@ -1103,8 +1107,6 @@ class Assistant:
             assert self.config.telegram_token is not None
             self.telegram_service = TelegramService(
                 telegram_token=self.config.telegram_token,
-                allowed_user_ids=self.config.allowed_user_ids,
-                developer_chat_id=self.config.developer_chat_id,
                 processing_service=self.default_processing_service,
                 processing_services_registry=self.processing_services_registry,
                 app_config=self.config,

--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -151,6 +151,8 @@ ENV_VAR_MAPPINGS: list[EnvVarMapping] = [
     EnvVarMapping("OTEL_DEBUG_CONSOLE_EXPORTER", "otel.debug_console_exporter", bool),
 ]
 
+USER_IDENTITIES_FILE_ENV_VAR = "USER_IDENTITIES_FILE"
+
 
 def set_nested_value(
     data: dict[str, Any],  # noqa: ANN401
@@ -416,6 +418,88 @@ def apply_env_var_overrides(
             config_data["allowed_user_ids"] = ids
         except ValueError:
             logger.error("Invalid ALLOWED_CHAT_IDS format. Using previous value.")
+
+
+def _coerce_user_identity_list(
+    raw_data: object,
+    source_label: str,
+) -> list[dict[str, Any]]:
+    if raw_data is None:
+        return []
+
+    if isinstance(raw_data, dict):
+        users_data = raw_data.get("users")
+        if users_data is None:
+            msg = f"{source_label} must contain a users list"
+            raise ValueError(msg)
+    else:
+        users_data = raw_data
+
+    if not isinstance(users_data, list):
+        msg = f"{source_label} users must be a list"
+        raise ValueError(msg)
+
+    users: list[dict[str, Any]] = []
+    for index, user_data in enumerate(users_data):
+        if not isinstance(user_data, dict):
+            msg = f"{source_label} users[{index}] must be an object"
+            raise ValueError(msg)
+        user_id = user_data.get("id")
+        if not isinstance(user_id, str) or not user_id.strip():
+            msg = f"{source_label} users[{index}].id must be a non-empty string"
+            raise ValueError(msg)
+        users.append(user_data)
+    return users
+
+
+def _merge_user_identity_lists(
+    base_users: list[dict[str, Any]],
+    overlay_users: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    result = copy.deepcopy(base_users)
+    result_by_id = {user["id"]: user for user in result}
+
+    for overlay_user in overlay_users:
+        user_id = overlay_user["id"]
+        base_user = result_by_id.get(user_id)
+        if base_user is None:
+            new_user = copy.deepcopy(overlay_user)
+            result.append(new_user)
+            result_by_id[user_id] = new_user
+        else:
+            merged_user = deep_merge_dicts(base_user, overlay_user)
+            base_user.clear()
+            base_user.update(merged_user)
+
+    return result
+
+
+def apply_user_identity_file(
+    config_data: dict[str, Any],  # noqa: ANN401 - config_data is parsed YAML/JSON
+) -> None:
+    """Overlay user identities from a YAML file named by the environment."""
+    file_path = os.getenv(USER_IDENTITIES_FILE_ENV_VAR)
+    if file_path is None or not file_path.strip():
+        return
+
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            raw_overlay = yaml.safe_load(f)
+    except FileNotFoundError as exc:
+        msg = f"{USER_IDENTITIES_FILE_ENV_VAR} file not found: {file_path}"
+        raise ValueError(msg) from exc
+    except yaml.YAMLError as exc:
+        msg = f"{USER_IDENTITIES_FILE_ENV_VAR} must point to valid YAML: {file_path}"
+        raise ValueError(msg) from exc
+
+    base_users = _coerce_user_identity_list(
+        config_data.get("users", []), "Config field"
+    )
+    overlay_users = _coerce_user_identity_list(
+        raw_overlay,
+        USER_IDENTITIES_FILE_ENV_VAR,
+    )
+    config_data["users"] = _merge_user_identity_lists(base_users, overlay_users)
 
 
 def apply_calendar_env_vars(
@@ -968,6 +1052,7 @@ def load_config(
         load_dotenv()
 
     apply_env_var_overrides(config_data)
+    apply_user_identity_file(config_data)
     apply_calendar_env_vars(config_data)
     config_data["telegram_enabled"] = bool(config_data.get("telegram_token"))
 

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -559,6 +559,47 @@ class AttachmentConfig(BaseModel):
     )
 
 
+def _normalize_string_set(values: object, label: str) -> set[str]:
+    if values is None:
+        return set()
+    if not isinstance(values, (list, set, tuple)):
+        msg = f"{label} values must be a list or set"
+        raise TypeError(msg)
+
+    normalized_values: set[str] = set()
+    for value in values:
+        if not isinstance(value, str):
+            msg = f"{label} values must be strings"
+            raise TypeError(msg)
+        normalized = value.strip()
+        if not normalized:
+            msg = f"Invalid {label}: {value!r}"
+            raise ValueError(msg)
+        normalized_values.add(normalized)
+    return normalized_values
+
+
+def _normalize_email_address_set(values: object, label: str) -> set[str]:
+    if values is None:
+        return set()
+    if not isinstance(values, (list, set, tuple)):
+        msg = f"{label} values must be a list or set"
+        raise TypeError(msg)
+
+    normalized_addresses: set[str] = set()
+    for value in values:
+        if not isinstance(value, str):
+            msg = f"{label} values must be strings"
+            raise TypeError(msg)
+        _, parsed_address = parseaddr(value)
+        normalized = parsed_address.strip().lower()
+        if not normalized:
+            msg = f"Invalid {label}: {value!r}"
+            raise ValueError(msg)
+        normalized_addresses.add(normalized)
+    return normalized_addresses
+
+
 class EmailIntakeUserMapping(BaseModel):
     """Maps authorized inbound email addresses to an application user."""
 
@@ -594,6 +635,85 @@ class EmailIntakeUserMapping(BaseModel):
     def require_at_least_one_address(self) -> EmailIntakeUserMapping:
         if not self.sender_addresses and not self.recipient_addresses:
             msg = "Email intake user mappings require at least one sender or recipient address"
+            raise ValueError(msg)
+        return self
+
+
+class OIDCUserIdentityConfig(BaseModel):
+    """OIDC identities associated with a canonical application user."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    emails: set[str] = Field(default_factory=set)
+    subjects: set[str] = Field(default_factory=set)
+
+    @field_validator("emails", mode="before")
+    @classmethod
+    def normalize_emails(cls, values: object) -> set[str]:
+        return _normalize_email_address_set(values, "OIDC email")
+
+    @field_validator("subjects", mode="before")
+    @classmethod
+    def normalize_subjects(cls, values: object) -> set[str]:
+        return _normalize_string_set(values, "OIDC subject")
+
+
+class TelegramUserIdentityConfig(BaseModel):
+    """Telegram identities associated with a canonical application user."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_ids: set[int] = Field(default_factory=set)
+    developer: bool = False
+
+
+class EmailIntakeIdentityConfig(BaseModel):
+    """Inbound email identities associated with a canonical application user."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    sender_addresses: set[str] = Field(default_factory=set)
+    recipient_addresses: set[str] = Field(default_factory=set)
+
+    @field_validator("sender_addresses", "recipient_addresses", mode="before")
+    @classmethod
+    def normalize_addresses(cls, values: object) -> set[str]:
+        return _normalize_email_address_set(values, "email intake address")
+
+
+class UserIdentityConfig(BaseModel):
+    """Canonical application user and the external identities that resolve to it."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    oidc: OIDCUserIdentityConfig = Field(default_factory=OIDCUserIdentityConfig)
+    telegram: TelegramUserIdentityConfig = Field(
+        default_factory=TelegramUserIdentityConfig
+    )
+    email_intake: EmailIntakeIdentityConfig = Field(
+        default_factory=EmailIntakeIdentityConfig
+    )
+
+    @field_validator("id")
+    @classmethod
+    def normalize_id(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            msg = "User id must not be empty"
+            raise ValueError(msg)
+        return normalized
+
+    @model_validator(mode="after")
+    def require_identity(self) -> UserIdentityConfig:
+        if (
+            not self.oidc.emails
+            and not self.oidc.subjects
+            and not self.telegram.user_ids
+            and not self.email_intake.sender_addresses
+            and not self.email_intake.recipient_addresses
+        ):
+            msg = f"User {self.id!r} must configure at least one external identity"
             raise ValueError(msg)
         return self
 
@@ -945,6 +1065,7 @@ class AppConfig(BaseSettings):
     openai_api_key: str | None = None
 
     # User access control
+    users: list[UserIdentityConfig] = Field(default_factory=list)
     allowed_user_ids: list[int] = Field(default_factory=list)
     developer_chat_id: int | None = None
 
@@ -1019,6 +1140,53 @@ class AppConfig(BaseSettings):
     # Attachment selection thresholds (global)
     attachment_selection_threshold: int = 3  # Trigger selection when > this many
     max_response_attachments: int = 6  # Max attachments per response
+
+    @model_validator(mode="after")
+    def validate_user_identity_uniqueness(self) -> AppConfig:
+        user_ids: set[str] = set()
+        oidc_emails: dict[str, str] = {}
+        oidc_subjects: dict[str, str] = {}
+        telegram_user_ids: dict[int, str] = {}
+        email_senders: dict[str, str] = {}
+        email_recipients: dict[str, str] = {}
+
+        def add_unique(
+            mapping: dict[Any, str],
+            value: Any,  # noqa: ANN401 - helper validates heterogeneous identity keys
+            user_id: str,
+            label: str,
+        ) -> None:
+            existing_user_id = mapping.get(value)
+            if existing_user_id is not None and existing_user_id != user_id:
+                msg = (
+                    f"{label} {value!r} is configured for both "
+                    f"{existing_user_id!r} and {user_id!r}"
+                )
+                raise ValueError(msg)
+            mapping[value] = user_id
+
+        for user in self.users:
+            if user.id in user_ids:
+                msg = f"Duplicate user id {user.id!r}"
+                raise ValueError(msg)
+            user_ids.add(user.id)
+            for email in user.oidc.emails:
+                add_unique(oidc_emails, email, user.id, "OIDC email")
+            for subject in user.oidc.subjects:
+                add_unique(oidc_subjects, subject, user.id, "OIDC subject")
+            for telegram_user_id in user.telegram.user_ids:
+                add_unique(
+                    telegram_user_ids,
+                    telegram_user_id,
+                    user.id,
+                    "Telegram user id",
+                )
+            for sender in user.email_intake.sender_addresses:
+                add_unique(email_senders, sender, user.id, "Email sender")
+            for recipient in user.email_intake.recipient_addresses:
+                add_unique(email_recipients, recipient, user.id, "Email recipient")
+
+        return self
 
     @field_validator("attachment_storage_path", "document_storage_path")
     @classmethod

--- a/src/family_assistant/services/user_identity.py
+++ b/src/family_assistant/services/user_identity.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from email.utils import parseaddr
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from starlette.datastructures import FormData
+
+    from family_assistant.config_models import AppConfig
+
+
+class UserIdentityResolutionError(ValueError):
+    """Raised when an external identity cannot be mapped to an application user."""
+
+
+@dataclass(frozen=True)
+class ResolvedUserIdentity:
+    """A canonical application user resolved from an interface-specific identity."""
+
+    user_id: str
+    source: str
+    source_identifier: str
+    email: str | None = None
+    subject: str | None = None
+
+
+class UserIdentityResolver:
+    """Resolves interface-specific identities to canonical application user ids."""
+
+    def __init__(self, config: AppConfig) -> None:
+        self._config = config
+        self._users_configured = bool(config.users)
+        self._oidc_email_to_user_id: dict[str, str] = {}
+        self._oidc_subject_to_user_id: dict[str, str] = {}
+        self._telegram_user_id_to_user_id: dict[int, str] = {}
+        self._developer_telegram_user_ids: set[int] = set()
+        self._email_sender_to_user_id: dict[str, str] = {}
+        self._email_recipient_to_user_id: dict[str, str] = {}
+
+        for user in config.users:
+            for email in user.oidc.emails:
+                self._oidc_email_to_user_id[email] = user.id
+            for subject in user.oidc.subjects:
+                self._oidc_subject_to_user_id[subject] = user.id
+            for telegram_user_id in user.telegram.user_ids:
+                self._telegram_user_id_to_user_id[telegram_user_id] = user.id
+                if user.telegram.developer:
+                    self._developer_telegram_user_ids.add(telegram_user_id)
+            for sender in user.email_intake.sender_addresses:
+                self._email_sender_to_user_id[sender] = user.id
+            for recipient in user.email_intake.recipient_addresses:
+                self._email_recipient_to_user_id[recipient] = user.id
+
+    @property
+    def users_configured(self) -> bool:
+        return self._users_configured
+
+    def resolve_oidc_user(self, user_info: dict[str, object]) -> ResolvedUserIdentity:
+        """Resolve an OIDC session or userinfo payload to a canonical user."""
+        email = normalize_email_address(_string_or_none(user_info.get("email")))
+        subject = _string_or_none(user_info.get("sub"))
+
+        if self._users_configured:
+            matched_user_ids: set[str] = set()
+            if email is not None and email in self._oidc_email_to_user_id:
+                matched_user_ids.add(self._oidc_email_to_user_id[email])
+            if subject is not None and subject in self._oidc_subject_to_user_id:
+                matched_user_ids.add(self._oidc_subject_to_user_id[subject])
+            if len(matched_user_ids) > 1:
+                sorted_user_ids = ", ".join(sorted(matched_user_ids))
+                msg = f"OIDC identity maps to multiple users: {sorted_user_ids}"
+                raise UserIdentityResolutionError(msg)
+            if matched_user_ids:
+                return ResolvedUserIdentity(
+                    user_id=next(iter(matched_user_ids)),
+                    source="oidc",
+                    source_identifier=email or subject or "unknown",
+                    email=email,
+                    subject=subject,
+                )
+            msg = (
+                "OIDC identity is not mapped to a configured user "
+                f"(email={email or '<missing>'}, sub={subject or '<missing>'})"
+            )
+            raise UserIdentityResolutionError(msg)
+
+        user_id = subject or email
+        if not user_id:
+            msg = "OIDC identity did not contain a subject or email"
+            raise UserIdentityResolutionError(msg)
+        return ResolvedUserIdentity(
+            user_id=user_id,
+            source="oidc",
+            source_identifier=user_id,
+            email=email,
+            subject=subject,
+        )
+
+    def resolve_api_token_user(self, user_identifier: str) -> ResolvedUserIdentity:
+        """Resolve an already-issued API token owner id."""
+        normalized_user_identifier = user_identifier.strip()
+        if not normalized_user_identifier:
+            msg = "API token user identifier is empty"
+            raise UserIdentityResolutionError(msg)
+        if self._users_configured:
+            email = normalize_email_address(normalized_user_identifier)
+            matched_user_ids: set[str] = set()
+            if email is not None and email in self._oidc_email_to_user_id:
+                matched_user_ids.add(self._oidc_email_to_user_id[email])
+            if normalized_user_identifier in self._oidc_subject_to_user_id:
+                matched_user_ids.add(
+                    self._oidc_subject_to_user_id[normalized_user_identifier]
+                )
+            configured_user_ids = {user.id for user in self._config.users}
+            if normalized_user_identifier in configured_user_ids:
+                matched_user_ids.add(normalized_user_identifier)
+            if len(matched_user_ids) > 1:
+                sorted_user_ids = ", ".join(
+                    repr(user_id) for user_id in sorted(matched_user_ids)
+                )
+                msg = (
+                    "API token owner maps to multiple configured users: "
+                    f"{sorted_user_ids}"
+                )
+                raise UserIdentityResolutionError(msg)
+            if not matched_user_ids:
+                msg = (
+                    "API token owner is not mapped to a configured user: "
+                    f"{normalized_user_identifier}"
+                )
+                raise UserIdentityResolutionError(msg)
+            normalized_user_identifier = next(iter(matched_user_ids))
+        return ResolvedUserIdentity(
+            user_id=normalized_user_identifier,
+            source="api_token",
+            source_identifier=user_identifier,
+        )
+
+    def resolve_telegram_user(self, telegram_user_id: int) -> ResolvedUserIdentity:
+        """Resolve a Telegram user id to a canonical user."""
+        if self._users_configured:
+            user_id = self._telegram_user_id_to_user_id.get(telegram_user_id)
+            if user_id is None:
+                msg = (
+                    "Telegram user id is not mapped to a configured user: "
+                    f"{telegram_user_id}"
+                )
+                raise UserIdentityResolutionError(msg)
+            return ResolvedUserIdentity(
+                user_id=user_id,
+                source="telegram",
+                source_identifier=str(telegram_user_id),
+            )
+
+        if (
+            self._config.allowed_user_ids
+            and telegram_user_id not in self._config.allowed_user_ids
+        ):
+            msg = f"Telegram user id is not authorized: {telegram_user_id}"
+            raise UserIdentityResolutionError(msg)
+        return ResolvedUserIdentity(
+            user_id=str(telegram_user_id),
+            source="telegram",
+            source_identifier=str(telegram_user_id),
+        )
+
+    def is_telegram_user_allowed(self, telegram_user_id: int) -> bool:
+        try:
+            self.resolve_telegram_user(telegram_user_id)
+        except UserIdentityResolutionError:
+            return False
+        return True
+
+    def is_developer_telegram_user(self, telegram_user_id: int) -> bool:
+        if self._users_configured:
+            return telegram_user_id in self._developer_telegram_user_ids
+        return self._config.developer_chat_id == telegram_user_id
+
+    def resolve_email_intake_user(self, form_data: FormData) -> str | None:
+        """Resolve an accepted inbound email to a canonical user id."""
+        sender = normalize_email_address(_string_or_none(form_data.get("sender")))
+        recipient = normalize_email_address(_string_or_none(form_data.get("recipient")))
+
+        if self._users_configured:
+            configured_matched_user_ids: set[str] = set()
+            if sender is not None and sender in self._email_sender_to_user_id:
+                configured_matched_user_ids.add(self._email_sender_to_user_id[sender])
+            if recipient is not None and recipient in self._email_recipient_to_user_id:
+                configured_matched_user_ids.add(
+                    self._email_recipient_to_user_id[recipient]
+                )
+            if len(configured_matched_user_ids) > 1:
+                sorted_user_ids = ", ".join(sorted(configured_matched_user_ids))
+                msg = f"Inbound email maps to multiple users: {sorted_user_ids}"
+                raise UserIdentityResolutionError(msg)
+            if configured_matched_user_ids:
+                return next(iter(configured_matched_user_ids))
+            if self._config.email_intake.require_user_mapping:
+                msg = "Inbound email does not map to a configured user"
+                raise UserIdentityResolutionError(msg)
+            return None
+
+        matched_user_ids: set[str] = set()
+        for mapping in self._config.email_intake.user_mappings:
+            if (sender is not None and sender in mapping.sender_addresses) or (
+                recipient is not None and recipient in mapping.recipient_addresses
+            ):
+                matched_user_ids.add(mapping.user_id)
+
+        if len(matched_user_ids) > 1:
+            sorted_user_ids = ", ".join(sorted(matched_user_ids))
+            msg = f"Inbound email maps to multiple users: {sorted_user_ids}"
+            raise UserIdentityResolutionError(msg)
+
+        if matched_user_ids:
+            return next(iter(matched_user_ids))
+
+        if self._config.email_intake.require_user_mapping:
+            msg = "Inbound email does not map to a configured user"
+            raise UserIdentityResolutionError(msg)
+
+        return None
+
+
+def normalize_email_address(raw_address: str | None) -> str | None:
+    """Extract and normalize an email address from a header or form field."""
+    if not raw_address:
+        return None
+    _, parsed_address = parseaddr(raw_address)
+    normalized = parsed_address.strip().lower()
+    return normalized or None
+
+
+def _string_or_none(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    return None

--- a/src/family_assistant/telegram/handler.py
+++ b/src/family_assistant/telegram/handler.py
@@ -38,6 +38,11 @@ from family_assistant.llm.messages import (
     text_content,
 )
 from family_assistant.processing import ProcessingService
+from family_assistant.services.user_identity import (
+    ResolvedUserIdentity,
+    UserIdentityResolutionError,
+    UserIdentityResolver,
+)
 from family_assistant.storage.message_history import (
     message_history_table,  # For error handling db update
 )
@@ -67,8 +72,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
     def __init__(
         self,
         telegram_service: TelegramService,  # Accept the service instance
-        allowed_user_ids: list[int],
-        developer_chat_id: int | None,
+        user_identity_resolver: UserIdentityResolver,
         processing_service: ProcessingService,  # Use string quote for forward reference
         get_db_context_func: Callable[
             ..., contextlib.AbstractAsyncContextManager[DatabaseContext]
@@ -81,8 +85,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
 
         Args:
             telegram_service: The parent TelegramService instance.
-            allowed_user_ids: List of chat IDs allowed to interact with the bot.
-            developer_chat_id: Chat ID for developer notifications.
+            user_identity_resolver: Resolver for Telegram user authorization.
             processing_service: The processing service for handling interactions.
             get_db_context_func: Function to get database context.
             message_batcher: Message batcher for grouping messages.
@@ -98,8 +101,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
         self.telegram_service = telegram_service  # Store the service instance
 
         # application is accessed via telegram_service.application if needed
-        self.allowed_user_ids = allowed_user_ids
-        self.developer_chat_id = developer_chat_id
+        self.user_identity_resolver = user_identity_resolver
         self.processing_service = processing_service  # Store the service instance
         self.get_db_context = get_db_context_func
         self.message_batcher = message_batcher  # Store the injected batcher
@@ -114,6 +116,15 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
             chunk_overlap=50,  # Small overlap to maintain context across messages
             separators=("\n\n", "\n", ". ", " ", ""),
         )
+
+    def _resolve_telegram_user(
+        self, telegram_user_id: int
+    ) -> ResolvedUserIdentity | None:
+        try:
+            return self.user_identity_resolver.resolve_telegram_user(telegram_user_id)
+        except UserIdentityResolutionError as exc:
+            logger.warning("Unauthorized Telegram user %s: %s", telegram_user_id, exc)
+            return None
 
     def _get_chat_interfaces(self) -> dict[str, ChatInterface] | None:
         """Get chat_interfaces registry from FastAPI app state for cross-interface messaging.
@@ -221,7 +232,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
             logger.warning("Update has no message, cannot reply to /start.")
             return
 
-        if self.allowed_user_ids and user_id not in self.allowed_user_ids:
+        if self._resolve_telegram_user(user_id) is None:
             logger.warning(f"Unauthorized /start command from chat_id {user_id}")
             await update.message.reply_text(
                 f"You're not authorized to use this bot. Give your user ID `{user_id}` to the person who runs this bot."
@@ -265,6 +276,12 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
         last_update, _ = batch[-1]
         user = last_update.effective_user
         user_name = user.first_name if user else "Unknown User"
+        resolved_user = (
+            self._resolve_telegram_user(user.id) if user is not None else None
+        )
+        if resolved_user is None:
+            logger.warning("Ignoring batch from unauthorized Telegram user")
+            return
 
         with tracer.start_as_current_span(
             "telegram.process_batch",
@@ -341,7 +358,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
 
                 # Register user attachments with database record for cross-turn access
                 async with self.get_db_context() as db_context:
-                    user_id_str = str(user.id) if user else "unknown"
+                    user_id_str = resolved_user.user_id
 
                     for attachment in all_attachments:
                         try:
@@ -560,9 +577,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
                                 tool_name=tool_name,
                                 tool_args=tool_args,
                                 timeout=timeout_seconds,
-                                target_user_id=str(last_update.effective_user.id)
-                                if last_update.effective_user
-                                else None,
+                                target_user_id=resolved_user.user_id,
                                 tool_call_id=call_id,
                                 source_message_internal_id=source_message_internal_id,
                             )
@@ -577,6 +592,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
                             trigger_content_parts=trigger_content_parts,
                             trigger_interface_message_id=trigger_interface_message_id,
                             user_name=user_name,
+                            user_id=resolved_user.user_id,
                             replied_to_interface_id=replied_to_interface_id,
                             chat_interface=self.telegram_service.chat_interface,
                             chat_interfaces=chat_interfaces,
@@ -815,7 +831,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
             logger.warning("Unknown command: Update has no message.")
             return
 
-        if self.allowed_user_ids and user_id not in self.allowed_user_ids:
+        if self._resolve_telegram_user(user_id) is None:
             logger.warning(
                 f"Unauthorized unknown command from chat_id {user_id}: {update.message.text}"
             )
@@ -884,7 +900,8 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
             logger.warning("Slash command: Update has no message or message text.")
             return
 
-        if self.allowed_user_ids and user_id not in self.allowed_user_ids:
+        resolved_user = self._resolve_telegram_user(user_id)
+        if resolved_user is None:
             logger.warning(f"Unauthorized slash command from user {user_id}")
             await update.message.reply_text(
                 f"You're not authorized to use this command. User ID: `{user_id}`"
@@ -1023,9 +1040,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
                         tool_name=tool_name,
                         tool_args=tool_args,
                         timeout=timeout_seconds,
-                        target_user_id=str(update.effective_user.id)
-                        if update.effective_user
-                        else None,
+                        target_user_id=resolved_user.user_id,
                         tool_call_id=call_id,
                         source_message_internal_id=source_message_internal_id,
                     )
@@ -1042,6 +1057,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
                         user_name=update.effective_user.full_name
                         if update.effective_user
                         else "Unknown User",
+                        user_id=resolved_user.user_id,
                         replied_to_interface_id=reply_to_interface_id_str,
                         chat_interface=self.telegram_service.chat_interface,
                         chat_interfaces=chat_interfaces,
@@ -1228,7 +1244,7 @@ class TelegramUpdateHandler:  # Renamed from TelegramBotHandler
         attachments: list[AttachmentData] = []
         max_file_size = self.telegram_service.attachment_registry.max_file_size
 
-        if self.allowed_user_ids and user_id not in self.allowed_user_ids:
+        if self._resolve_telegram_user(user_id) is None:
             logger.warning(f"Ignoring message from unauthorized user {user_id}")
             return
 

--- a/src/family_assistant/telegram/service.py
+++ b/src/family_assistant/telegram/service.py
@@ -9,6 +9,7 @@ from telegram.ext import (
     CallbackQueryHandler,
 )
 
+from family_assistant.services.user_identity import UserIdentityResolver
 from family_assistant.telegram.batching import (
     DefaultMessageBatcher,
     NoBatchMessageBatcher,
@@ -45,8 +46,6 @@ class TelegramService:
     def __init__(
         self,
         telegram_token: str,
-        allowed_user_ids: list[int],
-        developer_chat_id: int | None,
         processing_service: ProcessingService,  # Default processing service
         processing_services_registry: dict[
             str, DelegatableService
@@ -65,8 +64,6 @@ class TelegramService:
 
         Args:
             telegram_token: The Telegram Bot API token.
-            allowed_user_ids: List of chat IDs allowed to interact with the bot.
-            developer_chat_id: Optional chat ID for sending error notifications.
             processing_service: The Default ProcessingService instance.
             processing_services_registry: Dictionary of all ProcessingService instances.
             app_config: The main application configuration (typed AppConfig model).
@@ -112,6 +109,7 @@ class TelegramService:
             processing_services_registry  # Store registry
         )
         self.app_config = app_config  # Store app_config
+        self.user_identity_resolver = UserIdentityResolver(app_config)
         self.confirmation_service = confirmation_service
         self.confirmation_result_waiters = confirmation_result_waiters
         self.fastapi_app = (
@@ -150,14 +148,14 @@ class TelegramService:
             application=self.application,
             confirmation_service=confirmation_service,
             confirmation_result_waiters=confirmation_result_waiters,
+            user_identity_resolver=self.user_identity_resolver,
         )
 
         # Instantiate the handler class, passing self (the service instance)
         # The handler will use self.processing_service (the default one) for batched messages.
         self.update_handler = TelegramUpdateHandler(
             telegram_service=self,
-            allowed_user_ids=allowed_user_ids,
-            developer_chat_id=developer_chat_id,
+            user_identity_resolver=self.user_identity_resolver,
             processing_service=processing_service,  # Pass default service to handler
             get_db_context_func=get_db_context_func,
             message_batcher=None,

--- a/src/family_assistant/telegram/ui.py
+++ b/src/family_assistant/telegram/ui.py
@@ -20,6 +20,10 @@ from family_assistant.services.confirmation_service import (
     ConfirmationExpiredError,
     ConfirmationNotFoundError,
 )
+from family_assistant.services.user_identity import (
+    UserIdentityResolutionError,
+    UserIdentityResolver,
+)
 from family_assistant.telegram.markdown_utils import convert_to_telegram_markdown
 from family_assistant.telegram.protocols import ConfirmationUIManager
 from family_assistant.tools.types import ConfirmationOutcome
@@ -58,11 +62,13 @@ class TelegramConfirmationUIManager(ConfirmationUIManager):
         confirmation_timeout: float = 3600.0,
         confirmation_service: ConfirmationService | None = None,
         confirmation_result_waiters: ConfirmationResultWaiterRegistry | None = None,
+        user_identity_resolver: UserIdentityResolver | None = None,
     ) -> None:
         self.application = application
         self.confirmation_timeout = confirmation_timeout
         self.confirmation_service = confirmation_service
         self.confirmation_result_waiters = confirmation_result_waiters
+        self.user_identity_resolver = user_identity_resolver
         self.pending_confirmations: dict[str, PendingTelegramConfirmation] = {}
 
     def _unregister_execution_future(
@@ -75,6 +81,18 @@ class TelegramConfirmationUIManager(ConfirmationUIManager):
             and execution_future is not None
         ):
             self.confirmation_result_waiters.unregister(request_id, execution_future)
+
+    def _resolve_callback_user_id(self, telegram_user_id: int | None) -> str:
+        if telegram_user_id is None:
+            raise ConfirmationAuthorizationError("Telegram callback has no user")
+        if self.user_identity_resolver is None:
+            return str(telegram_user_id)
+        try:
+            return self.user_identity_resolver.resolve_telegram_user(
+                telegram_user_id
+            ).user_id
+        except UserIdentityResolutionError as exc:
+            raise ConfirmationAuthorizationError(str(exc)) from exc
 
     async def request_confirmation(
         self,
@@ -529,13 +547,9 @@ class TelegramConfirmationUIManager(ConfirmationUIManager):
             if decision_future and not decision_future.done():
                 decision_future.set_result(ConfirmationOutcome(kind="approved"))
             return
-        if telegram_user_id is None:
-            raise ConfirmationAuthorizationError(
-                f"Telegram confirmation {request_id} has no approving user"
-            )
         await self.confirmation_service.approve_and_enqueue_execution(
             request_id=request_id,
-            approving_user_id=str(telegram_user_id),
+            approving_user_id=self._resolve_callback_user_id(telegram_user_id),
             approving_interface="telegram",
         )
         if decision_future and not decision_future.done():
@@ -554,13 +568,9 @@ class TelegramConfirmationUIManager(ConfirmationUIManager):
             if decision_future and not decision_future.done():
                 decision_future.set_result(ConfirmationOutcome(kind="rejected"))
             return
-        if telegram_user_id is None:
-            raise ConfirmationAuthorizationError(
-                f"Telegram confirmation {request_id} has no rejecting user"
-            )
         await self.confirmation_service.reject(
             request_id=request_id,
-            rejecting_user_id=str(telegram_user_id),
+            rejecting_user_id=self._resolve_callback_user_id(telegram_user_id),
             rejecting_interface="telegram",
         )
         if decision_future and not decision_future.done():

--- a/src/family_assistant/web/auth.py
+++ b/src/family_assistant/web/auth.py
@@ -14,6 +14,10 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from starlette.config import Config
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from family_assistant.services.user_identity import (
+    UserIdentityResolutionError,
+    UserIdentityResolver,
+)
 from family_assistant.storage.base import api_tokens_table
 from family_assistant.storage.context import get_db_context
 
@@ -257,6 +261,23 @@ class AuthService:
                             status_code=status.HTTP_403_FORBIDDEN,
                             detail=f"Access denied: Email '{email}' is not in the allowlist.",
                         )
+
+                config_from_state = getattr(request.app.state, "config", None)
+                if config_from_state is not None:
+                    resolver = getattr(
+                        request.app.state, "user_identity_resolver", None
+                    )
+                    if resolver is None:
+                        resolver = UserIdentityResolver(config_from_state)
+                        request.app.state.user_identity_resolver = resolver
+                    try:
+                        resolver.resolve_oidc_user(dict(user_info))
+                    except UserIdentityResolutionError as exc:
+                        logger.warning("Unmapped OIDC login rejected: %s", exc)
+                        raise HTTPException(
+                            status_code=status.HTTP_403_FORBIDDEN,
+                            detail=str(exc),
+                        ) from exc
 
                 request.session["user"] = dict(user_info)
                 logger.info(

--- a/src/family_assistant/web/dependencies.py
+++ b/src/family_assistant/web/dependencies.py
@@ -7,6 +7,10 @@ from fastapi import HTTPException, Request, WebSocket, status
 
 from family_assistant.embeddings import EmbeddingGenerator
 from family_assistant.services.attachment_registry import AttachmentRegistry
+from family_assistant.services.user_identity import (
+    UserIdentityResolutionError,
+    UserIdentityResolver,
+)
 from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.tools import ToolsProvider
 from family_assistant.web.models import GeminiLiveConfig
@@ -17,6 +21,63 @@ if TYPE_CHECKING:
     from family_assistant.web.web_chat_interface import WebChatInterface
 
 logger = logging.getLogger(__name__)
+
+
+def get_user_identity_resolver(request: Request) -> UserIdentityResolver | None:
+    """Return the configured user identity resolver, if application config is available."""
+    resolver = getattr(request.app.state, "user_identity_resolver", None)
+    if resolver is not None:
+        if not isinstance(resolver, UserIdentityResolver):
+            logger.error(
+                "Invalid user_identity_resolver in app.state: %s",
+                type(resolver),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Invalid user identity resolver configuration.",
+            )
+        return resolver
+
+    config = getattr(request.app.state, "config", None)
+    if config is None:
+        return None
+    resolver = UserIdentityResolver(config)
+    request.app.state.user_identity_resolver = resolver
+    return resolver
+
+
+def resolve_current_user_payload(request: Request, user: dict) -> dict:
+    """Add canonical user identity fields to a session or API-token user payload."""
+    resolver = get_user_identity_resolver(request)
+    if resolver is None:
+        return {
+            "user_identifier": user.get("sub", user.get("email", "session_user")),
+            **user,
+        }
+
+    try:
+        if user.get("source") in {"api_token", "app_token_session"}:
+            resolved = resolver.resolve_api_token_user(
+                str(user.get("sub", user.get("user_identifier", "")))
+            )
+        else:
+            resolved = resolver.resolve_oidc_user(user)
+    except UserIdentityResolutionError as exc:
+        logger.warning("User identity resolution failed: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+
+    raw_user_identifier = user.get("sub", user.get("email", resolved.user_id))
+    return {
+        **user,
+        "raw_user_identifier": raw_user_identifier,
+        "user_identifier": resolved.user_id,
+        "sub": resolved.user_id,
+        "identity_source": resolved.source,
+        "identity_source_identifier": resolved.source_identifier,
+    }
 
 
 async def get_embedding_generator_dependency(request: Request) -> EmbeddingGenerator:
@@ -106,12 +167,7 @@ async def get_current_user(request: Request) -> dict:
         session_user = request.session.get("user")
         if session_user:
             logger.debug("User authenticated via session.")
-            return {
-                "user_identifier": session_user.get(
-                    "sub", session_user.get("email", "session_user")
-                ),
-                **session_user,
-            }
+            return resolve_current_user_payload(request, session_user)
     except AssertionError:
         # Session middleware not available
         pass
@@ -156,10 +212,7 @@ async def get_current_user(request: Request) -> dict:
         )
 
     logger.info(f"API user authenticated: {api_user.get('sub')}")
-    return {
-        "user_identifier": api_user.get("sub", "api_user"),
-        **api_user,
-    }
+    return resolve_current_user_payload(request, api_user)
 
 
 async def get_current_api_user(request: Request) -> dict:
@@ -230,8 +283,9 @@ async def get_current_active_user(request: Request) -> dict:
         )
 
     # User is authenticated via OIDC (or another primary method)
-    logger.debug("Current active user (OIDC): %s", user.get("sub"))
-    return user
+    resolved_user = resolve_current_user_payload(request, user)
+    logger.debug("Current active user (OIDC): %s", resolved_user.get("sub"))
+    return resolved_user
 
 
 async def get_attachment_registry(request: Request) -> AttachmentRegistry:

--- a/src/family_assistant/web/routers/api.py
+++ b/src/family_assistant/web/routers/api.py
@@ -13,6 +13,7 @@ from .diagnostics_api import diagnostics_api_router
 from .documents_api import documents_api_router
 from .errors_api import errors_api_router
 from .events_api import events_api_router
+from .me_api import me_router
 from .notes_api import notes_api_router
 from .tasks_api import tasks_api_router
 from .tools_api import tools_api_router
@@ -49,5 +50,6 @@ api_router.include_router(
     diagnostics_api_router, prefix="/diagnostics", tags=["Diagnostics"]
 )
 api_router.include_router(version_router, tags=["Version"])
+api_router.include_router(me_router, tags=["Identity"])
 api_router.include_router(a2a_router, prefix="/a2a", tags=["A2A Protocol"])
 api_router.include_router(api_auth_router, tags=["App Auth API"])

--- a/src/family_assistant/web/routers/app_auth.py
+++ b/src/family_assistant/web/routers/app_auth.py
@@ -25,10 +25,15 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from sqlalchemy import update as sa_update
 
+from family_assistant.services.user_identity import UserIdentityResolutionError
 from family_assistant.storage import api_tokens as api_tokens_storage
 from family_assistant.storage.base import api_tokens_table
 from family_assistant.storage.context import DatabaseContext
-from family_assistant.web.dependencies import get_current_user, get_db
+from family_assistant.web.dependencies import (
+    get_current_user,
+    get_db,
+    get_user_identity_resolver,
+)
 from family_assistant.web.models import (
     CodeExchangeRequest,
     CodeExchangeResponse,
@@ -239,6 +244,7 @@ async def app_auth_oidc_callback(request: Request) -> HTMLResponse:
 
 @api_auth_router.post("/exchange")
 async def exchange_code(
+    request: Request,
     payload: CodeExchangeRequest,
     db_context: Annotated[DatabaseContext, Depends(get_db)],
 ) -> CodeExchangeResponse:
@@ -271,7 +277,19 @@ async def exchange_code(
         )
 
     user_info = code_data["user_info"]
-    user_identifier = user_info.get("sub", user_info.get("email", "unknown"))
+    resolver = get_user_identity_resolver(request)
+    try:
+        user_identifier = (
+            resolver.resolve_oidc_user(user_info).user_id
+            if resolver is not None
+            else user_info.get("sub", user_info.get("email", "unknown"))
+        )
+    except UserIdentityResolutionError as exc:
+        logger.warning("App auth exchange rejected unmapped OIDC user: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
 
     # Create API token (30-day expiry)
     api_token_expires = datetime.now(UTC) + timedelta(days=API_TOKEN_EXPIRY_DAYS)
@@ -389,6 +407,22 @@ async def token_session(
     )
 
     return TokenSessionResponse(ok=True)
+
+
+@api_auth_router.get("/me")
+async def auth_me(
+    current_user: Annotated[dict[str, object], Depends(get_current_user)],
+) -> dict[str, object | None]:
+    """Return the authenticated application user for auth-oriented clients."""
+    return {
+        "user_identifier": current_user.get("user_identifier"),
+        "raw_user_identifier": current_user.get("raw_user_identifier"),
+        "identity_source": current_user.get("identity_source"),
+        "identity_source_identifier": current_user.get("identity_source_identifier"),
+        "email": current_user.get("email"),
+        "sub": current_user.get("sub"),
+        "source": current_user.get("source"),
+    }
 
 
 # --- Well-known endpoint ---

--- a/src/family_assistant/web/routers/me_api.py
+++ b/src/family_assistant/web/routers/me_api.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from family_assistant.web.dependencies import get_current_user
+
+me_router = APIRouter()
+
+
+@me_router.get("/me", summary="Return the authenticated application user")
+async def get_me(
+    current_user: Annotated[dict[str, object], Depends(get_current_user)],
+) -> dict[str, object | None]:
+    """Return non-sensitive identity diagnostics for the current authenticated user."""
+    return {
+        "user_identifier": current_user.get("user_identifier"),
+        "raw_user_identifier": current_user.get("raw_user_identifier"),
+        "identity_source": current_user.get("identity_source"),
+        "identity_source_identifier": current_user.get("identity_source_identifier"),
+        "email": current_user.get("email"),
+        "sub": current_user.get("sub"),
+        "source": current_user.get("source"),
+    }

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -21,9 +21,12 @@ from family_assistant.email_intake.security import (
     enforce_raw_request_size,
     extract_raw_mime,
     get_security_fields,
-    resolve_target_user_id,
     verify_mailgun_signature,
     verify_sender_authorization,
+)
+from family_assistant.services.user_identity import (
+    UserIdentityResolutionError,
+    UserIdentityResolver,
 )
 from family_assistant.storage.context import DatabaseContext
 from family_assistant.storage.email import AttachmentData, ParsedEmailData
@@ -169,7 +172,16 @@ async def handle_mail_webhook(
                 authentication.from_domain,
                 authentication.dkim_domain,
             )
-        target_user_id = resolve_target_user_id(form_data, email_intake_config)
+        user_identity_resolver = getattr(
+            request.app.state, "user_identity_resolver", None
+        )
+        if user_identity_resolver is None:
+            user_identity_resolver = UserIdentityResolver(config)
+            request.app.state.user_identity_resolver = user_identity_resolver
+        try:
+            target_user_id = user_identity_resolver.resolve_email_intake_user(form_data)
+        except UserIdentityResolutionError as exc:
+            raise EmailIntakeSecurityError(str(exc)) from exc
         if mailbox_raw_dir_to_use is not None:
             await _save_raw_mail_webhook(
                 raw_body_content=raw_body_content,

--- a/tests/functional/telegram/test_telegram_confirmation.py
+++ b/tests/functional/telegram/test_telegram_confirmation.py
@@ -13,6 +13,7 @@ from assertpy import assert_that, soft_assertions
 from telegram import Update
 
 # Import mock LLM helpers
+from family_assistant.config_models import AppConfig
 from family_assistant.llm import ToolCallFunction, ToolCallItem
 from family_assistant.services.confirmation_service import (
     CONFIRMATION_TOOL_EXECUTION_TASK_TYPE,
@@ -20,6 +21,7 @@ from family_assistant.services.confirmation_service import (
 from family_assistant.services.confirmation_waiters import (
     ConfirmationResultWaiterRegistry,
 )
+from family_assistant.services.user_identity import UserIdentityResolver
 from family_assistant.task_worker import TaskWorker, handle_confirmation_tool_execution
 from family_assistant.telegram.ui import (
     PendingTelegramConfirmation,
@@ -284,6 +286,41 @@ async def test_durable_telegram_confirmation_timeout_stops_after_approval() -> N
     assert isinstance(outcome, ConfirmationOutcome)
     assert outcome.kind == "completed"
     assert outcome.result == "executed:test"
+
+
+@pytest.mark.asyncio
+async def test_durable_telegram_confirmation_approval_uses_canonical_user_id() -> None:
+    """Telegram callback authorization should use the same canonical id as storage."""
+    canonical_user_id = "andrew@example.com"
+    confirmation_service = RecordingConfirmationService()
+    manager = TelegramConfirmationUIManager(
+        application=cast("Any", SimpleNamespace(bot=RecordingTelegramBot())),
+        confirmation_service=cast("Any", confirmation_service),
+        user_identity_resolver=UserIdentityResolver(
+            AppConfig.model_validate({
+                "users": [
+                    {
+                        "id": canonical_user_id,
+                        "oidc": {"emails": [canonical_user_id]},
+                        "telegram": {"user_ids": [USER_ID]},
+                    }
+                ]
+            })
+        ),
+    )
+
+    await manager._approve_confirmation(
+        "confirm_test",
+        USER_ID,
+        PendingTelegramConfirmation(
+            decision_future=asyncio.get_running_loop().create_future(),
+            execution_future=None,
+        ),
+    )
+
+    assert confirmation_service.approve_calls == [
+        ("confirm_test", canonical_user_id, "telegram")
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/functional/web/api/test_chat_confirmations.py
+++ b/tests/functional/web/api/test_chat_confirmations.py
@@ -6,13 +6,15 @@ from typing import TYPE_CHECKING
 import pytest
 from sqlalchemy import select
 
+from family_assistant.config_models import AppConfig
 from family_assistant.services.confirmation_service import ConfirmationService
+from family_assistant.services.user_identity import UserIdentityResolver
 from family_assistant.storage.context import get_db_context
 from family_assistant.storage.tasks import tasks_table
 from family_assistant.web.dependencies import get_current_user
 
 if TYPE_CHECKING:
-    from fastapi import FastAPI
+    from fastapi import FastAPI, Request
     from httpx import AsyncClient
     from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -44,6 +46,24 @@ async def _task_exists(db_engine: AsyncEngine, task_id: str) -> bool:
             select(tasks_table.c.id).where(tasks_table.c.original_task_id == task_id)
         )
     return row is not None
+
+
+class _TokenAuthService:
+    auth_enabled = True
+
+    async def get_user_from_api_token(
+        self,
+        auth_header: str,
+        request: Request,
+    ) -> dict[str, object] | None:
+        if auth_header == "Bearer test-token":
+            return {
+                "sub": "keycloak-subject",
+                "email": "andrew@example.com",
+                "source": "api_token",
+                "token_id": 1,
+            }
+        return None
 
 
 @pytest.mark.asyncio
@@ -141,6 +161,64 @@ async def test_other_web_user_cannot_list_or_resolve_confirmation(
     assert confirm_response.status_code == 200
     assert confirm_response.json()["success"] is False
     assert not await _task_exists(
+        db_engine,
+        f"confirmation_tool_execution:{request_id}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_web_can_approve_confirmation_created_for_matching_telegram_user(
+    app_fixture: FastAPI,
+    api_test_client: AsyncClient,
+    db_engine: AsyncEngine,
+) -> None:
+    canonical_user_id = "andrew@example.com"
+    app_fixture.state.config = AppConfig.model_validate({
+        "users": [
+            {
+                "id": canonical_user_id,
+                "oidc": {
+                    "emails": ["andrew@example.com"],
+                    "subjects": ["keycloak-subject"],
+                },
+                "telegram": {"user_ids": [123456789]},
+            }
+        ]
+    })
+    app_fixture.state.user_identity_resolver = UserIdentityResolver(
+        app_fixture.state.config
+    )
+    app_fixture.state.auth_service = _TokenAuthService()
+
+    request_id = await _create_confirmation(
+        db_engine,
+        request_user_id=canonical_user_id,
+    )
+
+    headers = {"Authorization": "Bearer test-token"}
+    pending_response = await api_test_client.get(
+        "/api/v1/chat/confirmations/pending",
+        headers=headers,
+    )
+    me_response = await api_test_client.get("/api/me", headers=headers)
+    auth_me_response = await api_test_client.get("/api/auth/me", headers=headers)
+    approve_response = await api_test_client.post(
+        "/api/v1/chat/confirm_tool",
+        json={"request_id": request_id, "approved": True},
+        headers=headers,
+    )
+
+    assert pending_response.status_code == 200
+    assert [
+        item["request_id"] for item in pending_response.json()["confirmations"]
+    ] == [request_id]
+    assert me_response.status_code == 200
+    assert me_response.json()["user_identifier"] == canonical_user_id
+    assert auth_me_response.status_code == 200
+    assert auth_me_response.json()["user_identifier"] == canonical_user_id
+    assert approve_response.status_code == 200
+    assert approve_response.json()["success"] is True
+    assert await _task_exists(
         db_engine,
         f"confirmation_tool_execution:{request_id}",
     )

--- a/tests/functional/web/api/test_mail_webhook_security.py
+++ b/tests/functional/web/api/test_mail_webhook_security.py
@@ -22,6 +22,7 @@ from family_assistant.config_models import (
     EmailIntakeConfig,
     EmailIntakeUserMapping,
 )
+from family_assistant.services.user_identity import UserIdentityResolver
 from family_assistant.storage.context import DatabaseContext
 from family_assistant.storage.email import received_emails_table
 from family_assistant.web.app_creator import app as fastapi_app
@@ -112,14 +113,21 @@ def _configure_email_intake(
     *,
     dns_resolver: FakeDnsResolver | None = None,
 ) -> None:
+    config = AppConfig(
+        attachment_storage_path=str(tmp_path / "attachments"),
+        mailbox_raw_dir=str(tmp_path / "raw"),
+        email_intake=email_intake,
+    )
     monkeypatch.setattr(
         fastapi_app.state,
         "config",
-        AppConfig(
-            attachment_storage_path=str(tmp_path / "attachments"),
-            mailbox_raw_dir=str(tmp_path / "raw"),
-            email_intake=email_intake,
-        ),
+        config,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        fastapi_app.state,
+        "user_identity_resolver",
+        UserIdentityResolver(config),
         raising=False,
     )
     monkeypatch.setattr(
@@ -203,6 +211,59 @@ async def test_mail_webhook_accepts_signed_authorized_authenticated_sender(
     assert await _email_target_user_id(db_engine, form["Message-Id"]) == "alice"
     assert await _email_dmarc_result(db_engine, form["Message-Id"]) == "pass"
     assert _raw_mail_files(tmp_path)
+
+
+@pytest.mark.asyncio
+@pytest.mark.postgres
+async def test_mail_webhook_maps_target_user_from_unified_users_config(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    email_intake = EmailIntakeConfig(
+        mailgun_webhook_signing_key=SIGNING_KEY,
+        allowed_sender_addresses=[SENDER],
+        allowed_recipient_addresses=[RECIPIENT],
+        require_authenticated_sender=True,
+        require_user_mapping=True,
+    )
+    config = AppConfig.model_validate({
+        "attachment_storage_path": str(tmp_path / "attachments"),
+        "mailbox_raw_dir": str(tmp_path / "raw"),
+        "email_intake": email_intake.model_dump(),
+        "users": [
+            {
+                "id": "andrew@example.com",
+                "oidc": {"emails": ["andrew@example.com"]},
+                "email_intake": {
+                    "sender_addresses": [SENDER],
+                    "recipient_addresses": [RECIPIENT],
+                },
+            }
+        ],
+    })
+    monkeypatch.setattr(fastapi_app.state, "config", config, raising=False)
+    monkeypatch.setattr(
+        fastapi_app.state,
+        "user_identity_resolver",
+        UserIdentityResolver(config),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        fastapi_app.state,
+        "email_intake_dns_resolver",
+        build_dns_for(domain=SENDER_DOMAIN),
+        raising=False,
+    )
+    form = _mailgun_form()
+
+    response = await api_client.post("/webhook/mail", data=form)
+
+    assert response.status_code == 200, response.text
+    assert await _email_target_user_id(db_engine, form["Message-Id"]) == (
+        "andrew@example.com"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_user_identity.py
+++ b/tests/unit/services/test_user_identity.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pydantic import ValidationError
+from starlette.datastructures import FormData
+
+from family_assistant.config_models import AppConfig
+from family_assistant.services.user_identity import (
+    UserIdentityResolutionError,
+    UserIdentityResolver,
+)
+
+
+def _config_with_user() -> AppConfig:
+    return AppConfig.model_validate({
+        "users": [
+            {
+                "id": "andrew@example.com",
+                "oidc": {
+                    "emails": ["Andrew <Andrew@Example.com>"],
+                    "subjects": ["keycloak-subject"],
+                },
+                "telegram": {"user_ids": [123456789], "developer": True},
+                "email_intake": {
+                    "sender_addresses": ["orders@gmail.com"],
+                    "recipient_addresses": ["assistant+andrew@example.net"],
+                },
+            }
+        ],
+        "email_intake": {"require_user_mapping": True},
+    })
+
+
+def test_resolves_oidc_telegram_and_email_to_same_canonical_user() -> None:
+    resolver = UserIdentityResolver(_config_with_user())
+
+    assert (
+        resolver.resolve_oidc_user({
+            "email": "andrew@example.com",
+            "sub": "keycloak-subject",
+        }).user_id
+        == "andrew@example.com"
+    )
+    assert resolver.resolve_telegram_user(123456789).user_id == "andrew@example.com"
+    assert resolver.is_developer_telegram_user(123456789) is True
+    assert (
+        resolver.resolve_email_intake_user(
+            FormData({"sender": "orders@gmail.com", "recipient": "unused@example.net"})
+        )
+        == "andrew@example.com"
+    )
+
+
+def test_rejects_unknown_telegram_user_when_users_configured() -> None:
+    resolver = UserIdentityResolver(_config_with_user())
+
+    try:
+        resolver.resolve_telegram_user(999)
+    except UserIdentityResolutionError as exc:
+        assert "not mapped" in str(exc)
+    else:
+        raise AssertionError("unknown Telegram user should be rejected")
+
+
+def test_rejects_duplicate_external_identities() -> None:
+    try:
+        AppConfig.model_validate({
+            "users": [
+                {
+                    "id": "one@example.com",
+                    "oidc": {"emails": ["same@example.com"]},
+                },
+                {
+                    "id": "two@example.com",
+                    "oidc": {"emails": ["same@example.com"]},
+                },
+            ]
+        })
+    except ValidationError as exc:
+        assert "same@example.com" in str(exc)
+    else:
+        raise AssertionError("duplicate external identities should be rejected")
+
+
+def test_legacy_telegram_identity_is_used_when_users_are_not_configured() -> None:
+    config = AppConfig.model_validate({"allowed_user_ids": [123]})
+    resolver = UserIdentityResolver(config)
+
+    assert resolver.resolve_telegram_user(123).user_id == "123"
+
+
+def test_api_token_resolution_rejects_conflicting_legacy_identifier() -> None:
+    config = AppConfig.model_validate({
+        "users": [
+            {
+                "id": "alice@example.com",
+                "oidc": {"emails": ["alice@example.com"]},
+            },
+            {
+                "id": "bob@example.com",
+                "oidc": {"subjects": ["alice@example.com"]},
+            },
+        ]
+    })
+    resolver = UserIdentityResolver(config)
+
+    try:
+        resolver.resolve_api_token_user("alice@example.com")
+    except UserIdentityResolutionError as exc:
+        assert "multiple configured users" in str(exc)
+    else:
+        raise AssertionError("conflicting API token owner should be rejected")

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -22,8 +22,10 @@ from pydantic import ValidationError
 
 from family_assistant.config_loader import (
     ENV_VAR_MAPPINGS,
+    USER_IDENTITIES_FILE_ENV_VAR,
     apply_calendar_env_vars,
     apply_env_var_overrides,
+    apply_user_identity_file,
     get_nested_value,
     load_config,
     parse_env_value,
@@ -551,6 +553,148 @@ class TestApplyEnvVarOverrides:
         )
 
 
+class TestApplyUserIdentityFile:
+    """Tests for user identity file overlays."""
+
+    def test_overlays_identity_file_on_configured_users(self, tmp_path: Path) -> None:
+        config: dict[str, Any] = {
+            "users": [
+                {
+                    "id": "alice@example.com",
+                    "oidc": {"emails": ["alice@example.com"]},
+                },
+                {
+                    "id": "bob@example.com",
+                    "email_intake": {"sender_addresses": ["bob@gmail.com"]},
+                },
+            ]
+        }
+        identities_file = tmp_path / "users.yaml"
+        identities_file.write_text(
+            yaml.dump({
+                "users": [
+                    {
+                        "id": "alice@example.com",
+                        "telegram": {"user_ids": [123], "developer": True},
+                    },
+                    {
+                        "id": "bob@example.com",
+                        "telegram": {"user_ids": [456]},
+                    },
+                ]
+            })
+        )
+
+        with mock.patch.dict(
+            os.environ,
+            {USER_IDENTITIES_FILE_ENV_VAR: str(identities_file)},
+            clear=False,
+        ):
+            apply_user_identity_file(config)
+
+        assert config["users"][0]["oidc"] == {"emails": ["alice@example.com"]}
+        assert config["users"][0]["telegram"] == {
+            "user_ids": [123],
+            "developer": True,
+        }
+        assert config["users"][1]["email_intake"] == {
+            "sender_addresses": ["bob@gmail.com"]
+        }
+        assert config["users"][1]["telegram"] == {"user_ids": [456]}
+
+    def test_deep_merges_with_existing_user(self, tmp_path: Path) -> None:
+        config: dict[str, Any] = {
+            "users": [
+                {
+                    "id": "alice@example.com",
+                    "telegram": {"user_ids": [123], "developer": False},
+                    "email_intake": {"sender_addresses": ["alice@example.com"]},
+                }
+            ]
+        }
+        identities_file = tmp_path / "users.yaml"
+        identities_file.write_text(
+            yaml.dump([
+                {
+                    "id": "alice@example.com",
+                    "telegram": {"developer": True},
+                }
+            ])
+        )
+
+        with mock.patch.dict(
+            os.environ,
+            {USER_IDENTITIES_FILE_ENV_VAR: str(identities_file)},
+            clear=False,
+        ):
+            apply_user_identity_file(config)
+
+        assert config["users"][0]["telegram"] == {
+            "user_ids": [123],
+            "developer": True,
+        }
+        assert config["users"][0]["email_intake"] == {
+            "sender_addresses": ["alice@example.com"]
+        }
+
+    def test_can_create_user_from_bare_list_file(self, tmp_path: Path) -> None:
+        config: dict[str, Any] = {"users": []}
+        identities_file = tmp_path / "users.yaml"
+        identities_file.write_text(
+            yaml.dump([{"id": "alice@example.com", "telegram": {"user_ids": [123]}}])
+        )
+
+        with mock.patch.dict(
+            os.environ,
+            {USER_IDENTITIES_FILE_ENV_VAR: str(identities_file)},
+            clear=False,
+        ):
+            apply_user_identity_file(config)
+
+        assert config["users"] == [
+            {"id": "alice@example.com", "telegram": {"user_ids": [123]}}
+        ]
+
+    def test_empty_env_var_is_ignored(self) -> None:
+        config: dict[str, Any] = {"users": []}
+
+        with mock.patch.dict(
+            os.environ, {USER_IDENTITIES_FILE_ENV_VAR: "   "}, clear=False
+        ):
+            apply_user_identity_file(config)
+
+        assert config == {"users": []}
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        config: dict[str, Any] = {"users": []}
+        identities_file = tmp_path / "missing.yaml"
+
+        with (
+            mock.patch.dict(
+                os.environ,
+                {USER_IDENTITIES_FILE_ENV_VAR: str(identities_file)},
+                clear=False,
+            ),
+            pytest.raises(ValueError, match="file not found"),
+        ):
+            apply_user_identity_file(config)
+
+    def test_invalid_users_shape_raises(self, tmp_path: Path) -> None:
+        config: dict[str, Any] = {"users": []}
+        identities_file = tmp_path / "users.yaml"
+        identities_file.write_text(yaml.dump({"users": {"alice": {}}}))
+
+        with (
+            mock.patch.dict(
+                os.environ,
+                {USER_IDENTITIES_FILE_ENV_VAR: str(identities_file)},
+                clear=False,
+            ),
+            pytest.raises(ValueError, match="users must be a list"),
+        ):
+            apply_user_identity_file(config)
+
+
 class TestApplyCalendarEnvVars:
     """Tests for apply_calendar_env_vars function."""
 
@@ -1039,6 +1183,60 @@ class TestLoadConfig:
 
         assert config.model == "defaults-model"
         assert config.server_url == "http://defaults.example.com"
+
+    def test_load_config_applies_user_identities_file(self, tmp_path: Path) -> None:
+        """Test loading user identity overlays from a configured file."""
+        defaults_file = tmp_path / "defaults.yaml"
+        defaults_file.write_text(yaml.dump({}))
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump({
+                "users": [
+                    {
+                        "id": "alice@example.com",
+                        "oidc": {"emails": ["alice@example.com"]},
+                    }
+                ]
+            })
+        )
+        prompts_file = tmp_path / "prompts.yaml"
+        prompts_file.write_text(yaml.dump({}))
+        identities_file = tmp_path / "users.yaml"
+        identities_file.write_text(
+            yaml.dump({
+                "users": [
+                    {
+                        "id": "alice@example.com",
+                        "telegram": {"user_ids": [123], "developer": True},
+                    }
+                ]
+            })
+        )
+
+        env_to_clear = [m.env_var for m in ENV_VAR_MAPPINGS]
+        env_to_clear.extend([
+            "CALDAV_USERNAME",
+            "CALDAV_PASSWORD",
+            "CALDAV_CALENDAR_URLS",
+            "ICAL_URLS",
+            "MCP_CONFIG_PATH",
+            "INDEXING_PIPELINE_CONFIG_JSON",
+            USER_IDENTITIES_FILE_ENV_VAR,
+        ])
+        clean_env = {k: v for k, v in os.environ.items() if k not in env_to_clear}
+        clean_env[USER_IDENTITIES_FILE_ENV_VAR] = str(identities_file)
+
+        with mock.patch.dict(os.environ, clean_env, clear=True):
+            config = load_config(
+                defaults_file_path=str(defaults_file),
+                config_file_path=str(config_file),
+                prompts_file_path=str(prompts_file),
+                load_dotenv_file=False,
+            )
+
+        assert len(config.users) == 1
+        assert config.users[0].telegram.user_ids == {123}
+        assert config.users[0].telegram.developer is True
 
     def test_config_yaml_overrides_defaults_yaml(self, tmp_path: Path) -> None:
         """Test that config.yaml (operator) overrides defaults.yaml (shipped)."""


### PR DESCRIPTION
## Summary

Adds a canonical `users` configuration block and resolver so OIDC/web, Telegram, and email intake can map the same human to the same application user id.

This fixes the durable-confirmation mismatch where Telegram-created confirmations were stored for the numeric Telegram user id, while the web UI listed confirmations for the OIDC/API-token user id.

## What Changed

- Added typed config for `users[].oidc`, `users[].telegram`, and `users[].email_intake`, with uniqueness validation across external identities.
- Added `UserIdentityResolver` for canonical identity resolution with legacy fallback when `users` is empty.
- Wired canonical identities through:
  - web session/API-token auth and new `/api/me` plus `/api/auth/me` diagnostics endpoints
  - iOS app auth token exchange
  - Telegram authorization, message ownership, durable confirmation creation, and Telegram callback approval/rejection
  - Mailgun email intake target-user resolution
- Updated operator/user/API docs and added a design note.
- Added tests for resolver behavior, cross-interface Telegram-to-web confirmation approval, Telegram callback canonicalization, and unified email intake mapping.

## Validation

- `scripts/format-and-lint.sh ...` on touched implementation/test files passed.
- Targeted identity tests passed:
  - `tests/unit/services/test_user_identity.py`
  - `tests/functional/telegram/test_telegram_confirmation.py::test_durable_telegram_confirmation_approval_uses_canonical_user_id`
  - `tests/functional/web/api/test_mail_webhook_security.py::test_mail_webhook_maps_target_user_from_unified_users_config`
  - `tests/functional/web/api/test_chat_confirmations.py::test_web_can_approve_confirmation_created_for_matching_telegram_user`
- Full `uv run poe test` passed:
  - `3252 passed, 3 skipped, 54 warnings`
  - `pytest`, `frontend-tests`, `basedpyright`, `pylint`, `frontend-lint`, and `frontend-typecheck` all passed.

## Related

Filed #809 for intermittent unrelated xdist worker crashes observed in video generation unit tests during earlier full-suite runs. Those tests passed standalone and a later full-suite run passed cleanly.