### PR TITLE
Add MCP / config diagnostic tools to engineer profile

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1773,9 +1773,13 @@ service_profiles:
           - **Source code**: Read files and search the codebase
           - **Database**: Execute SELECT queries to examine application state
           - **Error logs**: Read application error and warning logs
+          - **LLM history**: Inspect recent LLM requests/responses
           - **Notes and documents**: Read stored notes and documents
           - **Automations**: View automation configurations and statistics
           - **Events**: Query recent system events
+          - **Configuration**: Inspect the live AppConfig and individual service profile configs (with secrets redacted)
+          - **MCP servers**: View live MCP server connection status and the tools each server provides
+          - **System info**: Python version, OS platform, database dialect
 
           ## Your Limitations
 
@@ -1784,6 +1788,7 @@ service_profiles:
           - You CANNOT send messages to users
           - You CANNOT delegate to other profiles
           - You CAN create GitHub issues to report bugs (requires confirmation)
+          - You CAN reconnect a failed MCP server (requires confirmation)
 
           ## Investigation Approach
 
@@ -1791,8 +1796,10 @@ service_profiles:
           2. Check error logs for recent errors or warnings
           3. Examine relevant source code to understand the implementation
           4. Query the database to check application state
-          5. Summarize findings and recommend fixes
-          6. If appropriate, create a GitHub issue with your findings
+          5. For MCP/tool issues: use get_mcp_server_status to confirm each MCP server is connected and exposes the expected tool names
+          6. For config issues: use get_resolved_config and get_profile_config to inspect the live runtime config
+          7. Summarize findings and recommend fixes
+          8. If appropriate, create a GitHub issue with your findings
     tools_config:
       enable_local_tools:
         # Engineering-specific tools
@@ -1802,6 +1809,11 @@ service_profiles:
         - "read_error_logs"
         - "get_llm_request_history"
         - "create_github_issue"
+        - "get_mcp_server_status"
+        - "reconnect_mcp_server"
+        - "get_resolved_config"
+        - "get_profile_config"
+        - "get_system_info"
         # Read-only data tools
         - "get_message_history"
         - "list_notes"
@@ -1817,6 +1829,7 @@ service_profiles:
       enable_mcp_server_ids: []
       confirm_tools:
         - "create_github_issue"
+        - "reconnect_mcp_server"
     tools_policy:
       default_decision: "deny"
       rules:
@@ -1828,6 +1841,11 @@ service_profiles:
               - "read_error_logs"
               - "get_llm_request_history"
               - "create_github_issue"
+              - "get_mcp_server_status"
+              - "reconnect_mcp_server"
+              - "get_resolved_config"
+              - "get_profile_config"
+              - "get_system_info"
               - "get_message_history"
               - "list_notes"
               - "get_note"
@@ -1844,6 +1862,7 @@ service_profiles:
         - match:
             names:
               - "create_github_issue"
+              - "reconnect_mcp_server"
           decision: "confirm"
           priority: 20
     slash_commands:

