### PR TITLE
Wrap gemini and codex CLIs in the same venv-loading wrapper as claude

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -116,7 +116,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # Install development Node.js packages
 RUN --mount=type=cache,target=/home/claude/.npm,sharing=locked,uid=1001,gid=1001 \
-    npm install -g @google/gemini-cli@nightly
+    npm install -g @google/gemini-cli@nightly @openai/codex
 
 # Install Python development tools
 RUN --mount=type=cache,target=/home/claude/.cache/uv,sharing=locked,uid=1001,gid=1001 \
@@ -131,16 +131,24 @@ COPY .devcontainer/oneshot-config /opt/oneshot-config/
 COPY .devcontainer/setup-workspace.sh /usr/local/bin/
 COPY .devcontainer/setup-git-auth.sh /usr/local/bin/
 COPY .devcontainer/gh-wrapper /usr/local/bin/gh
+COPY .devcontainer/wrapper-common.sh /usr/local/bin/wrapper-common.sh
 COPY .devcontainer/claude-wrapper.sh /usr/local/bin/claude-wrapper
+COPY .devcontainer/gemini-wrapper.sh /usr/local/bin/gemini-wrapper
+COPY .devcontainer/codex-wrapper.sh /usr/local/bin/codex-wrapper
 COPY .devcontainer/throttle_backspaces.py /usr/local/bin/
 COPY .devcontainer/merge-settings.py /usr/local/bin/
 RUN chmod +x /usr/local/bin/setup-workspace.sh \
                /usr/local/bin/setup-git-auth.sh \
                /usr/local/bin/gh \
+               /usr/local/bin/wrapper-common.sh \
                /usr/local/bin/claude-wrapper \
+               /usr/local/bin/gemini-wrapper \
+               /usr/local/bin/codex-wrapper \
                /usr/local/bin/throttle_backspaces.py \
                /usr/local/bin/merge-settings.py && \
-    ln -sf /usr/local/bin/claude-wrapper /usr/local/bin/claude
+    ln -sf /usr/local/bin/claude-wrapper /usr/local/bin/claude && \
+    ln -sf /usr/local/bin/gemini-wrapper /usr/local/bin/gemini && \
+    ln -sf /usr/local/bin/codex-wrapper /usr/local/bin/codex
 
 # Final user and entrypoint
 USER claude

--- a/.devcontainer/claude-wrapper.sh
+++ b/.devcontainer/claude-wrapper.sh
@@ -1,53 +1,10 @@
 #!/bin/bash
 # Wrapper script to ensure virtual environment is activated when running claude
 
-# Auto-pull latest changes
-if [ -d "/workspace/main/.git" ]; then
-    # Save current commit to restore if needed
-    ORIG_HEAD=$(git rev-parse HEAD 2>/dev/null || echo "")
-    
-    # Fetch first to minimize critical period
-    if ! git fetch origin >/dev/null 2>&1; then
-        echo "⚠️  Couldn't fetch from remote (network issue or auth problem)"
-    else
-        # Check if we're behind remote
-        LOCAL=$(git rev-parse @ 2>/dev/null || echo "")
-        REMOTE=$(git rev-parse @{u} 2>/dev/null || echo "")
-        
-        if [ -z "$LOCAL" ] || [ -z "$REMOTE" ]; then
-            echo "⚠️  Git repository not properly configured"
-        elif [ "$LOCAL" != "$REMOTE" ]; then
-            # Stash any local changes
-            stashed=false
-            if ! git diff --quiet || ! git diff --cached --quiet; then
-                git stash push -q -m "auto-stash-$$"
-                stashed=true
-            fi
-            
-            # Try to pull with rebase
-            pull_output=$(git pull --rebase 2>&1)
-            pull_result=$?
-            
-            if [ $pull_result -ne 0 ]; then
-                # If rebase fails, abort and restore
-                git rebase --abort 2>/dev/null || true
-                echo "⚠️  Couldn't pull latest changes: $(echo "$pull_output" | grep -v "^From " | head -1)"
-            fi
-            
-            # Restore stashed changes
-            if [ "$stashed" = true ]; then
-                if ! git stash pop -q 2>/dev/null; then
-                    # If stash pop fails, reset to original state
-                    if [ -n "$ORIG_HEAD" ]; then
-                        git reset --hard "$ORIG_HEAD" >/dev/null 2>&1
-                        git stash pop -q 2>/dev/null || true
-                    fi
-                    echo "⚠️  Update skipped due to conflicts with local changes"
-                fi
-            fi
-        fi
-    fi
-fi
+# shellcheck disable=SC1091
+source /usr/local/bin/wrapper-common.sh
+
+wrapper_common_setup
 
 # Set up Claude settings for this worktree if not already configured
 if [ ! -f ".claude/settings.local.json" ]; then
