### PR TITLE
Include date in Today/Tomorrow calendar event labels

### DIFF
--- a/src/family_assistant/calendar_integration.py
+++ b/src/family_assistant/calendar_integration.py
@@ -54,22 +54,24 @@ def format_datetime_or_date(
             if is_end:
                 display_date -= timedelta(days=1)
 
+            date_str = display_date.strftime("%b %d")
             if display_date == today_local:
-                return "Today"
+                return f"Today ({date_str})"
             if display_date == tomorrow_local:
-                return "Tomorrow"
-            return display_date.strftime("%b %d")
+                return f"Tomorrow ({date_str})"
+            return date_str
 
         # Convert event time to local timezone for comparison and display
         dt_local = dt_obj.astimezone(local_tz)
-        # Example: "Today 14:30", "Tomorrow 09:00", "Apr 21 10:00"
+        # Example: "Today (Apr 21) 14:30", "Tomorrow (Apr 22) 09:00", "Apr 23 10:00"
 
+        date_str = dt_local.strftime("%b %d")
         if dt_local.date() == today_local:
-            day_str = "Today"
+            day_str = f"Today ({date_str})"
         elif dt_local.date() == tomorrow_local:
-            day_str = "Tomorrow"
+            day_str = f"Tomorrow ({date_str})"
         else:
-            day_str = dt_local.strftime("%b %d")  # e.g., Apr 21
+            day_str = date_str  # e.g., Apr 21
 
         # For end times exactly at midnight, display as end of previous day if makes sense
         if is_end and dt_obj.time() == time(0, 0):
@@ -87,11 +89,12 @@ def format_datetime_or_date(
         # Adjust end date for display: CalDAV often stores end date as the day *after*
         display_date = dt_obj - timedelta(days=1) if is_end else dt_obj
 
+        date_str = display_date.strftime("%b %d")
         if display_date == today_local:
-            return "Today"
+            return f"Today ({date_str})"
         if display_date == tomorrow_local:
-            return "Tomorrow"
-        return display_date.strftime("%b %d")  # e.g., Apr 21
+            return f"Tomorrow ({date_str})"
+        return date_str  # e.g., Apr 21
     # Fallback for other types, though dt_obj should only be datetime or date
     # Based on type hints, this path should not be reached if input is correct.
     # However, to satisfy linters about all paths returning, and for robustness:

--- a/tests/functional/calendar/test_integration.py
+++ b/tests/functional/calendar/test_integration.py
@@ -323,7 +323,7 @@ async def test_add_event_and_verify_in_system_prompt(
         f"Generated aggregated context for verification:\n{aggregated_context_str}"
     )
 
-    expected_time_str_in_prompt = "Tomorrow 10:00"
+    expected_time_str_in_prompt = f"Tomorrow ({start_dt_local.strftime('%b %d')}) 10:00"
     assert event_summary in aggregated_context_str, (
         "Event summary not found in aggregated context string."
     )


### PR DESCRIPTION
The system prompt previously labeled events as just "Today" or
"Tomorrow", which led the assistant to occasionally attribute events
from other dates to the wrong day. Embed the actual date alongside the
label (e.g. "Tomorrow (May 12) 09:00") so the date is unambiguous to
the model.

https://claude.ai/code/session_01MrpxkAuoGkChU1qQoFUGra