--- a/src/family_assistant/config_inspection.py
+++ b/src/family_assistant/config_inspection.py
@@ -1,0 +1,104 @@
+"""Shared helpers for serializing and redacting application config.
+
+These utilities are used by both the debug API endpoints and the engineer
+profile diagnostic tools so they share a single source of truth for which
+fields are sensitive and how profile dumps are produced.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from family_assistant.config_models import (
+        DefaultProfileSettings,
+        ServiceProfile,
+    )
+
+
+# Fields whose values may leak secrets or per-user credentials. When a key with
+# one of these names appears anywhere in the serialized config (including nested
+# dicts under e.g. ``camera_config`` or ``home_assistant_*``), its value is
+# replaced with "[REDACTED]" in the response.
+SENSITIVE_FIELD_NAMES: frozenset[str] = frozenset({
+    "home_assistant_token",
+    "password",
+    "client_secret",
+    "mailgun_webhook_signing_key",
+    "gemini_api_key",
+    "openai_api_key",
+    "openrouter_api_key",
+    "telegram_token",
+    "vapid_private_key",
+    "session_secret_key",
+    "token_env",
+})
+
+# Substring patterns used as a defense-in-depth fallback so config fields added
+# in the future with secret-looking names (e.g. ``*_api_key``, ``*_secret``,
+# ``*_token``, ``*_password``) are redacted even if not explicitly allowlisted.
+_SENSITIVE_SUBSTRINGS: tuple[str, ...] = (
+    "api_key",
+    "apikey",
+    "secret",
+    "token",
+    "password",
+    "passwd",
+    "private_key",
+)
+
+
+def is_sensitive_field_name(key: object) -> bool:
+    """Return True if the given dict key looks like it carries a secret."""
+    if not isinstance(key, str):
+        return False
+    if key in SENSITIVE_FIELD_NAMES:
+        return True
+    lowered = key.lower()
+    return any(substring in lowered for substring in _SENSITIVE_SUBSTRINGS)
+
+
+# ast-grep-ignore: no-dict-any - Recursive config redaction handles arbitrary nested structures
+def redact_sensitive_config(obj: Any) -> Any:  # noqa: ANN401 - recursive over arbitrary JSON-like data
+    """Recursively redact sensitive fields in a serialized config structure."""
+    if isinstance(obj, dict):
+        return {
+            key: "[REDACTED]"
+            if is_sensitive_field_name(key) and value
+            else redact_sensitive_config(value)
+            for key, value in obj.items()
+        }
+    if isinstance(obj, list):
+        return [redact_sensitive_config(item) for item in obj]
+    return obj
+
+
+def dump_profile_like(
+    profile: ServiceProfile | DefaultProfileSettings,
+    # ast-grep-ignore: no-dict-any - Serialized Pydantic model has heterogeneous top-level values
+) -> dict[str, Any]:
+    """Serialize a ServiceProfile/DefaultProfileSettings including excluded operator fields.
+
+    ``operator_tools_policy`` and ``operator_mcp_server_ids`` on both
+    ``ServiceProfile`` and ``DefaultProfileSettings`` are declared with
+    ``exclude=True`` so they do not round-trip through the YAML config, but they
+    ARE merged with the profile/defaults layers at runtime (see
+    ``PolicyEngine.from_layers``). For diagnostic dumps we want the caller to
+    see every layer contributing to the effective policy — including any
+    defaults that apply to every profile — so we serialize them explicitly here.
+    """
+    dumped = profile.model_dump(mode="json")
+
+    if profile.operator_tools_policy is not None:
+        dumped["operator_tools_policy"] = profile.operator_tools_policy.model_dump(
+            mode="json"
+        )
+    else:
+        dumped["operator_tools_policy"] = None
+
+    dumped["operator_mcp_server_ids"] = [
+        entry if isinstance(entry, str) else entry.model_dump(mode="json")
+        for entry in profile.operator_mcp_server_ids
+    ]
+
+    return dumped

--- a/src/family_assistant/tools/__init__.py
+++ b/src/family_assistant/tools/__init__.py
@@ -103,9 +103,14 @@ from family_assistant.tools.engineering import (
     ENGINEERING_TOOLS_DEFINITION,
     create_github_issue,
     get_llm_request_history,
+    get_mcp_server_status,
+    get_profile_config,
+    get_resolved_config,
+    get_system_info,
     query_database,
     read_error_logs,
     read_source_file,
+    reconnect_mcp_server,
     search_source_code,
 )
 from family_assistant.tools.events import (
@@ -413,6 +418,11 @@ __all__ = [
     "read_error_logs",
     "create_github_issue",
     "get_llm_request_history",
+    "get_mcp_server_status",
+    "reconnect_mcp_server",
+    "get_resolved_config",
+    "get_profile_config",
+    "get_system_info",
     # On-demand tool activation
     "ACTIVATE_TOOLS_DEFINITION",
     "OnDemandCatalogEntry",
@@ -608,6 +618,11 @@ _LOCAL_TOOL_IMPLEMENTATIONS: dict[str, ToolImplementation] = {
     "read_error_logs": read_error_logs,
     "create_github_issue": create_github_issue,
     "get_llm_request_history": get_llm_request_history,
+    "get_mcp_server_status": get_mcp_server_status,
+    "reconnect_mcp_server": reconnect_mcp_server,
+    "get_resolved_config": get_resolved_config,
+    "get_profile_config": get_profile_config,
+    "get_system_info": get_system_info,
     # MQTT tools
     "mqtt_publish": mqtt_publish_tool,
 }
@@ -1227,6 +1242,30 @@ LOCAL_TOOL_METADATA_BY_NAME: dict[str, LocalToolMetadata] = {
     "create_github_issue": _metadata(
         ToolTag.EXTERNAL_COMM,
         ToolTag.STATE_CHANGING,
+        ToolTag.OUTPUT_TRUSTED,
+    ),
+    "get_mcp_server_status": _metadata(
+        ToolTag.READ_ONLY,
+        ToolTag.SENSITIVE_DATA,
+        ToolTag.OUTPUT_TRUSTED,
+    ),
+    "reconnect_mcp_server": _metadata(
+        ToolTag.STATE_CHANGING,
+        ToolTag.SENSITIVE_DATA,
+        ToolTag.OUTPUT_TRUSTED,
+    ),
+    "get_resolved_config": _metadata(
+        ToolTag.READ_ONLY,
+        ToolTag.SENSITIVE_DATA,
+        ToolTag.OUTPUT_TRUSTED,
+    ),
+    "get_profile_config": _metadata(
+        ToolTag.READ_ONLY,
+        ToolTag.SENSITIVE_DATA,
+        ToolTag.OUTPUT_TRUSTED,
+    ),
+    "get_system_info": _metadata(
+        ToolTag.READ_ONLY,
         ToolTag.OUTPUT_TRUSTED,
     ),
     # MQTT tools

--- a/src/family_assistant/tools/engineering.py
+++ b/src/family_assistant/tools/engineering.py
@@ -1,7 +1,9 @@
 """Engineering tools for debugging and diagnosing the application.
 
 Provides read-only access to source code, database queries, error logs,
