### PR TITLE
[codex] Support multi-reference image transforms

### DIFF
--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -314,6 +314,13 @@ throughout your conversation. This means:
 - Identify objects, people, or scenes
 - Answer specific questions about the image content
 
+**Image Generation and Editing:** Ask the assistant to create or transform images:
+
+- Generate a new image from a text description
+- Edit one attached image, such as removing an object or changing the style
+- Combine multiple attached images, such as placing a subject from one image into another scene
+- Use one image as the primary image and another as a visual style or reference image
+
 **Document Processing:** Upload documents to have the assistant:
 
 - Summarize the content

--- a/src/family_assistant/skills/builtin/image-tools.md
+++ b/src/family_assistant/skills/builtin/image-tools.md
@@ -24,11 +24,15 @@ Create images from text descriptions using AI (`generate_image` tool).
 
 ### 2. Transform Existing Images
 
-Send/attach an image with transformation instructions:
+Send or attach one or more images with transformation instructions. Use multiple reference images
+when the request combines subjects, transfers style, or uses one image as the primary scene and
+another as a reference:
 
 - **Edit content**: "Remove the car from this photo", "Add clouds to the sky"
 - **Change style**: "Make this look like a watercolor painting", "Convert to black and white"
 - **Create variations**: "Show this scene at night", "Make the colors more vibrant"
+- **Combine references**: "Put the dog from the first image into the room from the second image",
+  "Use the second image's style for the portrait in the first image"
 
 ### 3. Highlight and Annotate
 

--- a/src/family_assistant/tools/image_backends.py
+++ b/src/family_assistant/tools/image_backends.py
@@ -11,10 +11,13 @@ import asyncio
 import base64
 import io
 import logging
+import mimetypes
 import random
 from abc import abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 from PIL import Image, ImageDraw, ImageFilter, ImageFont, ImageOps
 
@@ -24,6 +27,7 @@ if TYPE_CHECKING:
 # Optional imports for production use
 try:
     from google import genai
+    from google.genai import types as genai_types
 
     GENAI_AVAILABLE = True
 except ImportError:
@@ -39,6 +43,35 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class ImageReference:
+    """Image bytes plus MIME type metadata for provider reference inputs."""
+
+    content: bytes
+    mime_type: str = "image/png"
+
+
+type ImageReferenceInput = bytes | ImageReference
+type ImageReferenceInputs = ImageReferenceInput | Sequence[ImageReferenceInput]
+
+
+def _normalize_image_references(
+    image_bytes: ImageReferenceInputs,
+) -> list[ImageReference]:
+    """Normalize one or more image references to metadata-rich inputs."""
+    image_inputs = (
+        [image_bytes]
+        if isinstance(image_bytes, bytes | ImageReference)
+        else list(image_bytes)
+    )
+    return [
+        image_input
+        if isinstance(image_input, ImageReference)
+        else ImageReference(content=image_input)
+        for image_input in image_inputs
+    ]
+
+
 @runtime_checkable
 class ImageGenerationBackend(Protocol):
     """Protocol for image generation backends."""
@@ -49,8 +82,10 @@ class ImageGenerationBackend(Protocol):
         ...
 
     @abstractmethod
-    async def transform_image(self, image_bytes: bytes, instruction: str) -> bytes:
-        """Transform an existing image based on text instruction."""
+    async def transform_image(
+        self, image_bytes: ImageReferenceInputs, instruction: str
+    ) -> bytes:
+        """Transform existing image references based on text instruction."""
         ...
 
 
@@ -99,11 +134,14 @@ class MockImageBackend:
         img.save(buffer, format="PNG")
         return buffer.getvalue()
 
-    async def transform_image(self, image_bytes: bytes, instruction: str) -> bytes:
+    async def transform_image(
+        self, image_bytes: ImageReferenceInputs, instruction: str
+    ) -> bytes:
         """Apply mock transformation to test image."""
         self.logger.debug(f"Transforming image with instruction: {instruction}")
 
-        img = Image.open(io.BytesIO(image_bytes))
+        image_inputs = _normalize_image_references(image_bytes)
+        img = Image.open(io.BytesIO(image_inputs[0].content))
 
         # Add transformation indicator at top
         draw = ImageDraw.Draw(img)
