### PR TITLE
Add Antigravity CLI (agy) to dev container image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -142,6 +142,9 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 RUN --mount=type=cache,target=/home/claude/.npm,sharing=locked,uid=1001,gid=1001 \
     npm install -g @google/gemini-cli@nightly @openai/codex
 
+# Install Antigravity CLI (agy) - installs to /home/claude/.local/bin/agy
+RUN curl -fsSL https://antigravity.google/cli/install.sh | bash
+
 # Install Python development tools
 RUN --mount=type=cache,target=/home/claude/.cache/uv,sharing=locked,uid=1001,gid=1001 \
     uv tool install --with llm-gemini --with llm-openrouter --with llm-fragments-github llm && \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -41,7 +41,9 @@ separation of concerns:
 │ - Dev tools:      │    │ - Python test deps         │
 │   * claude-code   │    │ - NO dev tools (smaller!)  │
 │   * gemini-cli    │    │                            │
-│   * llm           │    │ Used by: CI workflows      │
+│   * codex         │    │ Used by: CI workflows      │
+│   * agy           │    │                            │
+│   * llm           │    │                            │
 │   * claudecodeui  │    │                            │
 │                   │    │                            │
 │ Used by: devs     │    │                            │


### PR DESCRIPTION
Installs the official Antigravity CLI via the upstream install.sh so
it is available alongside claude-code, gemini-cli, and codex in the
developer image. The binary lands in /home/claude/.local/bin/agy,
which is already on PATH.