-and GitHub issue creation for the engineer processing profile.
+resolved configuration, profile configuration, and live MCP server status,
+plus a confirmation-gated MCP reconnect action and GitHub issue creation
+for the engineer processing profile.
 """
 
 from __future__ import annotations
@@ -9,6 +11,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import platform
+import sys
 from typing import TYPE_CHECKING
 
 import aiofiles
@@ -16,13 +20,20 @@ import httpx
 import sqlparse
 from sqlalchemy import text
 
+from family_assistant.config_inspection import (
+    dump_profile_like,
+    redact_sensitive_config,
+)
 from family_assistant.llm.request_buffer import get_request_buffer
 from family_assistant.paths import PROJECT_ROOT
+from family_assistant.tools.infrastructure import find_provider_by_type
 from family_assistant.tools.types import ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from family_assistant.config_models import AppConfig
+    from family_assistant.tools.mcp import MCPToolsProvider
     from family_assistant.tools.types import ToolExecutionContext
 
 logger = logging.getLogger(__name__)
@@ -425,6 +436,273 @@ async def create_github_issue(
     )
 
 
+def _resolve_mcp_provider(
+    exec_context: ToolExecutionContext,
+) -> MCPToolsProvider | None:
+    """Locate the live MCPToolsProvider in the runtime tools provider tree.
+
+    Returns ``None`` when MCP support is not built in, when no tools provider
+    is wired into the execution context, or when no MCPToolsProvider was
+    configured. Callers should surface a clear diagnostic in that case rather
+    than treating it as a connection failure.
+    """
+    # ``tools.mcp`` depends on the optional ``mcp`` SDK; deployments without
+    # the SDK installed must still be able to import ``engineering.py``, so
+    # we defer the import to call time. ``__init__.py`` already wraps this
+    # import in a try/except and substitutes ``None`` when unavailable, but
+    # we re-import here from the concrete module rather than the package
+    # so static type checkers can resolve the symbol. The function-scope
+    # import is intentional — top-level would break that contract.
+    from family_assistant.tools.mcp import (  # noqa: PLC0415 - lazy import: optional MCP SDK may be absent at module load
+        MCPToolsProvider as _MCPToolsProvider,
+    )
+
+    tools_provider = exec_context.tools_provider
+    if (
+        tools_provider is None
+        and exec_context.processing_service is not None
+        and hasattr(exec_context.processing_service, "tools_provider")
+    ):
+        tools_provider = exec_context.processing_service.tools_provider
+
+    if tools_provider is None:
+        return None
+
+    return find_provider_by_type(tools_provider, _MCPToolsProvider)
+
+
+async def get_mcp_server_status(
+    exec_context: ToolExecutionContext,
+) -> ToolResult:
+    """Return the live connection status of all configured MCP servers.
+
+    Includes per-server status (``connected`` / ``failed`` / ``cancelled`` /
+    ``pending`` / ``connecting``), transport, the discovered tool list, and
+    whether a session is currently active. Tokens are omitted; URLs and stdio
+    commands are included verbatim so the engineer can correlate against the
+    deployment config.
+    """
+    logger.info("get_mcp_server_status: dumping live MCP server statuses")
+
+    mcp_provider = _resolve_mcp_provider(exec_context)
+    if mcp_provider is None:
+        return ToolResult(
+            data={
+                "error": (
+                    "No MCPToolsProvider available in the current tools provider tree. "
+                    "Either MCP support is not installed, no MCP servers are configured, "
+                    "or the tools provider has not been wired into this execution context."
+                ),
+                "servers": {},
+            }
+        )
+
+    statuses = mcp_provider.get_server_statuses()
+    summary = {
+        "total": len(statuses),
+        "connected": sum(
+            1 for entry in statuses.values() if entry["status"] == "connected"
+        ),
+        "failed": sum(1 for entry in statuses.values() if entry["status"] == "failed"),
+        "cancelled": sum(
+            1 for entry in statuses.values() if entry["status"] == "cancelled"
+        ),
+        "pending": sum(
+            1
+            for entry in statuses.values()
+            if entry["status"] in {"pending", "connecting"}
+        ),
+    }
+    return ToolResult(data={"summary": summary, "servers": statuses})
+
+
+async def reconnect_mcp_server(
+    exec_context: ToolExecutionContext,
+    server_id: str,
+) -> ToolResult:
+    """Tear down and re-establish an MCP server's session.
+
+    This is a state-changing diagnostic action: it closes any existing
+    session for ``server_id``, runs the regular discovery flow, and updates
+    the in-memory tool registry. The engineer profile gates this tool with a
+    confirmation policy.
+    """
+    logger.info("reconnect_mcp_server: server_id=%s", server_id)
+
+    mcp_provider = _resolve_mcp_provider(exec_context)
+    if mcp_provider is None:
+        return ToolResult(
+            data={
+                "error": (
+                    "No MCPToolsProvider available; cannot reconnect. "
+                    "Check that MCP support is installed and the tools provider "
+                    "is wired into this execution context."
+                ),
+                "server_id": server_id,
+            }
+        )
+
+    try:
+        success = await mcp_provider.reconnect_server(server_id)
+    except KeyError:
+        return ToolResult(
+            data={
+                "error": f"Unknown MCP server id: {server_id!r}",
+                "configured_servers": sorted(mcp_provider.server_configs.keys()),
+            }
+        )
+
+    statuses = mcp_provider.get_server_statuses()
+    return ToolResult(
+        data={
+            "server_id": server_id,
+            "success": success,
+            "status": statuses.get(server_id, {}),
+        }
+    )
+
+
+def _resolve_app_config(
+    exec_context: ToolExecutionContext,
+) -> AppConfig | None:
+    """Return the ``AppConfig`` instance from the execution context, if any.
+
+    Engineer-profile diagnostic tools rely on ``processing_service.app_config``
+    being available. ``None`` indicates the context is missing infrastructure
+    and the caller should surface a clear error.
+    """
+    processing_service = exec_context.processing_service
+    if processing_service is None:
+        return None
+    return getattr(processing_service, "app_config", None)
+
+
+async def get_resolved_config(
+    exec_context: ToolExecutionContext,
+) -> ToolResult:
+    """Return the live ``AppConfig`` (excluding service profiles) with secrets redacted.
+
+    Service profile and default-profile bodies are omitted because they can
+    be large; use ``get_profile_config`` to retrieve them individually. The
+    profile id list is included so the caller knows what's available.
+    """
+    logger.info("get_resolved_config: dumping live application config")
+
+    app_config = _resolve_app_config(exec_context)
+    if app_config is None:
+        return ToolResult(
+            data={
+                "error": (
+                    "No AppConfig available on the processing service. "
+                    "This tool must be invoked from within a live processing flow."
+                )
+            }
+        )
+
+    full_dump = app_config.model_dump(mode="json")
+    profiles = full_dump.pop("service_profiles", [])
+    full_dump.pop("default_profile_settings", None)
+
+    profile_ids: list[str] = sorted(
+        entry["id"]
+        for entry in profiles
+        if isinstance(entry, dict) and isinstance(entry.get("id"), str)
+    )
+
+    return ToolResult(
+        data={
+            "config": redact_sensitive_config(full_dump),
+            "profile_ids": profile_ids,
+            "profile_count": len(profile_ids),
+            "default_service_profile_id": full_dump.get("default_service_profile_id"),
+        }
+    )
+
+
+async def get_profile_config(
+    exec_context: ToolExecutionContext,
+    profile_id: str | None = None,
+) -> ToolResult:
+    """Return live profile configuration with secrets redacted.
+
+    With ``profile_id``, returns just that profile's config. Without one,
+    returns the profile id list (call again with a specific id to fetch the
+    body) plus the merged ``default_profile_settings``. This avoids dumping
+    every profile in one giant payload.
+    """
+    logger.info("get_profile_config: profile_id=%s", profile_id)
+
+    app_config = _resolve_app_config(exec_context)
+    if app_config is None:
+        return ToolResult(
+            data={
+                "error": (
+                    "No AppConfig available on the processing service. "
+                    "This tool must be invoked from within a live processing flow."
+                )
+            }
+        )
+
+    profiles = list(getattr(app_config, "service_profiles", []) or [])
+
+    if profile_id is None:
+        return ToolResult(
+            data={
+                "profile_ids": sorted(p.id for p in profiles),
+                "default_service_profile_id": getattr(
+                    app_config, "default_service_profile_id", None
+                ),
+                "default_profile_settings": redact_sensitive_config(
+                    dump_profile_like(app_config.default_profile_settings)
+                ),
+            }
+        )
+
+    matched = next((p for p in profiles if p.id == profile_id), None)
+    if matched is None:
+        return ToolResult(
+            data={
+                "error": f"Profile {profile_id!r} not found",
+                "profile_ids": sorted(p.id for p in profiles),
+            }
+        )
+
+    return ToolResult(
+        data={
+            "id": matched.id,
+            "description": matched.description,
+            "config": redact_sensitive_config(dump_profile_like(matched)),
+        }
+    )
+
+
+async def get_system_info(
+    exec_context: ToolExecutionContext,
+) -> ToolResult:
+    """Return runtime environment info (Python, platform, database dialect).
+
+    Mirrors the ``system_info`` block of the ``/api/diagnostics/export``
+    endpoint so the engineer profile can include it in bug reports without
+    leaving the chat.
+    """
+    logger.info("get_system_info: gathering runtime environment info")
+
+    db_dialect = "unknown"
+    db_context = exec_context.db_context
+    engine = getattr(db_context, "engine", None)
+    if engine is not None:
+        dialect = getattr(engine, "dialect", None)
+        db_dialect = getattr(dialect, "name", "unknown")
+
+    return ToolResult(
+        data={
+            "python_version": sys.version.split()[0],
+            "platform": platform.platform(),
+            "database_dialect": db_dialect,
+        }
+    )
+
+
 # Tool Definitions
 
 ENGINEERING_TOOLS_DEFINITION: list[ToolDefinition] = [
@@ -585,6 +863,110 @@ ENGINEERING_TOOLS_DEFINITION: list[ToolDefinition] = [
                     },
                 },
                 "required": ["title", "body"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_mcp_server_status",
+            "description": (
+                "Return the live connection status of every configured MCP server, "
+                "including transport, command/url, session activity, and the list "
+                "of tools each server currently provides. Use this when scripts or "
+                "the LLM report that an MCP-backed tool name is undefined, or to "
+                "confirm an MCP server is reachable before depending on it."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "reconnect_mcp_server",
+            "description": (
+                "Tear down and re-establish the connection to a single MCP server. "
+                "Useful when a server has dropped to a 'failed' or 'cancelled' "
+                "state and you want to retry without restarting the application. "
+                "This is a state-changing operation; the engineer profile gates "
+                "it behind user confirmation."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "server_id": {
+                        "type": "string",
+                        "description": (
+                            "Configured MCP server id (matches a key in "
+                            "AppConfig.mcp_servers). Use get_mcp_server_status "
+                            "to see available ids."
+                        ),
+                    },
+                },
+                "required": ["server_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_resolved_config",
+            "description": (
+                "Return the live AppConfig (with secrets redacted), excluding the "
+                "service profile bodies which can be large. Use get_profile_config "
+                "to fetch a profile by id. The response includes the full list of "
+                "configured profile ids so you know what's available."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_profile_config",
+            "description": (
+                "Return the live configuration of a service profile (with secrets "
+                "redacted). Without profile_id returns the list of available "
+                "profile ids plus the merged default_profile_settings; with "
+                "profile_id returns just that profile's body, including merged "
+                "operator_tools_policy and operator_mcp_server_ids."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "profile_id": {
+                        "type": "string",
+                        "description": (
+                            "Service profile id to dump. Omit to list available "
+                            "profile ids and view default_profile_settings."
+                        ),
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_system_info",
+            "description": (
+                "Return runtime environment info (Python version, OS platform, "
+                "database dialect). Mirrors the system_info block of "
+                "/api/diagnostics/export so it can be included in bug reports."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
             },
         },
     },

--- a/src/family_assistant/tools/mcp.py
+++ b/src/family_assistant/tools/mcp.py
@@ -7,6 +7,7 @@ import os  # Import os for environment variable resolution
 from typing import (
     TYPE_CHECKING,
     Any,
+    TypedDict,
 )  # Added Tuple
 
 import anyio
@@ -44,6 +45,24 @@ MCP_SERVER_STATUS_CONNECTING = "connecting"
 MCP_SERVER_STATUS_CONNECTED = "connected"
 MCP_SERVER_STATUS_FAILED = "failed"
 MCP_SERVER_STATUS_CANCELLED = "cancelled"
+
+
+class MCPServerStatus(TypedDict):
+    """Diagnostic snapshot describing one MCP server's connection state.
+
+    Used by ``MCPToolsProvider.get_server_statuses`` and surfaced through
+    the engineer-profile ``get_mcp_server_status`` tool. Token-bearing
+    config fields are intentionally omitted.
+    """
+
+    status: str
+    transport: str
+    command: str | None
+    args: list[str]
+    url: str | None
+    session_active: bool
+    tool_count: int
+    tools: list[str]
 
 
 class MCPToolsProvider:
@@ -86,6 +105,40 @@ class MCPToolsProvider:
     def server_configs(self) -> dict[str, MCPServerConfig]:
         """Returns the configured MCP servers."""
         return self._mcp_server_configs
+
+    def get_server_statuses(self) -> dict[str, MCPServerStatus]:
+        """Return a snapshot of MCP server connection status for diagnostics.
+
+        Returns a mapping of ``server_id`` to an ``MCPServerStatus`` describing
+        the current connection state, transport, configured connection
+        details (no tokens), session activity, and the tools currently
+        provided by that server.
+
+        Designed to be called by engineer-profile diagnostic tools without
+        requiring any further reconnection or I/O.
+        """
+        # Invert the tool_map so we can list tools per-server without
+        # touching internal storage in callers.
+        tools_by_server: dict[str, list[str]] = {
+            server_id: [] for server_id in self._mcp_server_configs
+        }
+        for tool_name, server_id in self._tool_map.items():
+            tools_by_server.setdefault(server_id, []).append(tool_name)
+
+        snapshot: dict[str, MCPServerStatus] = {}
+        for server_id, config in self._mcp_server_configs.items():
+            tools = sorted(tools_by_server.get(server_id, []))
+            snapshot[server_id] = MCPServerStatus(
+                status=self._server_statuses.get(server_id, MCP_SERVER_STATUS_PENDING),
+                transport=config.get("transport", "stdio"),
+                command=config.get("command"),
+                args=list(config.get("args", []) or []),
+                url=config.get("url"),
+                session_active=server_id in self._sessions,
+                tool_count=len(tools),
+                tools=tools,
+            )
+        return snapshot
 
     def _build_mcp_descriptors(
         self,
@@ -727,6 +780,17 @@ class MCPToolsProvider:
                 # Continue the loop despite errors
 
         logger.info("Health check loop stopped")
+
+    async def reconnect_server(self, server_id: str) -> bool:
+        """Public wrapper around the internal reconnect routine.
+
+        Used by diagnostic tools (e.g. the engineer profile's
+        ``reconnect_mcp_server``) so callers don't have to reach into a
+        private method.
+        """
+        if server_id not in self._mcp_server_configs:
+            raise KeyError(server_id)
+        return await self._reconnect_server(server_id)
 
     async def _reconnect_server(self, server_id: str) -> bool:
         """Attempts to reconnect a single MCP server."""

--- a/src/family_assistant/web/routers/debug_api.py
+++ b/src/family_assistant/web/routers/debug_api.py
@@ -10,7 +10,12 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
 
-from family_assistant.config_models import DefaultProfileSettings, ServiceProfile
+from family_assistant.config_inspection import (
+    SENSITIVE_FIELD_NAMES,
+    dump_profile_like,
+    is_sensitive_field_name,
+    redact_sensitive_config,
+)
 from family_assistant.web.auth import (
     AUTH_ENABLED,
     OIDC_CLIENT_ID,
@@ -22,92 +27,14 @@ from family_assistant.web.dependencies import get_current_user
 logger = logging.getLogger(__name__)
 debug_api_router = APIRouter()
 
-# Fields whose values may leak secrets or per-user credentials. When a key with
-# one of these names appears anywhere in the serialized config (including nested
-# dicts under e.g. ``camera_config`` or ``home_assistant_*``), its value is
-# replaced with "[REDACTED]" in the response.
-SENSITIVE_FIELD_NAMES: frozenset[str] = frozenset({
-    "home_assistant_token",
-    "password",
-    "client_secret",
-    "mailgun_webhook_signing_key",
-    "gemini_api_key",
-    "openai_api_key",
-    "openrouter_api_key",
-    "telegram_token",
-    "vapid_private_key",
-    "session_secret_key",
-    "token_env",  # name of env var, redacted defensively
-})
-
-# Substring patterns used as a defense-in-depth fallback so config fields added
-# in the future with secret-looking names (e.g. ``*_api_key``, ``*_secret``,
-# ``*_token``, ``*_password``) are redacted even if not explicitly allowlisted.
-_SENSITIVE_SUBSTRINGS: tuple[str, ...] = (
-    "api_key",
-    "apikey",
-    "secret",
-    "token",
-    "password",
-    "passwd",
-    "private_key",
-)
-
-
-def is_sensitive_field_name(key: object) -> bool:
-    """Return True if the given dict key looks like it carries a secret."""
-    if not isinstance(key, str):
-        return False
-    if key in SENSITIVE_FIELD_NAMES:
-        return True
-    lowered = key.lower()
-    return any(substring in lowered for substring in _SENSITIVE_SUBSTRINGS)
-
-
-# ast-grep-ignore: no-dict-any - Recursive config redaction handles arbitrary nested structures
-def redact_sensitive_config(obj: Any) -> Any:  # noqa: ANN401 - recursive over arbitrary JSON-like data
-    """Recursively redact sensitive fields in a serialized config structure."""
-    if isinstance(obj, dict):
-        return {
-            key: "[REDACTED]"
-            if is_sensitive_field_name(key) and value
-            else redact_sensitive_config(value)
-            for key, value in obj.items()
-        }
-    if isinstance(obj, list):
-        return [redact_sensitive_config(item) for item in obj]
-    return obj
-
-
-def _dump_profile_like(
-    profile: ServiceProfile | DefaultProfileSettings,
-    # ast-grep-ignore: no-dict-any - Serialized Pydantic model has heterogeneous top-level values
-) -> dict[str, Any]:
-    """Serialize a ServiceProfile/DefaultProfileSettings including excluded operator fields.
-
-    ``operator_tools_policy`` and ``operator_mcp_server_ids`` on both
-    ``ServiceProfile`` and ``DefaultProfileSettings`` are declared with
-    ``exclude=True`` so they do not round-trip through the YAML config, but they
-    ARE merged with the profile/defaults layers at runtime (see
-    ``PolicyEngine.from_layers``). For the debug dump we want the caller to see
-    every layer contributing to the effective policy — including any defaults
-    that apply to every profile — so we serialize them explicitly here.
-    """
-    dumped = profile.model_dump(mode="json")
-
-    if profile.operator_tools_policy is not None:
-        dumped["operator_tools_policy"] = profile.operator_tools_policy.model_dump(
-            mode="json"
-        )
-    else:
-        dumped["operator_tools_policy"] = None
-
-    dumped["operator_mcp_server_ids"] = [
-        entry if isinstance(entry, str) else entry.model_dump(mode="json")
-        for entry in profile.operator_mcp_server_ids
-    ]
-
-    return dumped
+# Re-export shared helpers from config_inspection so existing call sites and
+# tests that imported them from this module keep working.
+__all__ = [
+    "SENSITIVE_FIELD_NAMES",
+    "debug_api_router",
+    "is_sensitive_field_name",
+    "redact_sensitive_config",
+]
 
 
 def _strip_google_prefix(model: str) -> str:
@@ -432,7 +359,7 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
     for profile in config.service_profiles:
         if profile_id is not None and profile.id != profile_id:
             continue
-        profile_dump = redact_sensitive_config(_dump_profile_like(profile))
+        profile_dump = redact_sensitive_config(dump_profile_like(profile))
         runtime_info = _runtime_info_for(profile.id, processing_services_registry)
         profiles_info.append({
             "id": profile.id,
@@ -448,7 +375,7 @@ async def dump_profiles(  # noqa: A002 - FastAPI query param name shadows builti
         )
 
     default_settings_dump = redact_sensitive_config(
-        _dump_profile_like(config.default_profile_settings)
+        dump_profile_like(config.default_profile_settings)
     )
 
     # ast-grep-ignore: no-dict-any - Debug endpoint returns serialized Pydantic config dicts

--- a/tests/unit/tools/test_engineering.py
+++ b/tests/unit/tools/test_engineering.py
@@ -391,42 +391,33 @@ class TestGetLlmRequestHistory:
 # --- Tool definitions tests ---
 
 
+_ENGINEERING_TOOL_NAMES: frozenset[str] = frozenset({
+    "read_source_file",
+    "search_source_code",
+    "query_database",
+    "read_error_logs",
+    "get_llm_request_history",
+    "create_github_issue",
+    "get_mcp_server_status",
+    "reconnect_mcp_server",
+    "get_resolved_config",
+    "get_profile_config",
+    "get_system_info",
+})
+
+
 class TestToolDefinitions:
     def test_definitions_list_is_complete(self) -> None:
         tool_names = {t["function"]["name"] for t in ENGINEERING_TOOLS_DEFINITION}
-        expected = {
-            "read_source_file",
-            "search_source_code",
-            "query_database",
-            "read_error_logs",
-            "get_llm_request_history",
-            "create_github_issue",
-        }
-        assert tool_names == expected
+        assert tool_names == _ENGINEERING_TOOL_NAMES
 
     def test_tools_registered_in_available_functions(self) -> None:
-        expected_tools = [
-            "read_source_file",
-            "search_source_code",
-            "query_database",
-            "read_error_logs",
-            "get_llm_request_history",
-            "create_github_issue",
-        ]
-        for tool_name in expected_tools:
+        for tool_name in _ENGINEERING_TOOL_NAMES:
             assert tool_name in AVAILABLE_FUNCTIONS, (
                 f"{tool_name} not in AVAILABLE_FUNCTIONS"
             )
 
     def test_tools_in_tools_definition(self) -> None:
         all_tool_names = {t["function"]["name"] for t in TOOLS_DEFINITION}
-        expected_tools = [
-            "read_source_file",
-            "search_source_code",
-            "query_database",
-            "read_error_logs",
-            "get_llm_request_history",
-            "create_github_issue",
-        ]
-        for tool_name in expected_tools:
+        for tool_name in _ENGINEERING_TOOL_NAMES:
             assert tool_name in all_tool_names, f"{tool_name} not in TOOLS_DEFINITION"

--- a/tests/unit/tools/test_engineering_diagnostics.py
+++ b/tests/unit/tools/test_engineering_diagnostics.py
@@ -1,0 +1,332 @@
+"""Tests for engineer-profile diagnostic tools.
+
+Covers the MCP status / reconnect tools, resolved config / profile config
+inspection, and system info. Heavy mocking is used because these tools wrap
+runtime infrastructure (MCPToolsProvider, ProcessingService, AppConfig) which
+isn't trivially constructable in a unit test.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from family_assistant.tools.engineering import (
+    get_mcp_server_status,
+    get_profile_config,
+    get_resolved_config,
+    get_system_info,
+    reconnect_mcp_server,
+)
+from family_assistant.tools.mcp import MCPToolsProvider
+from family_assistant.tools.types import ToolExecutionContext
+
+
+@pytest.fixture
+def exec_context_with_db() -> ToolExecutionContext:
+    """Minimal execution context with a fake db dialect."""
+    db = Mock()
+    db.engine = Mock()
+    db.engine.dialect = Mock()
+    db.engine.dialect.name = "sqlite"
+    return ToolExecutionContext(
+        interface_type="test",
+        conversation_id="conv-1",
+        user_name="tester",
+        turn_id=None,
+        db_context=db,
+        processing_service=None,
+        clock=None,
+        home_assistant_client=None,
+        event_sources=None,
+        attachment_registry=None,
+        camera_backend=None,
+        timezone=ZoneInfo("UTC"),
+    )
+
+
+# --- get_system_info ---
+
+
+@pytest.mark.anyio
+async def test_get_system_info_returns_runtime_metadata(
+    exec_context_with_db: ToolExecutionContext,
+) -> None:
+    result = await get_system_info(exec_context_with_db)
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "python_version" in data
+    assert "platform" in data
+    assert data["database_dialect"] == "sqlite"
+
+
+@pytest.mark.anyio
+async def test_get_system_info_handles_missing_engine() -> None:
+    """If the db_context lacks an engine, dialect falls back to 'unknown'."""
+    db = Mock(spec=[])  # no `engine` attribute
+    ctx = ToolExecutionContext(
+        interface_type="test",
+        conversation_id="c",
+        user_name="u",
+        turn_id=None,
+        db_context=db,
+        processing_service=None,
+        clock=None,
+        home_assistant_client=None,
+        event_sources=None,
+        attachment_registry=None,
+        camera_backend=None,
+        timezone=ZoneInfo("UTC"),
+    )
+    result = await get_system_info(ctx)
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert data["database_dialect"] == "unknown"
+
+
+# --- MCP status / reconnect ---
+
+
+def _make_ctx_with_tools_provider(
+    tools_provider: Mock,
+) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        interface_type="test",
+        conversation_id="c",
+        user_name="u",
+        turn_id=None,
+        db_context=Mock(),
+        processing_service=None,
+        clock=None,
+        home_assistant_client=None,
+        event_sources=None,
+        attachment_registry=None,
+        camera_backend=None,
+        timezone=ZoneInfo("UTC"),
+        tools_provider=tools_provider,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_mcp_server_status_with_no_provider(
+    exec_context_with_db: ToolExecutionContext,
+) -> None:
+    """Without a tools_provider wired in, the tool reports a clear error
+    rather than silently pretending all servers are healthy."""
+    result = await get_mcp_server_status(exec_context_with_db)
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "error" in data
+    assert data["servers"] == {}
+
+
+@pytest.mark.anyio
+async def test_get_mcp_server_status_aggregates_statuses() -> None:
+    """When an MCPToolsProvider is reachable, the tool dumps its statuses
+    and computes a summary count."""
+    fake_provider = Mock(spec=MCPToolsProvider)
+    fake_provider.get_server_statuses.return_value = {
+        "code-execution": {
+            "status": "connected",
+            "transport": "stdio",
+            "tool_count": 3,
+            "tools": ["create_workspace", "execute_shell", "write_file"],
+            "session_active": True,
+            "command": "code-execution-mcp",
+            "args": [],
+            "url": None,
+        },
+        "broken": {
+            "status": "failed",
+            "transport": "sse",
+            "tool_count": 0,
+            "tools": [],
+            "session_active": False,
+            "command": None,
+            "args": [],
+            "url": "http://broken.invalid",
+        },
+    }
+
+    # Patch find_provider_by_type to return our fake provider regardless of
+    # the wrapped tools_provider passed in.
+    ctx = _make_ctx_with_tools_provider(fake_provider)
+
+    result = await get_mcp_server_status(ctx)
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert data["summary"] == {
+        "total": 2,
+        "connected": 1,
+        "failed": 1,
+        "cancelled": 0,
+        "pending": 0,
+    }
+    assert "code-execution" in data["servers"]
+    assert "broken" in data["servers"]
+
+
+@pytest.mark.anyio
+async def test_reconnect_mcp_server_unknown_id_returns_error() -> None:
+    fake_provider = Mock(spec=MCPToolsProvider)
+    fake_provider.reconnect_server = AsyncMock(side_effect=KeyError("nope"))
+    fake_provider.server_configs = {"a": {}, "b": {}}
+    fake_provider.get_server_statuses.return_value = {}
+
+    ctx = _make_ctx_with_tools_provider(fake_provider)
+    result = await reconnect_mcp_server(ctx, server_id="nope")
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "error" in data
+    assert data["configured_servers"] == ["a", "b"]
+
+
+@pytest.mark.anyio
+async def test_reconnect_mcp_server_success() -> None:
+    fake_provider = Mock(spec=MCPToolsProvider)
+    fake_provider.reconnect_server = AsyncMock(return_value=True)
+    fake_provider.server_configs = {"code-execution": {}}
+    fake_provider.get_server_statuses.return_value = {
+        "code-execution": {"status": "connected", "tool_count": 3},
+    }
+
+    ctx = _make_ctx_with_tools_provider(fake_provider)
+    result = await reconnect_mcp_server(ctx, server_id="code-execution")
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert data["success"] is True
+    assert data["server_id"] == "code-execution"
+    assert data["status"]["status"] == "connected"
+
+
+# --- get_resolved_config / get_profile_config ---
+
+
+def _ctx_with_app_config(app_config: Mock) -> ToolExecutionContext:
+    """Build a context whose processing_service.app_config is the given object."""
+    processing_service = Mock()
+    processing_service.app_config = app_config
+    return ToolExecutionContext(
+        interface_type="test",
+        conversation_id="c",
+        user_name="u",
+        turn_id=None,
+        db_context=Mock(),
+        processing_service=processing_service,
+        clock=None,
+        home_assistant_client=None,
+        event_sources=None,
+        attachment_registry=None,
+        camera_backend=None,
+        timezone=ZoneInfo("UTC"),
+    )
+
+
+@pytest.mark.anyio
+async def test_get_resolved_config_redacts_secrets_and_omits_profile_bodies() -> None:
+    fake_app_config = Mock()
+    fake_app_config.model_dump.return_value = {
+        "default_service_profile_id": "default_assistant",
+        "openai_api_key": "sk-secret-value",
+        "telegram_token": "telegram-secret",
+        "service_profiles": [
+            {"id": "default_assistant", "description": "Default"},
+            {"id": "engineer", "description": "Engineer"},
+        ],
+        "default_profile_settings": {"some": "data"},
+    }
+
+    ctx = _ctx_with_app_config(fake_app_config)
+    result = await get_resolved_config(ctx)
+    data = result.get_data()
+    assert isinstance(data, dict)
+    cfg = data["config"]
+    assert isinstance(cfg, dict)
+    assert cfg["openai_api_key"] == "[REDACTED]"
+    assert cfg["telegram_token"] == "[REDACTED]"
+    assert "service_profiles" not in cfg  # bodies omitted
+    assert "default_profile_settings" not in cfg
+    assert data["profile_ids"] == ["default_assistant", "engineer"]
+    assert data["profile_count"] == 2
+
+
+@pytest.mark.anyio
+async def test_get_resolved_config_without_processing_service(
+    exec_context_with_db: ToolExecutionContext,
+) -> None:
+    result = await get_resolved_config(exec_context_with_db)
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "error" in data
+
+
+@pytest.mark.anyio
+async def test_get_profile_config_lists_when_id_omitted() -> None:
+    fake_default_settings = Mock()
+    fake_default_settings.model_dump.return_value = {"description": "default"}
+    fake_default_settings.operator_tools_policy = None
+    fake_default_settings.operator_mcp_server_ids = []
+
+    p1 = Mock()
+    p1.id = "default_assistant"
+    p1.description = "Default"
+    p2 = Mock()
+    p2.id = "engineer"
+    p2.description = "Engineer"
+
+    fake_app_config = Mock()
+    fake_app_config.service_profiles = [p1, p2]
+    fake_app_config.default_profile_settings = fake_default_settings
+    fake_app_config.default_service_profile_id = "default_assistant"
+
+    ctx = _ctx_with_app_config(fake_app_config)
+    result = await get_profile_config(ctx)
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert data["profile_ids"] == ["default_assistant", "engineer"]
+    assert data["default_service_profile_id"] == "default_assistant"
+    assert "default_profile_settings" in data
+
+
+@pytest.mark.anyio
+async def test_get_profile_config_returns_specific_profile() -> None:
+    matched = Mock()
+    matched.id = "engineer"
+    matched.description = "Engineer profile"
+    matched.model_dump.return_value = {
+        "id": "engineer",
+        "description": "Engineer profile",
+        "processing_config": {"openai_api_key": "leak-me"},
+    }
+    matched.operator_tools_policy = None
+    matched.operator_mcp_server_ids = []
+
+    fake_app_config = Mock()
+    fake_app_config.service_profiles = [matched]
+
+    ctx = _ctx_with_app_config(fake_app_config)
+    result = await get_profile_config(ctx, profile_id="engineer")
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert data["id"] == "engineer"
+    assert data["description"] == "Engineer profile"
+    cfg = data["config"]
+    assert isinstance(cfg, dict)
+    assert cfg["processing_config"]["openai_api_key"] == "[REDACTED]"
+
+
+@pytest.mark.anyio
+async def test_get_profile_config_unknown_id_returns_error() -> None:
+    p1 = Mock()
+    p1.id = "default_assistant"
+    fake_app_config = Mock()
+    fake_app_config.service_profiles = [p1]
+
+    ctx = _ctx_with_app_config(fake_app_config)
+    result = await get_profile_config(ctx, profile_id="does_not_exist")
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "error" in data
+    assert data["profile_ids"] == ["default_assistant"]

