### PR TITLE
[codex] Reduce runtime image vulnerability surface

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -91,7 +91,31 @@ USER root
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     --mount=type=cache,target=/root/.npm,sharing=locked \
-    npx --yes playwright@1.55.0 install-deps chromium && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        libasound2t64 \
+        libatk-bridge2.0-0 \
+        libatk1.0-0 \
+        libatspi2.0-0 \
+        libcairo2 \
+        libcups2 \
+        libdbus-1-3 \
+        libdrm2 \
+        libgbm1 \
+        libglib2.0-0 \
+        libnspr4 \
+        libnss3 \
+        libpango-1.0-0 \
+        libx11-6 \
+        libxcb1 \
+        libxcomposite1 \
+        libxdamage1 \
+        libxext6 \
+        libxfixes3 \
+        libxkbcommon0 \
+        libxrandr2 \
+        fonts-liberation \
+        fonts-noto-color-emoji \
+        fonts-unifont && \
     npx --yes playwright@1.55.0 install chromium
 
 # Python venv with shared Playwright browsers

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN groupadd -r -g 1001 appuser && useradd -r -u 1001 -g appuser -m -d /home/app
 # Install system dependencies: npm for Node.js MCP servers and frontend build
 # Using --mount for caching apt downloads
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     # Add CA certificates for HTTPS communication
     ca-certificates \
     curl \
@@ -117,7 +117,7 @@ RUN uv pip install "rebrowser-playwright>=1.52.0" "markitdown[html]>=0.1.0"
 # Note: We install deps manually to handle renamed packages in newer Debian
 # (ttf-ubuntu-font-family -> fonts-ubuntu, ttf-unifont -> fonts-unifont)
 USER root
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     libasound2 \
     libatk-bridge2.0-0 \
     libatk1.0-0 \
@@ -186,6 +186,13 @@ COPY --chown=appuser:appuser . .
 # This completes the installation by adding the project itself.
 USER appuser
 RUN uv sync --extra local-embeddings
+
+# The production app serves prebuilt assets from src/family_assistant/static/dist.
+# Keeping the frontend workspace in the runtime image also keeps npm lockfiles and
+# build-only dependencies visible to vulnerability scanners.
+USER root
+RUN rm -rf /app/frontend
+USER appuser
 
 # --- Runtime Configuration ---
 # Expose the port the web server listens on


### PR DESCRIPTION
## Summary

Updates the production image build to reduce packages and metadata that Trivy reports in the running image:

- run Debian package upgrades before installing apt dependencies in both apt layers
- remove `/app/frontend` after the Vite build because production serves the built assets from `src/family_assistant/static/dist`

## Why

The live Trivy report for `ghcr.io/werdnum/family-assistant` includes Debian packages with fixed versions, plus npm build/development dependencies from the frontend workspace. This image is single-stage, so build-only frontend files and lockfiles remain visible in the runtime filesystem unless explicitly removed.

Removing the frontend workspace keeps the built static assets, while dropping npm lockfiles and build-only dependencies from the production image. The apt upgrade step lets rebuilds pick up fixed Debian packages even when the base image tag itself has not changed.

I deliberately did not include a broad `uv lock --upgrade` in this PR; that resolver update touched thousands of dependency lines and several large framework/library versions, which is too much risk for this narrow image-hardening pass.

## Validation

- `git diff --check -- Dockerfile`
- `UV_CACHE_DIR=/tmp/codex-uv-cache PRE_COMMIT_HOME=/tmp/codex-pre-commit-cache uvx pre-commit run --files Dockerfile`

Note: I could not run a local Docker build in this workspace because there is no Docker/containerd daemon available.