### PR TITLE
[codex] Fix flaky assistant message locator wait

### DIFF
--- a/.ast-grep/check-conformance.py
+++ b/.ast-grep/check-conformance.py
@@ -181,6 +181,7 @@ def run_ast_grep(files: list[str]) -> list[Violation]:
             "no-asyncio-sleep-in-tests",
             "no-time-sleep-in-tests",
             "no-playwright-wait-for-timeout",
+            "no-strict-assistant-message-wait",
         }
 
         violations = []

--- a/.ast-grep/exemptions.yml
+++ b/.ast-grep/exemptions.yml
@@ -69,6 +69,17 @@ exemptions:
     ticket: "#TBD-refactor-sleep-to-wait-for-condition"
 
   # ===========================================================================
+  # ast-grep rule fixtures - Deliberate positive examples
+  # ===========================================================================
+  - rule: no-strict-assistant-message-wait
+    files:
+      - .ast-grep/tests/conformance/no-strict-assistant-message-wait-positive.py
+    reason: |
+      Positive rule fixture intentionally contains banned Playwright locator waits
+      so .ast-grep/test-rules.py can verify the rule catches them.
+    ticket: null
+
+  # ===========================================================================
   # dict[str, Any] exemptions - Hook scripts with arbitrary JSON
   # ===========================================================================
   - rule: no-dict-any
@@ -80,4 +91,3 @@ exemptions:
       tools have different structures. Creating typed structures for this would be overly
       rigid and doesn't provide value since the hook only extracts specific fields.
     ticket: null
-