--- a/tests/unit/tools/test_mcp_tool_filtering.py
+++ b/tests/unit/tools/test_mcp_tool_filtering.py
@@ -46,6 +46,67 @@ async def test_mcp_provider_exposes_tool_to_server_mapping() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_server_statuses_returns_per_server_diagnostics() -> None:
+    """get_server_statuses produces a snapshot suitable for the engineer profile.
+
+    Includes status, transport, command/url, session_active, and the tool
+    list for each configured server. Tokens must not leak into the snapshot.
+    """
+    mcp_configs: dict[str, MCPServerConfig] = {
+        "code-execution": {"transport": "stdio", "command": "code-exec"},
+        "remote-tools": {
+            "transport": "sse",
+            "url": "https://example.com/mcp",
+            "token": "$REMOTE_TOKEN",
+        },
+    }
+
+    provider = MCPToolsProvider(mcp_configs)
+    # Simulate two states: code-execution connected with two tools, remote-tools failed.
+    provider._server_statuses["code-execution"] = MCP_SERVER_STATUS_CONNECTED
+    provider._server_statuses["remote-tools"] = MCP_SERVER_STATUS_FAILED
+    provider._tool_map = {
+        "create_workspace": "code-execution",
+        "execute_shell": "code-execution",
+    }
+    provider._sessions = {"code-execution": cast("ClientSession", object())}
+
+    statuses = provider.get_server_statuses()
+
+    assert set(statuses.keys()) == {"code-execution", "remote-tools"}
+
+    code_exec = statuses["code-execution"]
+    assert code_exec["status"] == MCP_SERVER_STATUS_CONNECTED
+    assert code_exec["transport"] == "stdio"
+    assert code_exec["command"] == "code-exec"
+    assert code_exec["url"] is None
+    assert code_exec["session_active"] is True
+    assert code_exec["tool_count"] == 2
+    assert code_exec["tools"] == ["create_workspace", "execute_shell"]
+
+    remote = statuses["remote-tools"]
+    assert remote["status"] == MCP_SERVER_STATUS_FAILED
+    assert remote["transport"] == "sse"
+    assert remote["url"] == "https://example.com/mcp"
+    assert remote["session_active"] is False
+    assert remote["tool_count"] == 0
+    assert remote["tools"] == []
+    assert "token" not in remote
+
+
+@pytest.mark.asyncio
+async def test_reconnect_server_unknown_id_raises_key_error() -> None:
+    """reconnect_server raises KeyError for unknown server ids so the
+    engineer-profile tool can surface a clear error instead of silently
+    no-oping."""
+    provider = MCPToolsProvider({
+        "server1": {"transport": "stdio", "command": "echo"},
+    })
+    with pytest.raises(KeyError):
+        await provider.reconnect_server("does-not-exist")
+
+
+@pytest.mark.asyncio
 async def test_filtered_tools_provider_with_mcp_filtering() -> None:
     """Test that FilteredToolsProvider correctly filters tools including MCP tools."""
 