@@ -70,40 +27,12 @@ if [ -f "/home/claude/.claude/CLAUDE.local.md" ] && [ ! -f ".claude/CLAUDE.local
     cp /home/claude/.claude/CLAUDE.local.md .claude/
 fi
 
-# Set up Python virtual environment if this is a Python project
-if [ -f "pyproject.toml" ]; then
-    # Create virtual environment if it doesn't exist or is invalid
-    if [ ! -d ".venv" ] || [ ! -f ".venv/bin/python" ]; then
-        echo "Creating virtual environment..."
-        rm -rf .venv
-        uv venv .venv
-
-        # Activate and install dependencies
-        source .venv/bin/activate
-        echo "Installing Python dependencies..."
-        uv sync --extra dev
-        uv pip install poethepoet pytest-xdist
-    else
-        # Just activate existing venv
-        source .venv/bin/activate
-    fi
-fi
-
-# Install frontend dependencies if needed
-if [ -f "frontend/package.json" ] && [ ! -d "frontend/node_modules" ]; then
-    echo "Installing frontend dependencies..."
-    npm install --prefix frontend
-fi
-
 # Update Claude plugin marketplaces (fetches latest from GitHub)
 echo "🔄 Updating Claude plugin marketplaces..."
 /home/claude/.npm-global/bin/claude plugin marketplace update >/dev/null 2>&1 || {
     echo "⚠️  Warning: Failed to update plugin marketplaces"
 }
 
-export BASH_DEFAULT_TIMEOUT_MS=300000
-export BASH_MAX_TIMEOUT_MS=3600000
 export CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1
 
 exec /home/claude/.npm-global/bin/claude "$@"
-

--- a/.devcontainer/codex-wrapper.sh
+++ b/.devcontainer/codex-wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Wrapper script to ensure virtual environment is activated when running codex
+
+# shellcheck disable=SC1091
+source /usr/local/bin/wrapper-common.sh
+
+wrapper_common_setup
+
+exec /home/claude/.npm-global/bin/codex "$@"

--- a/.devcontainer/gemini-wrapper.sh
+++ b/.devcontainer/gemini-wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Wrapper script to ensure virtual environment is activated when running gemini
+
+# shellcheck disable=SC1091
+source /usr/local/bin/wrapper-common.sh
+
+wrapper_common_setup
+
+exec /home/claude/.npm-global/bin/gemini "$@"

--- a/.devcontainer/setup-workspace.sh
+++ b/.devcontainer/setup-workspace.sh
@@ -75,6 +75,7 @@ if [ "$HOME_IS_MOUNTED" = "true" ] && ! which claude >/dev/null 2>&1; then
     # Install tools
     npm install -g @anthropic-ai/claude-code
     npm install -g @google/gemini-cli@nightly
+    npm install -g @openai/codex
     npm install -g playwright
 
     # Install Playwright browsers

--- a/.devcontainer/setup-workspace.sh
+++ b/.devcontainer/setup-workspace.sh
@@ -64,36 +64,48 @@ if mountpoint -q /home/claude 2>/dev/null || [ -n "$(findmnt -n -o SOURCE --targ
     HOME_IS_MOUNTED=true
 fi
 
-# Install npm tools if they don't exist (e.g., when home is mounted)
-if [ "$HOME_IS_MOUNTED" = "true" ] && ! which claude >/dev/null 2>&1; then
-    echo "Installing npm tools in mounted home directory..."
-    
-    # Ensure npm global directory exists
-    mkdir -p /home/claude/.npm-global
+# Install npm tools individually if missing (e.g., when home is mounted from an older image).
+# We check each binary in /home/claude/.npm-global/bin directly: relying on `which claude`
+# would falsely succeed because the wrapper symlink in /usr/local/bin always exists.
+if [ "$HOME_IS_MOUNTED" = "true" ]; then
+    NPM_BIN_DIR=/home/claude/.npm-global/bin
+    mkdir -p "$NPM_BIN_DIR"
     export NPM_CONFIG_PREFIX=/home/claude/.npm-global
-    
-    # Install tools
-    npm install -g @anthropic-ai/claude-code
-    npm install -g @google/gemini-cli@nightly
-    npm install -g @openai/codex
-    npm install -g playwright
 
-    # Install Playwright browsers
-    if [ -n "$PLAYWRIGHT_BROWSERS_PATH" ]; then
-        npx playwright install chromium
+    installed_any=false
+    install_npm_tool() {
+        local binary="$1"
+        local package="$2"
+        if [ ! -x "$NPM_BIN_DIR/$binary" ]; then
+            echo "Installing $package..."
+            npm install -g "$package"
+            installed_any=true
+        fi
+    }
+
+    install_npm_tool claude "@anthropic-ai/claude-code"
+    install_npm_tool gemini "@google/gemini-cli@nightly"
+    install_npm_tool codex "@openai/codex"
+    install_npm_tool playwright playwright
+
+    if [ "$installed_any" = "true" ]; then
+        # Install Playwright browsers
+        if [ -n "$PLAYWRIGHT_BROWSERS_PATH" ]; then
+            npx playwright install chromium
+        fi
+
+        # Install LLM tools using uv (idempotent: uv tool install is a no-op if already present)
+        export PATH="/home/claude/.local/bin:$PATH"
+        uv tool install --with llm-gemini --with llm-openrouter --with llm-fragments-github llm
+
+        # Ensure proper ownership of installed tools (avoid recursive chown on large dirs)
+        # Only chown the bin directory and key files, not the entire node_modules
+        chown claude:claude /home/claude/.npm-global
+        chown -R claude:claude /home/claude/.npm-global/bin
+        [ -d "/home/claude/.local" ] && chown -R claude:claude /home/claude/.local
+
+        echo "npm tools installation complete"
     fi
-    
-    # Install LLM tools using uv
-    export PATH="/home/claude/.local/bin:$PATH"
-    uv tool install --with llm-gemini --with llm-openrouter --with llm-fragments-github llm
-    
-    # Ensure proper ownership of installed tools (avoid recursive chown on large dirs)
-    # Only chown the bin directory and key files, not the entire node_modules
-    chown claude:claude /home/claude/.npm-global
-    chown -R claude:claude /home/claude/.npm-global/bin
-    [ -d "/home/claude/.local" ] && chown -R claude:claude /home/claude/.local
-    
-    echo "npm tools installation complete"
 fi
 
 # If running as root, ensure proper ownership later

--- a/.devcontainer/wrapper-common.sh
+++ b/.devcontainer/wrapper-common.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Shared setup for dev-container CLI wrappers (claude, gemini, codex).
+# Source this script from a tool-specific wrapper; it performs the shared
+# workspace setup (git auto-pull, Python venv activation, frontend deps)
+# so every tool inherits the same environment.
+
+# Auto-pull latest changes
+wrapper_common_auto_pull() {
+    [ -d ".git" ] || return 0
+
+    local orig_head
+    orig_head=$(git rev-parse HEAD 2>/dev/null || echo "")
+
+    if ! git fetch origin >/dev/null 2>&1; then
+        echo "⚠️  Couldn't fetch from remote (network issue or auth problem)"
+        return 0
+    fi
+
+    local local_rev remote_rev
+    local_rev=$(git rev-parse @ 2>/dev/null || echo "")
+    # shellcheck disable=SC1083  # @{u} is git upstream syntax, not shell brace expansion
+    remote_rev=$(git rev-parse @{u} 2>/dev/null || echo "")
+
+    if [ -z "$local_rev" ] || [ -z "$remote_rev" ]; then
+        echo "⚠️  Git repository not properly configured"
+        return 0
+    fi
+
+    if [ "$local_rev" = "$remote_rev" ]; then
+        return 0
+    fi
+
+    local stashed=false
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        git stash push -q -m "auto-stash-$$"
+        stashed=true
+    fi
+
+    local pull_output pull_result
+    pull_output=$(git pull --rebase 2>&1)
+    pull_result=$?
+
+    if [ $pull_result -ne 0 ]; then
+        git rebase --abort 2>/dev/null || true
+        echo "⚠️  Couldn't pull latest changes: $(echo "$pull_output" | grep -v "^From " | head -1)"
+    fi
+
+    if [ "$stashed" = true ]; then
+        if ! git stash pop -q 2>/dev/null; then
+            if [ -n "$orig_head" ]; then
+                git reset --hard "$orig_head" >/dev/null 2>&1
+                git stash pop -q 2>/dev/null || true
+            fi
+            echo "⚠️  Update skipped due to conflicts with local changes"
+        fi
+    fi
+}
+
+# Set up & activate Python virtual environment if this is a Python project.
+# Exports the activated venv so the exec'd tool inherits it.
+wrapper_common_activate_venv() {
+    [ -f "pyproject.toml" ] || return 0
+
+    if [ ! -d ".venv" ] || [ ! -f ".venv/bin/python" ]; then
+        echo "Creating virtual environment..."
+        rm -rf .venv
+        uv venv .venv
+
+        # shellcheck disable=SC1091
+        source .venv/bin/activate
+        echo "Installing Python dependencies..."
+        uv sync --extra dev
+        uv pip install poethepoet pytest-xdist
+    else
+        # shellcheck disable=SC1091
+        source .venv/bin/activate
+    fi
+}
+
+# Install frontend dependencies if needed.
+wrapper_common_install_frontend() {
+    if [ -f "frontend/package.json" ] && [ ! -d "frontend/node_modules" ]; then
+        echo "Installing frontend dependencies..."
+        npm install --prefix frontend
+    fi
+}
+
+# Bash timeout defaults shared by all wrapped CLIs.
+wrapper_common_export_env() {
+    export BASH_DEFAULT_TIMEOUT_MS=300000
+    export BASH_MAX_TIMEOUT_MS=3600000
+}
+
+# Run the full shared setup pipeline.
+wrapper_common_setup() {
+    wrapper_common_auto_pull
+    wrapper_common_activate_venv
+    wrapper_common_install_frontend
+    wrapper_common_export_env
+}

--- a/.devcontainer/wrapper-common.sh
+++ b/.devcontainer/wrapper-common.sh
@@ -6,7 +6,7 @@
 
 # Auto-pull latest changes
 wrapper_common_auto_pull() {
-    [ -d ".git" ] || return 0
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
 
     local orig_head
     orig_head=$(git rev-parse HEAD 2>/dev/null || echo "")
@@ -98,3 +98,4 @@ wrapper_common_setup() {
     wrapper_common_install_frontend
     wrapper_common_export_env
 }
+


### PR DESCRIPTION
Extract the shared workspace setup (git auto-pull, Python venv
activation, frontend deps) from claude-wrapper.sh into a reusable
wrapper-common.sh, and add gemini-wrapper.sh and codex-wrapper.sh
that source it. So gemini and codex now activate .venv automatically
the same way claude does. Also installs @openai/codex in the dev
container alongside the existing gemini-cli.