--- a/.ast-grep/rules/README.md
+++ b/.ast-grep/rules/README.md
@@ -69,6 +69,29 @@ await expect(page.locator("#status")).to_have_text("Complete")
 await page.wait_for_load_state("networkidle")
 ```
 
+#### `no-strict-assistant-message-wait`
+
+**Pattern**: `wait_for()` on a Playwright locator that targets `[data-testid="assistant-message"]`
+or `get_by_test_id("assistant-message")`
+
+**Why it's banned**: Chat tests can legitimately render multiple assistant messages, for example an
+initial assistant response followed by a final response after tool calls. Playwright `wait_for()` on
+a locator expects one matching element, so this pattern can fail in strict mode before the test
+reaches its real assertions.
+
+**Replacement**:
+
+```python
+# Wait for expected message content
+await chat_page.wait_for_message_content("I'll add several notes for you.")
+
+# Or wait for the concrete UI under test
+await page.wait_for_selector('[data-testid*="tool-call"]', state="visible")
+
+# If one assistant message is genuinely intended, scope it explicitly
+await page.locator('[data-testid="assistant-message"]').first.wait_for(state="visible")
+```
+
 ### Tool Development Anti-Patterns
 
 #### `toolresult-text-literal-with-data`

--- a/.ast-grep/rules/no-strict-assistant-message-wait.yml
+++ b/.ast-grep/rules/no-strict-assistant-message-wait.yml
@@ -1,0 +1,49 @@
+id: no-strict-assistant-message-wait
+language: python
+severity: error
+message: "Avoid strict Playwright wait_for() on assistant-message locators"
+note: |
+  Chat tests can legitimately render multiple assistant messages, such as an initial
+  assistant response followed by a final response after tool calls. Playwright locator
+  operations like wait_for() require a single matching element and will fail in strict
+  mode if [data-testid="assistant-message"] resolves to multiple elements.
+
+  Prefer waiting for the behavior under test:
+
+    await chat_page.wait_for_message_content("Expected assistant text")
+    await page.wait_for_selector('[data-testid*="tool-call"]', state="visible")
+    await page.locator('[data-testid="assistant-message"]').first.wait_for(...)
+
+  For exemptions, add a comment above the line:
+    # ast-grep-ignore: no-strict-assistant-message-wait - reason
+rule:
+  any:
+    - pattern: await $PAGE.locator($SEL).wait_for($$$)
+    - pattern: await $PAGE.get_by_test_id($TEST_ID).wait_for($$$)
+    - all:
+        - pattern: await $VAR.wait_for($$$)
+        - inside:
+            stopBy: end
+            pattern:
+              context: |
+                async def $FUNC($$$ARGS):
+                    $$$PRE
+                    $VAR = $PAGE.locator($SEL)
+                    $$$POST
+              selector: function_definition
+    - all:
+        - pattern: await $VAR.wait_for($$$)
+        - inside:
+            stopBy: end
+            pattern:
+              context: |
+                async def $FUNC($$$ARGS):
+                    $$$PRE
+                    $VAR = $PAGE.get_by_test_id($TEST_ID)
+                    $$$POST
+              selector: function_definition
+constraints:
+  SEL:
+    regex: assistant-message
+  TEST_ID:
+    regex: assistant-message

--- a/.ast-grep/tests/conformance/no-strict-assistant-message-wait-negative.py
+++ b/.ast-grep/tests/conformance/no-strict-assistant-message-wait-negative.py
@@ -1,0 +1,29 @@
+# ruff: noqa
+# pyright: reportMissingImports=false, reportUndefinedVariable=false
+"""Negative test cases for no-strict-assistant-message-wait.
+
+These examples SHOULD NOT trigger the conformance rule.
+"""
+
+
+async def test_wait_for_specific_message_content(chat_page):
+    await chat_page.wait_for_message_content("I'll add several notes for you.")
+
+
+async def test_wait_for_concrete_tool_ui(page):
+    await page.wait_for_selector('[data-testid*="tool-call"]', state="visible")
+    await page.locator('[data-testid="tool-group"]').wait_for(state="visible")
+
+
+async def test_count_assistant_messages(page):
+    assistant_message = page.locator('[data-testid="assistant-message"]')
+    assert await assistant_message.count() > 0
+
+
+async def test_deliberately_scoped_assistant_message_wait(page):
+    await page.locator('[data-testid="assistant-message"]').first.wait_for(
+        state="visible"
+    )
+
+    assistant_message = page.get_by_test_id("assistant-message").last
+    await assistant_message.wait_for(state="visible")

--- a/.ast-grep/tests/conformance/no-strict-assistant-message-wait-positive.py
+++ b/.ast-grep/tests/conformance/no-strict-assistant-message-wait-positive.py
@@ -1,0 +1,26 @@
+# ruff: noqa
+# pyright: reportMissingImports=false, reportUndefinedVariable=false
+"""Positive test cases for no-strict-assistant-message-wait.
+
+These examples SHOULD trigger the conformance rule.
+"""
+
+
+async def test_direct_locator_wait(page):
+    await page.locator('[data-testid="assistant-message"]').wait_for(
+        state="visible", timeout=10000
+    )
+
+
+async def test_assigned_locator_wait(page):
+    assistant_message = page.locator('[data-testid="assistant-message"]')
+    await assistant_message.wait_for(state="visible", timeout=10000)
+
+
+async def test_direct_get_by_test_id_wait(page):
+    await page.get_by_test_id("assistant-message").wait_for(state="visible")
+
+
+async def test_assigned_get_by_test_id_wait(page):
+    assistant_message = page.get_by_test_id("assistant-message")
+    await assistant_message.wait_for(state="visible")

--- a/tests/functional/web/CLAUDE.md
+++ b/tests/functional/web/CLAUDE.md
@@ -95,6 +95,31 @@ Screenshots are saved to `screenshots/{desktop,mobile}/` and can be used in docu
 End-to-end tests for the web UI are written using Playwright and can be found in
 `tests/functional/web/ui/`. These tests are marked with `@pytest.mark.playwright`.
 
+### Playwright Locator Strictness
+
+Playwright actions and waits on locators run in strict mode when they imply a single target. Do not
+call `wait_for()`, `click()`, `text_content()`, or similar single-element operations on locators
+that can legitimately match multiple elements.
+
+Specific failure mode to avoid: chat tests can have multiple `[data-testid="assistant-message"]`
+elements after an initial assistant response and a later final assistant response. A line like this
+is flaky and can fail before the actual assertion runs:
+
+```python
+assistant_message = page.locator('[data-testid="assistant-message"]')
+await assistant_message.wait_for(state="visible", timeout=10000)
+```
+
+Prefer waiting for the specific behavior under test instead:
+
+- Use `ChatPage.wait_for_message_content(...)` when the expected assistant/user text matters.
+- Use a selector for the concrete UI being asserted, such as `[data-testid*="tool-call"]` or
+  `[data-testid="tool-group"]`, when testing tool-call rendering.
+- If the test genuinely needs one item from a multi-match locator, use `.first`, `.last`, or
+  `.nth(index)` deliberately and document the ordering assumption through the assertion.
+- If the test only needs to prove at least one matching element exists, use `count()` or
+  `expect(locator).to_have_count(...)` rather than a strict single-element wait.
+
 ## Debugging Playwright Tests
 
 When a Playwright test fails, `pytest-playwright` automatically captures screenshots and records a

--- a/tests/functional/web/ui/test_tool_call_grouping.py
+++ b/tests/functional/web/ui/test_tool_call_grouping.py
@@ -104,10 +104,6 @@ async def test_multiple_tool_calls_are_grouped(
         "Successfully added all three notes.", timeout=30000
     )
 
-    # Wait for tool calls to appear
-    assistant_message = page.locator('[data-testid="assistant-message"]')
-    await assistant_message.wait_for(state="visible", timeout=10000)
-
     # Wait for tool call summary or details to appear
     await chat_page.wait_for_tool_call_display(timeout=10000)
 


### PR DESCRIPTION
## Summary

Fixes the flaky Playwright tool grouping test tracked in #818.

## Root Cause

`test_multiple_tool_calls_are_grouped` waited on `page.locator('[data-testid="assistant-message"]')` with `wait_for()`. Chat flows can legitimately render multiple assistant messages: an initial assistant response and a later final response after tool execution. Playwright locator `wait_for()` expects a single matching element, so the test could fail in strict mode before reaching the tool-group assertions.

## Changes

- Removed the redundant strict assistant-message wait from the tool grouping test while preserving waits for the actual message content and tool-call display.
- Documented the specific Playwright strict-locator failure mode in the web testing guide.
- Added the `no-strict-assistant-message-wait` ast-grep conformance rule with positive and negative fixtures so the pattern does not regress.

## Validation

- `npm run build --prefix frontend`
- `.venv/bin/pytest tests/functional/web/ui/test_tool_call_grouping.py -xq` -> `6 passed`
- `.venv/bin/poe test` -> `3284 passed, 3 skipped`; frontend tests, basedpyright, pylint, frontend linting, and TypeScript type checking all passed.

Closes #818