### PR DESCRIPTION
When a stored script referenced MCP tool names like create_workspace and
execute_shell, the script validator rejected them because the live tool
list returned by tools_provider didn't include them — most often because
the underlying MCP server (e.g. code-execution) wasn't connected at
validation time. From the chat there was no way to confirm that diagnosis
without leaving the session.

This adds five engineer-profile tools:
- get_mcp_server_status: per-server status, transport, command/url,
  session activity, and the tool list each server currently exposes
- reconnect_mcp_server: confirmation-gated reconnect for a single server
- get_resolved_config: live AppConfig (profile bodies omitted) with
  secrets redacted
- get_profile_config: profile dump (one or all) with secrets redacted
- get_system_info: Python/platform/db dialect (mirrors the system_info
  block of /api/diagnostics/export, which is the only piece that wasn't
  already covered by read_error_logs / get_llm_request_history /
  get_message_history)

Plumbing:
- MCPToolsProvider gains get_server_statuses() returning a typed
  MCPServerStatus snapshot, plus a public reconnect_server() wrapper.
- The redaction helpers from web/routers/debug_api.py move to a shared
  family_assistant.config_inspection module so engineering tools and
  /api/debug/profiles share one source of truth (the previous names are
  re-exported from debug_api for backward compatibility).
- defaults.yaml engineer profile gets the new tools in
  enable_local_tools, tools_policy.rules, and confirm_tools, and the
  system prompt mentions the new capabilities.

Tests cover the new MCPToolsProvider methods (status snapshot omits
tokens; reconnect with unknown id raises KeyError) and each new
engineer tool's success and error paths.