@@ -322,6 +360,8 @@ class MockImageBackend:
 class GeminiImageBackend:
     """Gemini API backend for production image generation."""
 
+    MODEL = "gemini-3-pro-image-preview"
+
     def __init__(self, api_key: str) -> None:
         """Initialize the Gemini backend with API key."""
         if not GENAI_AVAILABLE:
@@ -357,7 +397,7 @@ class GeminiImageBackend:
 
         # Call Gemini image generation
         response = await self.client.aio.models.generate_content(
-            model="gemini-3-pro-image-preview", contents=full_prompt
+            model=self.MODEL, contents=full_prompt
         )
 
         # Log response structure for debugging
@@ -481,19 +521,59 @@ class GeminiImageBackend:
 
         raise ValueError("No image data found in Gemini API response")
 
-    async def transform_image(self, image_bytes: bytes, instruction: str) -> bytes:
-        """Transform an existing image using Gemini API."""
-        # For now, this would require the Gemini edit/transform endpoint
-        # which may not be available yet. Fall back to mock for now.
-        self.logger.warning(
-            "Gemini image transformation not yet implemented, falling back to mock"
+    async def transform_image(
+        self, image_bytes: ImageReferenceInputs, instruction: str
+    ) -> bytes:
+        """Transform existing image references using Gemini API."""
+        self.logger.debug(f"Calling Gemini image edit with instruction: {instruction}")
+
+        image_inputs = _normalize_image_references(image_bytes)
+        content_parts: list[object] = [instruction]
+        content_parts.extend(
+            genai_types.Part.from_bytes(
+                data=image_input.content, mime_type=image_input.mime_type
+            )
+            for image_input in image_inputs
         )
-        mock_backend = MockImageBackend()
-        return await mock_backend.transform_image(image_bytes, instruction)
+        contents = cast("genai_types.ContentListUnion", content_parts)
+
+        response = await self.client.aio.models.generate_content(
+            model=self.MODEL,
+            contents=contents,
+            config=genai_types.GenerateContentConfig(
+                response_modalities=["TEXT", "IMAGE"]
+            ),
+        )
+
+        if hasattr(response, "parts") and response.parts:
+            for part in response.parts:
+                if part.inline_data is not None:
+                    image_data = part.inline_data.data
+                    if isinstance(image_data, str):
+                        return base64.b64decode(image_data)
+                    if isinstance(image_data, bytes):
+                        return image_data
+
+        if hasattr(response, "candidates") and response.candidates:
+            candidate = response.candidates[0]
+            if (
+                hasattr(candidate, "content")
+                and candidate.content
+                and candidate.content.parts
+            ):
+                for part in candidate.content.parts:
+                    if part.inline_data is not None:
+                        image_data = part.inline_data.data
+                        if isinstance(image_data, str):
+                            return base64.b64decode(image_data)
+                        if isinstance(image_data, bytes):
+                            return image_data
+
+        raise ValueError("No image data found in Gemini edit API response")
 
 
 class OpenAIImageBackend:
-    """OpenAI API backend for image generation using gpt-image-2."""
+    """OpenAI API backend for image generation."""
 
     def __init__(
         self,
@@ -548,23 +628,30 @@ class OpenAIImageBackend:
 
         return image_bytes
 
-    async def transform_image(self, image_bytes: bytes, instruction: str) -> bytes:
-        """Transform an existing image using OpenAI gpt-image-2 edit endpoint."""
+    async def transform_image(
+        self, image_bytes: ImageReferenceInputs, instruction: str
+    ) -> bytes:
+        """Transform existing image references using the OpenAI edit endpoint."""
         self.logger.debug(f"Calling OpenAI image edit with instruction: {instruction}")
 
-        # gpt-image-2 supports mask-free editing
-        image_file = io.BytesIO(image_bytes)
-        image_file.name = "image.png"
+        # The OpenAI SDK accepts either one image file or an ordered list of files.
+        image_inputs = _normalize_image_references(image_bytes)
+        image_files: list[io.BytesIO] = []
+        for index, image_input in enumerate(image_inputs, start=1):
+            image_file = io.BytesIO(image_input.content)
+            extension = mimetypes.guess_extension(image_input.mime_type) or ".png"
+            image_file.name = f"image_{index}{extension}"
+            image_files.append(image_file)
 
+        image_request = image_files[0] if len(image_files) == 1 else image_files
         cfg = self.edit_config
         response = await self.client.images.edit(
             model=self.model,
-            image=image_file,
+            image=image_request,
             prompt=instruction,
             n=1,
             size=cfg.size,
             quality=cfg.quality,
-            input_fidelity=cfg.input_fidelity,
             output_format=cfg.output_format,
             output_compression=cfg.output_compression,
         )
@@ -632,7 +719,9 @@ class FallbackImageBackend:
         self.logger.debug("Using mock backend for generation")
         return await self.mock_backend.generate_image(prompt, style)
 
-    async def transform_image(self, image_bytes: bytes, instruction: str) -> bytes:
+    async def transform_image(
+        self, image_bytes: ImageReferenceInputs, instruction: str
+    ) -> bytes:
         """Transform image with fallback from Gemini to mock."""
         if self.gemini_backend:
             try:

--- a/src/family_assistant/tools/image_generation.py
+++ b/src/family_assistant/tools/image_generation.py
@@ -18,6 +18,7 @@ from PIL import Image
 from family_assistant.tools.image_backends import (
     GeminiImageBackend,
     ImageGenerationBackend,
+    ImageReference,
     MockImageBackend,
     OpenAIImageBackend,
 )
@@ -59,20 +60,26 @@ IMAGE_GENERATION_TOOLS_DEFINITION: list[ToolDefinition] = [
         "type": "function",
         "function": {
             "name": "transform_image",
-            "description": "Transform and display an existing image based on text instruction. Works for editing (remove objects), styling (make it look like a painting), or variations (same scene at night).",
+            "description": "Edit, transform, or combine one or more existing reference images based on text instructions. Use this for object removal/addition, style changes, variations, or merging elements from multiple images.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "image": {
                         "type": "attachment",
-                        "description": "The image to transform",
+                        "description": "Single image to transform. Prefer `images` when using multiple references.",
+                    },
+                    "images": {
+                        "type": "array",
+                        "items": {"type": "attachment"},
+                        "description": "One or more reference images to edit, transform, or combine. When combining images, put the primary image first.",
+                        "minItems": 1,
                     },
                     "instruction": {
                         "type": "string",
                         "description": "Natural language instruction for how to transform the image",
                     },
                 },
-                "required": ["image", "instruction"],
+                "required": ["instruction"],
             },
         },
     },
@@ -188,7 +195,10 @@ async def generate_image_tool(
 
 
 async def transform_image_tool(
-    exec_context: "ToolExecutionContext", image: "ScriptAttachment", instruction: str
+    exec_context: "ToolExecutionContext",
+    instruction: str,
+    image: "ScriptAttachment | None" = None,
+    images: "list[ScriptAttachment] | None" = None,
 ) -> ToolResult:
     """
     Transform an existing image based on text instruction.
@@ -200,8 +210,9 @@ async def transform_image_tool(
 
     Args:
         exec_context: The execution context
-        image: The image to transform
         instruction: Natural language instruction for transformation
+        image: A single image to transform.
+        images: One or more reference images to transform or combine.
 
     Returns:
         ToolResult with transformed image attachment
@@ -209,17 +220,36 @@ async def transform_image_tool(
     logger.info(f"Transforming image with instruction: '{instruction}'")
 
     try:
-        # Get original image content
-        original_content = await image.get_content_async()
-        if not original_content:
-            logger.error(f"Could not retrieve content for attachment {image.get_id()}")
-            return ToolResult(text="Could not access the image content")
+        image_attachments: list[ScriptAttachment] = []
+        if image is not None:
+            image_attachments.append(image)
+        if images:
+            image_attachments.extend(images)
+
+        if not image_attachments:
+            return ToolResult(text="Error: Provide at least one image to transform")
+
+        image_contents: list[ImageReference] = []
+        for image_attachment in image_attachments:
+            content = await image_attachment.get_content_async()
+            if not content:
+                logger.error(
+                    "Could not retrieve content for attachment %s",
+                    image_attachment.get_id(),
+                )
+                return ToolResult(text="Could not access the image content")
+            image_contents.append(
+                ImageReference(
+                    content=content,
+                    mime_type=image_attachment.get_mime_type() or "image/png",
+                )
+            )
 
         # Get the appropriate backend
         backend = _create_image_backend(exec_context)
 
         # Transform the image
-        transformed_bytes = await backend.transform_image(original_content, instruction)
+        transformed_bytes = await backend.transform_image(image_contents, instruction)
 
         # Create attachment
         attachment = ToolAttachment(

--- a/tests/functional/integration/test_image_generation.py
+++ b/tests/functional/integration/test_image_generation.py
@@ -2,7 +2,7 @@
 
 import os
 from dataclasses import dataclass
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -128,9 +128,9 @@ async def test_transform_image_mock_mode() -> None:
 
     # Create mock attachment with test image
     mock_attachment = AsyncMock()
-    mock_attachment.get_id.return_value = "test-attachment-id"
-    mock_attachment.get_description.return_value = "Test image"
-    mock_attachment.get_mime_type.return_value = "image/png"
+    mock_attachment.get_id = Mock(return_value="test-attachment-id")
+    mock_attachment.get_description = Mock(return_value="Test image")
+    mock_attachment.get_mime_type = Mock(return_value="image/png")
 
     # Generate test image content using mock backend
     test_image_bytes = await mock_backend.generate_image("original test image", "auto")

--- a/tests/unit/tools/test_image_generation_tools.py
+++ b/tests/unit/tools/test_image_generation_tools.py
@@ -14,6 +14,8 @@ from family_assistant.config_models import (
     OpenAIImageRequestConfig,
 )
 from family_assistant.tools.image_backends import (
+    GeminiImageBackend,
+    ImageReference,
     MockImageBackend,
     OpenAIImageBackend,
 )
@@ -126,9 +128,9 @@ class TestImageGenerationTools:
     async def mock_script_attachment(self) -> AsyncMock:
         """Create a mock ScriptAttachment."""
         attachment = AsyncMock()
-        attachment.get_id.return_value = "test-attachment-id"
-        attachment.get_description.return_value = "Test image"
-        attachment.get_mime_type.return_value = "image/png"
+        attachment.get_id = Mock(return_value="test-attachment-id")
+        attachment.get_description = Mock(return_value="Test image")
+        attachment.get_mime_type = Mock(return_value="image/png")
 
         # Create test image content using mock backend
         mock_backend = MockImageBackend()
@@ -217,6 +219,57 @@ class TestImageGenerationTools:
         mock_script_attachment.get_content_async.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_transform_image_tool_multiple_references(
+        self, mock_exec_context: Mock
+    ) -> None:
+        """Test transformation with multiple reference images."""
+        mock_backend = Mock()
+        mock_backend.transform_image = AsyncMock(return_value=_make_png_bytes())
+        mock_exec_context.image_backend = mock_backend
+
+        first_attachment = AsyncMock()
+        first_attachment.get_content_async.return_value = b"first image content"
+        first_attachment.get_id = Mock(return_value="first-attachment")
+        first_attachment.get_mime_type = Mock(return_value="image/jpeg")
+
+        second_attachment = AsyncMock()
+        second_attachment.get_content_async.return_value = b"second image content"
+        second_attachment.get_id = Mock(return_value="second-attachment")
+        second_attachment.get_mime_type = Mock(return_value="image/webp")
+
+        result = await transform_image_tool(
+            mock_exec_context,
+            images=[first_attachment, second_attachment],
+            instruction="combine these into one image",
+        )
+
+        assert isinstance(result, ToolResult)
+        assert "Transformed image: combine these into one image" in result.get_text()
+        assert result.attachments and len(result.attachments) > 0
+        mock_backend.transform_image.assert_awaited_once_with(
+            [
+                ImageReference(b"first image content", "image/jpeg"),
+                ImageReference(b"second image content", "image/webp"),
+            ],
+            "combine these into one image",
+        )
+        first_attachment.get_content_async.assert_called_once()
+        second_attachment.get_content_async.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_transform_image_tool_requires_image(
+        self, mock_exec_context: Mock
+    ) -> None:
+        """Test transformation requires at least one image attachment."""
+        result = await transform_image_tool(
+            mock_exec_context, instruction="make it brighter"
+        )
+
+        assert isinstance(result, ToolResult)
+        assert "Provide at least one image to transform" in result.get_text()
+        assert not result.attachments or len(result.attachments) == 0
+
+    @pytest.mark.asyncio
     async def test_transform_image_tool_grayscale(
         self, mock_exec_context: Mock, mock_script_attachment: AsyncMock
     ) -> None:
@@ -283,7 +336,7 @@ class TestImageGenerationTools:
         """Test transformation when attachment has no content."""
         attachment = AsyncMock()
         attachment.get_content_async.return_value = None
-        attachment.get_id.return_value = "empty-attachment"
+        attachment.get_id = Mock(return_value="empty-attachment")
 
         result = await transform_image_tool(
             mock_exec_context, image=attachment, instruction="transform this"
@@ -339,7 +392,7 @@ class TestImageGenerationTools:
         # Mock an exception during attachment access
         attachment = AsyncMock()
         attachment.get_content_async.side_effect = Exception("Attachment error")
-        attachment.get_id.return_value = "error-attachment"
+        attachment.get_id = Mock(return_value="error-attachment")
 
         result = await transform_image_tool(
             mock_exec_context, image=attachment, instruction="transform this"
@@ -362,7 +415,8 @@ class TestImageGenerationTools:
         # Mock attachment that works
         attachment = AsyncMock()
         attachment.get_content_async.return_value = b"fake image content"
-        attachment.get_id.return_value = "test-attachment"
+        attachment.get_id = Mock(return_value="test-attachment")
+        attachment.get_mime_type = Mock(return_value="image/png")
 
         result = await transform_image_tool(
             mock_exec_context, image=attachment, instruction="transform this"
@@ -498,8 +552,65 @@ class TestOpenAIImageBackend:
         assert call_kwargs["model"] == "gpt-image-2"
         assert call_kwargs["prompt"] == "make it red"
         assert call_kwargs["quality"] == "high"
-        assert call_kwargs["input_fidelity"] == "high"
+        assert "input_fidelity" not in call_kwargs
         assert call_kwargs["output_format"] == "png"
+
+    @pytest.mark.asyncio
+    async def test_transform_image_drops_configured_input_fidelity(
+        self,
+    ) -> None:
+        """Test image transformation omits input_fidelity from edit calls."""
+        openai_backend = OpenAIImageBackend(
+            api_key="test-key",
+            model="gpt-image-1",
+            generate_config=OpenAIImageRequestConfig(),
+            edit_config=OpenAIImageRequestConfig(
+                size="auto",
+                quality="high",
+                input_fidelity="high",
+                output_format="png",
+            ),
+        )
+        png_b64 = _make_png_b64()
+        mock_response = Mock()
+        mock_response.data = [Mock(b64_json=png_b64)]
+
+        openai_backend.client.images.edit = AsyncMock(return_value=mock_response)
+
+        result = await openai_backend.transform_image(_make_png_bytes(), "make it red")
+
+        assert isinstance(result, bytes)
+        call_kwargs = openai_backend.client.images.edit.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-image-1"
+        assert "input_fidelity" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_transform_image_multiple_references(
+        self, openai_backend: OpenAIImageBackend
+    ) -> None:
+        """Test image transformation forwards multiple reference files."""
+        png_b64 = _make_png_b64()
+        mock_response = Mock()
+        mock_response.data = [Mock(b64_json=png_b64)]
+
+        openai_backend.client.images.edit = AsyncMock(return_value=mock_response)
+
+        result = await openai_backend.transform_image(
+            [_make_png_bytes(), _make_png_bytes()],
+            "combine these images",
+        )
+
+        assert isinstance(result, bytes)
+        call_kwargs = openai_backend.client.images.edit.call_args.kwargs
+        image_files = call_kwargs["image"]
+        assert isinstance(image_files, list)
+        assert len(image_files) == 2
+        assert [image_file.name for image_file in image_files] == [
+            "image_1.png",
+            "image_2.png",
+        ]
+        assert call_kwargs["prompt"] == "combine these images"
+        assert "input_fidelity" not in call_kwargs
 
     @pytest.mark.asyncio
     async def test_transform_image_no_data_raises(
@@ -551,6 +662,66 @@ class TestOpenAIImageBackend:
 
         auto = OpenAIImageBackend._apply_style_to_prompt("a cat", "auto")
         assert auto == "a cat"
+
+
+class TestGeminiImageBackend:
+    """Test the Gemini image backend."""
+
+    @pytest.fixture
+    def gemini_backend(self) -> GeminiImageBackend:
+        """Create a Gemini backend with a dummy key."""
+        return GeminiImageBackend(api_key="test-key")
+
+    @pytest.mark.asyncio
+    async def test_transform_image_multiple_references(
+        self, gemini_backend: GeminiImageBackend
+    ) -> None:
+        """Test Gemini transformation forwards multiple reference images."""
+        image_part = Mock()
+        image_part.inline_data = Mock(data=_make_png_bytes())
+        mock_response = Mock()
+        mock_response.parts = [image_part]
+        mock_response.candidates = None
+
+        gemini_backend.client.aio.models.generate_content = AsyncMock(
+            return_value=mock_response
+        )
+
+        result = await gemini_backend.transform_image(
+            [
+                ImageReference(b"first image content", "image/jpeg"),
+                ImageReference(b"second image content", "image/webp"),
+            ],
+            "combine these images",
+        )
+
+        assert isinstance(result, bytes)
+        call_kwargs = gemini_backend.client.aio.models.generate_content.call_args.kwargs
+        assert call_kwargs["model"] == "gemini-3-pro-image-preview"
+        contents = call_kwargs["contents"]
+        assert contents[0] == "combine these images"
+        assert contents[1].inline_data.data == b"first image content"
+        assert contents[1].inline_data.mime_type == "image/jpeg"
+        assert contents[2].inline_data.data == b"second image content"
+        assert contents[2].inline_data.mime_type == "image/webp"
+        config = call_kwargs["config"]
+        assert config.response_modalities == ["TEXT", "IMAGE"]
+
+    @pytest.mark.asyncio
+    async def test_transform_image_no_data_raises(
+        self, gemini_backend: GeminiImageBackend
+    ) -> None:
+        """Test error when Gemini transform API returns no image data."""
+        mock_response = Mock()
+        mock_response.parts = []
+        mock_response.candidates = None
+
+        gemini_backend.client.aio.models.generate_content = AsyncMock(
+            return_value=mock_response
+        )
+
+        with pytest.raises(ValueError, match="No image data"):
+            await gemini_backend.transform_image(_make_png_bytes(), "make it red")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds multi-reference image transform support across the image tool and backends.

- Allows `transform_image` to accept either a single `image` attachment or ordered `images` references.
- Sends multiple reference files to OpenAI image edits and removes the unsupported `input_fidelity` option from edit calls.
- Implements Gemini image transform/edit support using ordered inline image parts with image response modalities instead of falling back to the mock backend.
- Updates image-tool guidance and the user guide for multi-image editing workflows.

## Root Cause

The earlier library bump made the Python client accept `input_fidelity`, but the configured backend model `gpt-image-2` rejects that parameter at the API layer. The transform tool also only exposed a single reference image even though the underlying providers can accept multiple reference images.

## Validation

- `uv run pytest tests/unit/tools/test_image_generation_tools.py tests/functional/integration/test_image_generation.py -xq` passed.
- Live direct backend checks passed for OpenAI and Gemini multi-reference transforms using environment API keys.
- Local dev server HTTP test passed via `/api/attachments/upload` plus `/api/tools/execute/transform_image`, returning a PNG attachment from two uploaded references.
- `uv run poe test` passed: 3290 passed, 3 skipped; pytest, frontend tests, basedpyright, pylint, frontend lint, and frontend typecheck all passed.