### PR TITLE
Convert LaTeX math markup in assistant replies to Unicode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -450,5 +450,6 @@ telegram-bot-api-mock = { git = "https://github.com/werdnum/telegram-bot-api-moc
 
 [dependency-groups]
 dev = [
+    "hypothesis>=6.152.9",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ dev = [
     "pytest-recording>=0.13.0", # VCR.py integration for pytest
     "pytest-xdist>=3.8.0", # Parallel test execution
     "pytest-rerunfailures>=16.0.1", # Enable @pytest.mark.flaky reruns in CI
+    "hypothesis>=6.152.9", # Property-based testing
     "vcrpy>=7.0.0", # HTTP record/replay for testing - v7 fixes urllib3 conflicts
     "aiosqlite",
     "assertpy>=1.1", # Add assertpy
@@ -447,9 +448,4 @@ explicit = true
 [tool.uv.sources]
 torch = { index = "torch-cpu" }
 telegram-bot-api-mock = { git = "https://github.com/werdnum/telegram-bot-api-mock" }
-
-[dependency-groups]
-dev = [
-    "hypothesis>=6.152.9",
-]
 

--- a/src/family_assistant/processing/service.py
+++ b/src/family_assistant/processing/service.py
@@ -23,6 +23,7 @@ from family_assistant.llm.messages import (
     UserMessage,
 )
 from family_assistant.utils.clock import Clock, SystemClock
+from family_assistant.utils.text_normalization import normalize_latex_to_unicode
 
 from .attachments import AttachmentProcessor
 from .context import ContextPreparer
@@ -740,6 +741,9 @@ class ProcessingService:
 
             if generated_turn_messages:
                 for turn_msg in generated_turn_messages:
+                    if isinstance(turn_msg, AssistantMessage) and turn_msg.content:
+                        turn_msg.content = normalize_latex_to_unicode(turn_msg.content)
+
                     reasoning_info_for_msg = (
                         final_reasoning_info
                         if isinstance(turn_msg, AssistantMessage)
@@ -894,6 +898,13 @@ class ProcessingService:
 
                         # Save messages as they're generated
                         if stream_msg is not None:
+                            if (
+                                isinstance(stream_msg, AssistantMessage)
+                                and stream_msg.content
+                            ):
+                                stream_msg.content = normalize_latex_to_unicode(
+                                    stream_msg.content
+                                )
                             reasoning_info_for_stream = (
                                 event.metadata.get("reasoning_info")
                                 if isinstance(stream_msg, AssistantMessage)

--- a/src/family_assistant/processing/service.py
+++ b/src/family_assistant/processing/service.py
@@ -741,7 +741,15 @@ class ProcessingService:
 
             if generated_turn_messages:
                 for turn_msg in generated_turn_messages:
-                    if isinstance(turn_msg, AssistantMessage) and turn_msg.content:
+                    if (
+                        isinstance(turn_msg, AssistantMessage)
+                        and turn_msg.content
+                        and not turn_msg.tool_calls
+                    ):
+                        # Skip messages that carry tool calls: their content
+                        # may be cryptographically tied to a Google thought
+                        # signature (see ContextPreparer.format_history) and
+                        # rewriting it would break replay continuity.
                         turn_msg.content = normalize_latex_to_unicode(turn_msg.content)
 
                     reasoning_info_for_msg = (
@@ -901,7 +909,12 @@ class ProcessingService:
                             if (
                                 isinstance(stream_msg, AssistantMessage)
                                 and stream_msg.content
+                                and not stream_msg.tool_calls
                             ):
+                                # Skip messages that carry tool calls: see
+                                # the matching branch in
+                                # handle_chat_interaction for the
+                                # thought-signature rationale.
                                 stream_msg.content = normalize_latex_to_unicode(
                                     stream_msg.content
                                 )

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -256,7 +256,7 @@ def _last_unmatched(text: str, marker: str, *, line_scoped: bool) -> int:
     """Return the position of the last unmatched ``marker`` occurrence.
 
     ``line_scoped`` resets the open/close state at every newline (matches
-    Markdown inline conventions for ``$`` and inline backticks).
+    Markdown inline conventions for inline backticks).
     """
     open_pos = -1
     in_span = False
@@ -275,6 +275,57 @@ def _last_unmatched(text: str, marker: str, *, line_scoped: bool) -> int:
                 in_span = True
                 open_pos = i
     return open_pos if in_span else -1
+
+
+# Matches a literal ``$`` that's followed by ``\letters`` (a candidate inline
+# math opener). The negative lookbehind rejects escaped ``\$``, and the
+# lookahead requires the content to start with a backslash command -- the same
+# rule ``_INLINE_DOLLAR_MATH_RE`` enforces for closed spans.
+_INLINE_MATH_OPENER_RE = re.compile(r"(?<!\\)\$(?=\\[a-zA-Z])")
+
+
+def _last_unclosed_inline_math_dollar(text: str) -> int:
+    """Return the position of the last ``$`` that opens an unclosed math span.
+
+    Unlike a naive toggle, this treats a ``$`` as a math delimiter only when
+    it is immediately followed by a ``\\command`` (matching the production
+    inline-math rule). Currency mentions like ``$5`` are not paired with a
+    later ``$\\command`` opener, so streamed text like
+    ``"cost $5 and $\\alpha$ end"`` is split correctly.
+    """
+    # Closed inline math spans found by the production regex -- positions
+    # inside these are safe (the closing ``$`` is already paired).
+    closed_ranges = [
+        (m.start(), m.end()) for m in _INLINE_DOLLAR_MATH_RE.finditer(text)
+    ]
+
+    def is_closed(pos: int) -> bool:
+        return any(start <= pos < end for start, end in closed_ranges)
+
+    last_open = -1
+    for opener_match in _INLINE_MATH_OPENER_RE.finditer(text):
+        pos = opener_match.start()
+        if is_closed(pos):
+            continue
+        # An opener with no closing ``$`` before EOL is the boundary we care
+        # about. Look for the next unescaped ``$`` on the same line.
+        i = pos + 1
+        end = text.find("\n", i)
+        line_end = len(text) if end < 0 else end
+        closer_pos = -1
+        j = i
+        while j < line_end:
+            ch = text[j]
+            if ch == "\\" and j + 1 < line_end:
+                j += 2
+                continue
+            if ch == "$":
+                closer_pos = j
+                break
+            j += 1
+        if closer_pos == -1:
+            last_open = pos
+    return last_open
 
 
 def _streaming_safe_split(buffer: str) -> int:
@@ -301,7 +352,7 @@ def _streaming_safe_split(buffer: str) -> int:
     if bracket and r"\]" not in bracket.group(0):
         candidates.append(bracket.start())
 
-    dollar = _last_unmatched(buffer, "$", line_scoped=True)
+    dollar = _last_unclosed_inline_math_dollar(buffer)
     if dollar >= 0:
         candidates.append(dollar)
 

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -205,10 +205,11 @@ def _strip_delims(match: re.Match[str]) -> str:
 
 # Markdown code spans whose contents must be preserved verbatim. CommonMark
 # allows code spans to be delimited by any number of backticks; the closing
-# string must have the same count. ``(`+)([\s\S]*?)\1`` captures the opener
-# and matches a closer of equal length, which also covers fenced
-# ``` ```...``` ``` blocks.
-_CODE_SPAN_RE = re.compile(r"(`+)[\s\S]*?\1")
+# string must have the same count and contents must be non-empty (otherwise
+# ``  `` would match as an empty span between two adjacent backticks).
+# ``(`+)[\s\S]+?\1`` captures the opener and matches a closer of equal length;
+# this also covers fenced ``` ```...``` ``` blocks.
+_CODE_SPAN_RE = re.compile(r"(`+)[\s\S]+?\1")
 
 
 def _normalize_segment(text: str) -> str:
@@ -257,22 +258,40 @@ def _streaming_safe_split(buffer: str) -> int:
     construct, or ``len(buffer)`` if the entire buffer is safe to emit.
     """
     n = len(buffer)
+    # Find all closed code spans first. ``normalize_latex_to_unicode`` removes
+    # these before applying math/command substitutions, so the scan must
+    # treat code spans as opaque -- a math closer (e.g. ``\]``) sitting
+    # inside a code span isn't a real closer.
+    code_span_ranges = [(m.start(), m.end()) for m in _CODE_SPAN_RE.finditer(buffer)]
+    code_span_starts = {start: end for start, end in code_span_ranges}
+
+    def _in_code_span(pos: int) -> bool:
+        for start, end in code_span_ranges:
+            if start <= pos < end:
+                return True
+            if start > pos:
+                break
+        return False
+
+    def _find_outside_code(needle: str, start: int) -> int:
+        pos = buffer.find(needle, start)
+        while pos >= 0 and _in_code_span(pos):
+            pos = buffer.find(needle, pos + 1)
+        return pos
+
     i = 0
     while i < n:
-        ch = buffer[i]
-
-        # Fenced code block: ```...```
-        if buffer.startswith("```", i):
-            close = buffer.find("```", i + 3)
-            if close < 0:
-                return i
-            i = close + 3
+        # Closed code span starts here -- skip its whole length atomically.
+        if i in code_span_starts:
+            i = code_span_starts[i]
             continue
+
+        ch = buffer[i]
 
         # Display dollar math: $$...$$ (must be checked before single ``$``
         # so the first ``$`` isn't consumed as a non-opener literal).
         if buffer.startswith("$$", i) and (i == 0 or buffer[i - 1] != "\\"):
-            close = buffer.find("$$", i + 2)
+            close = _find_outside_code("$$", i + 2)
             if close < 0:
                 return i
             i = close + 2
@@ -280,7 +299,7 @@ def _streaming_safe_split(buffer: str) -> int:
 
         # Display math: \[...\]
         if buffer.startswith("\\[", i):
-            close = buffer.find("\\]", i + 2)
+            close = _find_outside_code("\\]", i + 2)
             if close < 0:
                 return i
             i = close + 2
@@ -288,7 +307,7 @@ def _streaming_safe_split(buffer: str) -> int:
 
         # Inline math: \(...\)
         if buffer.startswith("\\(", i):
-            close = buffer.find("\\)", i + 2)
+            close = _find_outside_code("\\)", i + 2)
             if close < 0:
                 return i
             i = close + 2
@@ -318,6 +337,9 @@ def _streaming_safe_split(buffer: str) -> int:
                         cj = buffer[j]
                         if cj == "\n":
                             break
+                        if _in_code_span(j):
+                            j += 1
+                            continue
                         if cj == "\\" and j + 1 < n:
                             j += 2
                             continue
@@ -331,21 +353,11 @@ def _streaming_safe_split(buffer: str) -> int:
                     continue
             # Otherwise: $ is followed by a non-math character -- literal.
 
-        # Code span: ``+``...``+`` where opener and closer have matching
-        # backtick count (CommonMark). Covers single-backtick inline spans
-        # and multi-backtick spans the LLM emits when the code itself
-        # contains backticks. Fenced blocks already matched above, but a
-        # short ``` ```x``` ``` on one line is also handled here.
+        # Code span opener that didn't form a closed span (otherwise the
+        # ``code_span_starts`` skip above would have caught it). The buffer
+        # is mid-code-span; defer until the closer arrives.
         if ch == "`":
-            count = 0
-            while i + count < n and buffer[i + count] == "`":
-                count += 1
-            closer = "`" * count
-            close = buffer.find(closer, i + count)
-            if close < 0:
-                return i
-            i = close + count
-            continue
+            return i
 
         # Bare backslash command. A backslash followed by letters is a
         # candidate command; only the trailing one matters because anything

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -164,12 +164,12 @@ _LATEX_COMMANDS: dict[str, str] = {
 
 _LATEX_COMMAND_RE = re.compile(r"\\([a-zA-Z]+)")
 
-# Inline ``$...$`` is only treated as math when the content starts with a
-# backslash command. This avoids corrupting currency mentions like
-# ``"Price $5 and \alpha cost $10."`` where the dollars are not math
-# delimiters.
+# Inline ``$...$`` is only treated as math when the content (after optional
+# leading whitespace) starts with a backslash command. This avoids corrupting
+# currency mentions like ``"Price $5 and \alpha cost $10."`` while still
+# normalizing common LLM output such as ``"$ \alpha + \beta $"``.
 _INLINE_DOLLAR_MATH_RE = re.compile(
-    r"(?<!\\)\$(?!\$)(\\[a-zA-Z]+[^$\n]*?)(?<!\\)\$(?!\$)"
+    r"(?<!\\)\$(?!\$)([ \t]*\\[a-zA-Z]+[^$\n]*?)(?<!\\)\$(?!\$)"
 )
 
 _DISPLAY_DOLLAR_MATH_RE = re.compile(
@@ -198,7 +198,9 @@ def _convert_commands(text: str) -> str:
 
 
 def _strip_delims(match: re.Match[str]) -> str:
-    return _convert_commands(match.group(1))
+    # Trim surrounding whitespace so that ``$ \alpha $`` renders as ``α``
+    # without the literal padding the LLM emitted.
+    return _convert_commands(match.group(1)).strip()
 
 
 # Markdown code spans whose contents must be preserved verbatim. Fenced blocks
@@ -292,34 +294,38 @@ def _streaming_safe_split(buffer: str) -> int:
             i = close + 2
             continue
 
-        # Dollar math: $\command...$ on the same line. A bare ``$`` is only a
-        # delimiter when followed by ``\letter`` (matches the inline-math
-        # rule that preserves currency mentions like ``$5``).
-        if (
-            ch == "$"
-            and (i == 0 or buffer[i - 1] != "\\")
-            and i + 2 < n
-            and buffer[i + 1] == "\\"
-            and buffer[i + 2].isascii()
-            and buffer[i + 2].isalpha()
-        ):
-            j = i + 1
-            close = -1
-            while j < n:
-                cj = buffer[j]
-                if cj == "\n":
-                    break
-                if cj == "\\" and j + 1 < n:
-                    j += 2
-                    continue
-                if cj == "$":
-                    close = j
-                    break
-                j += 1
-            if close < 0:
-                return i
-            i = close + 1
-            continue
+        # Dollar math: ``$[ \t]*\command...$`` on the same line. A bare ``$``
+        # is only a delimiter when the content (after optional whitespace)
+        # starts with ``\letter`` -- this matches the inline-math regex and
+        # preserves currency mentions like ``$5``.
+        if ch == "$" and (i == 0 or buffer[i - 1] != "\\"):
+            # Skip optional inline whitespace, then look for ``\letter``.
+            probe = i + 1
+            while probe < n and buffer[probe] in " \t":
+                probe += 1
+            if (
+                probe + 1 < n
+                and buffer[probe] == "\\"
+                and buffer[probe + 1].isascii()
+                and buffer[probe + 1].isalpha()
+            ):
+                j = probe
+                close = -1
+                while j < n:
+                    cj = buffer[j]
+                    if cj == "\n":
+                        break
+                    if cj == "\\" and j + 1 < n:
+                        j += 2
+                        continue
+                    if cj == "$":
+                        close = j
+                        break
+                    j += 1
+                if close < 0:
+                    return i
+                i = close + 1
+                continue
 
         # Inline code span: `...` on the same line.
         if ch == "`":

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -201,6 +201,25 @@ def _strip_delims(match: re.Match[str]) -> str:
     return _convert_commands(match.group(1))
 
 
+# Markdown code spans whose contents must be preserved verbatim. Fenced blocks
+# come first so a stray backtick inside a fence doesn't terminate it early.
+_CODE_SPAN_RE = re.compile(
+    r"```[\s\S]*?```"  # fenced code block
+    r"|`[^`\n]+`"  # inline code span
+)
+
+
+def _normalize_segment(text: str) -> str:
+    """Apply math/command substitutions to a non-code segment."""
+    if not text or "\\" not in text:
+        return text
+    text = _DISPLAY_DOLLAR_MATH_RE.sub(_strip_delims, text)
+    text = _INLINE_DOLLAR_MATH_RE.sub(_strip_delims, text)
+    text = _BRACKET_MATH_RE.sub(_strip_delims, text)
+    text = _PAREN_MATH_RE.sub(_strip_delims, text)
+    return _convert_commands(text)
+
+
 def normalize_latex_to_unicode(text: str) -> str:
     """Replace LaTeX math markup with Unicode equivalents.
 
@@ -209,13 +228,121 @@ def normalize_latex_to_unicode(text: str) -> str:
     replaced with their glyphs; unknown commands are left intact. Math
     delimiters (``$...$``, ``$$...$$``, ``\\(...\\)``, ``\\[...\\]``) are
     stripped only when their contents contain a backslash command, so prose
-    like ``"$100 fee"`` is unaffected.
+    like ``"$100 fee"`` is unaffected. Markdown code spans -- fenced
+    ``` ```...``` ``` blocks and inline `` `...` `` -- are preserved verbatim,
+    so explanations of LaTeX syntax aren't corrupted.
     """
     if not text or "\\" not in text:
         return text
 
-    text = _DISPLAY_DOLLAR_MATH_RE.sub(_strip_delims, text)
-    text = _INLINE_DOLLAR_MATH_RE.sub(_strip_delims, text)
-    text = _BRACKET_MATH_RE.sub(_strip_delims, text)
-    text = _PAREN_MATH_RE.sub(_strip_delims, text)
-    return _convert_commands(text)
+    pieces: list[str] = []
+    cursor = 0
+    for match in _CODE_SPAN_RE.finditer(text):
+        pieces.append(_normalize_segment(text[cursor : match.start()]))
+        pieces.append(match.group(0))
+        cursor = match.end()
+    pieces.append(_normalize_segment(text[cursor:]))
+    return "".join(pieces)
+
+
+# Patterns describing where the trailing edge of a buffered stream might still
+# be inside an incomplete construct that must not be normalized in isolation.
+_TRAILING_BARE_COMMAND_RE = re.compile(r"\\[a-zA-Z]*\Z")
+_TRAILING_OPEN_PAREN_MATH_RE = re.compile(r"\\\([^\n]*\Z")
+_TRAILING_OPEN_BRACKET_MATH_RE = re.compile(r"\\\[[\s\S]*\Z")
+
+
+def _last_unmatched(text: str, marker: str, *, line_scoped: bool) -> int:
+    """Return the position of the last unmatched ``marker`` occurrence.
+
+    ``line_scoped`` resets the open/close state at every newline (matches
+    Markdown inline conventions for ``$`` and inline backticks).
+    """
+    open_pos = -1
+    in_span = False
+    for i, ch in enumerate(text):
+        if line_scoped and ch == "\n":
+            open_pos = -1
+            in_span = False
+            continue
+        if ch == "\\" and i + 1 < len(text):
+            # Skip escaped character.
+            continue
+        if ch == marker:
+            if in_span:
+                in_span = False
+            else:
+                in_span = True
+                open_pos = i
+    return open_pos if in_span else -1
+
+
+def _streaming_safe_split(buffer: str) -> int:
+    """Find the position up to which ``buffer`` can be normalized in isolation.
+
+    Anything after the returned position may still be inside an open math
+    span, code span, or partial backslash command, so it must wait for more
+    input. Returns ``len(buffer)`` when the entire buffer is safe to emit.
+    """
+    if not buffer:
+        return 0
+
+    candidates: list[int] = [len(buffer)]
+
+    bare = _TRAILING_BARE_COMMAND_RE.search(buffer)
+    if bare:
+        candidates.append(bare.start())
+
+    paren = _TRAILING_OPEN_PAREN_MATH_RE.search(buffer)
+    if paren and r"\)" not in paren.group(0):
+        candidates.append(paren.start())
+
+    bracket = _TRAILING_OPEN_BRACKET_MATH_RE.search(buffer)
+    if bracket and r"\]" not in bracket.group(0):
+        candidates.append(bracket.start())
+
+    dollar = _last_unmatched(buffer, "$", line_scoped=True)
+    if dollar >= 0:
+        candidates.append(dollar)
+
+    backtick = _last_unmatched(buffer, "`", line_scoped=True)
+    if backtick >= 0:
+        candidates.append(backtick)
+
+    fence_positions = [m.start() for m in re.finditer(r"```", buffer)]
+    if len(fence_positions) % 2 == 1:
+        candidates.append(fence_positions[-1])
+
+    return min(candidates)
+
+
+class StreamingLatexNormalizer:
+    """Stateful normalizer for chunked text streams.
+
+    Token-streamed text can split LaTeX commands, math delimiters, or code
+    spans across chunks. Per-chunk normalization would leak partially-rewritten
+    markup. This buffer holds back the tail of each chunk while it might still
+    extend an incomplete construct, normalizes the safe prefix, and flushes
+    the remainder at end of stream.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = ""
+
+    def feed(self, chunk: str) -> str:
+        """Append ``chunk`` and return text that is now safe to emit."""
+        if not chunk:
+            return ""
+        self._buffer += chunk
+        split = _streaming_safe_split(self._buffer)
+        if split <= 0:
+            return ""
+        emit = self._buffer[:split]
+        self._buffer = self._buffer[split:]
+        return normalize_latex_to_unicode(emit)
+
+    def flush(self) -> str:
+        """Return any remaining buffered text normalized at end of stream."""
+        remaining = self._buffer
+        self._buffer = ""
+        return normalize_latex_to_unicode(remaining)

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -297,35 +297,39 @@ def _streaming_safe_split(buffer: str) -> int:
         # Dollar math: ``$[ \t]*\command...$`` on the same line. A bare ``$``
         # is only a delimiter when the content (after optional whitespace)
         # starts with ``\letter`` -- this matches the inline-math regex and
-        # preserves currency mentions like ``$5``.
+        # preserves currency mentions like ``$5``. When the buffer ends with
+        # ``$``, ``$ ``, or ``$\`` we can't yet decide whether the next chunk
+        # turns it into a math opener, so hold back from that position.
         if ch == "$" and (i == 0 or buffer[i - 1] != "\\"):
-            # Skip optional inline whitespace, then look for ``\letter``.
             probe = i + 1
             while probe < n and buffer[probe] in " \t":
                 probe += 1
-            if (
-                probe + 1 < n
-                and buffer[probe] == "\\"
-                and buffer[probe + 1].isascii()
-                and buffer[probe + 1].isalpha()
-            ):
-                j = probe
-                close = -1
-                while j < n:
-                    cj = buffer[j]
-                    if cj == "\n":
-                        break
-                    if cj == "\\" and j + 1 < n:
-                        j += 2
-                        continue
-                    if cj == "$":
-                        close = j
-                        break
-                    j += 1
-                if close < 0:
+            if probe == n:
+                # Trailing ``$`` (possibly with whitespace) -- defer.
+                return i
+            if buffer[probe] == "\\":
+                if probe + 1 == n:
+                    # Trailing ``$\`` -- defer, the next char decides.
                     return i
-                i = close + 1
-                continue
+                if buffer[probe + 1].isascii() and buffer[probe + 1].isalpha():
+                    j = probe
+                    close = -1
+                    while j < n:
+                        cj = buffer[j]
+                        if cj == "\n":
+                            break
+                        if cj == "\\" and j + 1 < n:
+                            j += 2
+                            continue
+                        if cj == "$":
+                            close = j
+                            break
+                        j += 1
+                    if close < 0:
+                        return i
+                    i = close + 1
+                    continue
+            # Otherwise: $ is followed by a non-math character -- literal.
 
         # Code span: ``+``...``+`` where opener and closer have matching
         # backtick count (CommonMark). Covers single-backtick inline spans

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -267,6 +267,15 @@ def _streaming_safe_split(buffer: str) -> int:
             i = close + 3
             continue
 
+        # Display dollar math: $$...$$ (must be checked before single ``$``
+        # so the first ``$`` isn't consumed as a non-opener literal).
+        if buffer.startswith("$$", i) and (i == 0 or buffer[i - 1] != "\\"):
+            close = buffer.find("$$", i + 2)
+            if close < 0:
+                return i
+            i = close + 2
+            continue
+
         # Display math: \[...\]
         if buffer.startswith("\\[", i):
             close = buffer.find("\\]", i + 2)

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -184,6 +184,21 @@ _BRACKET_MATH_RE = re.compile(
     re.DOTALL,
 )
 
+# Single combined regex used by ``_normalize_segment``. Applying each math
+# pattern in turn would let earlier substitutions create new match
+# opportunities for later patterns -- e.g. ``$$\alpha$$`` collapsing to
+# ``α`` could turn a previously-rejected ``$...$`` pair into valid inline
+# math. That cascading behaviour is impossible to reproduce in the
+# streaming scan, which can only see the buffer as one snapshot. Combining
+# all alternatives into one ``re.sub`` ensures both code paths agree.
+_MATH_PATTERN_RE = re.compile(
+    r"(?<!\\)\$\$(?P<display>.*?\\[a-zA-Z]+.*?)\$\$"
+    r"|(?<!\\)\$(?!\$)(?P<inline>[ \t]*\\[a-zA-Z]+[^$\n]*?)(?<!\\)\$(?!\$)"
+    r"|\\\[(?P<bracket>.*?\\[a-zA-Z]+.*?)\\\]"
+    r"|\\\((?P<paren>[^\n]*?\\[a-zA-Z]+[^\n]*?)\\\)",
+    re.DOTALL,
+)
+
 
 def _replace_command(match: re.Match[str]) -> str:
     name = match.group(1)
@@ -197,10 +212,12 @@ def _convert_commands(text: str) -> str:
     return _LATEX_COMMAND_RE.sub(_replace_command, text)
 
 
-def _strip_delims(match: re.Match[str]) -> str:
-    # Trim surrounding whitespace so that ``$ \alpha $`` renders as ``α``
-    # without the literal padding the LLM emitted.
-    return _convert_commands(match.group(1)).strip()
+def _strip_math_delims(match: re.Match[str]) -> str:
+    for name in ("display", "inline", "bracket", "paren"):
+        content = match.group(name)
+        if content is not None:
+            return _convert_commands(content).strip()
+    return match.group(0)
 
 
 # Markdown code spans whose contents must be preserved verbatim. CommonMark
@@ -216,10 +233,7 @@ def _normalize_segment(text: str) -> str:
     """Apply math/command substitutions to a non-code segment."""
     if not text or "\\" not in text:
         return text
-    text = _DISPLAY_DOLLAR_MATH_RE.sub(_strip_delims, text)
-    text = _INLINE_DOLLAR_MATH_RE.sub(_strip_delims, text)
-    text = _BRACKET_MATH_RE.sub(_strip_delims, text)
-    text = _PAREN_MATH_RE.sub(_strip_delims, text)
+    text = _MATH_PATTERN_RE.sub(_strip_math_delims, text)
     return _convert_commands(text)
 
 
@@ -262,7 +276,14 @@ def _streaming_safe_split(buffer: str) -> int:
     # these before applying math/command substitutions, so the scan must
     # treat code spans as opaque -- a math closer (e.g. ``\]``) sitting
     # inside a code span isn't a real closer.
-    code_span_ranges = [(m.start(), m.end()) for m in _CODE_SPAN_RE.finditer(buffer)]
+    # Drop matches whose closer sits at end-of-buffer: ``_CODE_SPAN_RE``
+    # requires the closer not to be followed by another backtick
+    # (``(?!`)``); end-of-buffer satisfies that vacuously, but a future
+    # chunk could add a backtick and invalidate the match. Deferring is
+    # the safe choice.
+    code_span_ranges = [
+        (m.start(), m.end()) for m in _CODE_SPAN_RE.finditer(buffer) if m.end() < n
+    ]
     code_span_starts = {start: end for start, end in code_span_ranges}
 
     def _in_code_span(pos: int) -> bool:
@@ -279,6 +300,41 @@ def _streaming_safe_split(buffer: str) -> int:
             pos = buffer.find(needle, pos + 1)
         return pos
 
+    def _has_orphan_backtick(start: int, end: int) -> bool:
+        """Return True if any backtick in ``buffer[start:end]`` is not part
+        of a confirmed code span. Such a backtick could open a code span in
+        a later chunk and swallow the math closer we just found, so the
+        math construct can't be finalised yet.
+        """
+        return any(buffer[j] == "`" and not _in_code_span(j) for j in range(start, end))
+
+    def _has_command(start: int, end: int) -> bool:
+        """Return True if ``buffer[start:end]`` contains ``\\letter+``."""
+        j = start
+        while j < end - 1:
+            if (
+                buffer[j] == "\\"
+                and buffer[j + 1].isascii()
+                and buffer[j + 1].isalpha()
+            ):
+                return True
+            j += 1
+        return False
+
+    def _find_math_close(content_start: int, closer: str) -> int:
+        """Find the first ``closer`` after ``content_start`` whose preceding
+        content contains a ``\\command`` (matching the math regex's
+        ``\\[a-zA-Z]+`` requirement). Returns -1 if no valid closer exists.
+        """
+        search_from = content_start
+        while True:
+            candidate = _find_outside_code(closer, search_from)
+            if candidate < 0:
+                return -1
+            if _has_command(content_start, candidate):
+                return candidate
+            search_from = candidate + 1
+
     i = 0
     while i < n:
         # Closed code span starts here -- skip its whole length atomically.
@@ -291,24 +347,30 @@ def _streaming_safe_split(buffer: str) -> int:
         # Display dollar math: $$...$$ (must be checked before single ``$``
         # so the first ``$`` isn't consumed as a non-opener literal).
         if buffer.startswith("$$", i) and (i == 0 or buffer[i - 1] != "\\"):
-            close = _find_outside_code("$$", i + 2)
+            close = _find_math_close(i + 2, "$$")
             if close < 0:
+                return i
+            if _has_orphan_backtick(i + 2, close):
                 return i
             i = close + 2
             continue
 
         # Display math: \[...\]
         if buffer.startswith("\\[", i):
-            close = _find_outside_code("\\]", i + 2)
+            close = _find_math_close(i + 2, "\\]")
             if close < 0:
+                return i
+            if _has_orphan_backtick(i + 2, close):
                 return i
             i = close + 2
             continue
 
         # Inline math: \(...\)
         if buffer.startswith("\\(", i):
-            close = _find_outside_code("\\)", i + 2)
+            close = _find_math_close(i + 2, "\\)")
             if close < 0:
+                return i
+            if _has_orphan_backtick(i + 2, close):
                 return i
             i = close + 2
             continue
@@ -333,9 +395,14 @@ def _streaming_safe_split(buffer: str) -> int:
                 if buffer[probe + 1].isascii() and buffer[probe + 1].isalpha():
                     j = probe
                     close = -1
+                    hit_newline = False
                     while j < n:
                         cj = buffer[j]
                         if cj == "\n":
+                            # Inline math regex's ``[^$\n]*?`` forbids
+                            # newlines; once we see one the opener can never
+                            # become valid math. Treat as literal.
+                            hit_newline = True
                             break
                         if _in_code_span(j):
                             j += 1
@@ -348,6 +415,24 @@ def _streaming_safe_split(buffer: str) -> int:
                             break
                         j += 1
                     if close < 0:
+                        if hit_newline:
+                            # Opener can't form a math span -- it's literal.
+                            i += 1
+                            continue
+                        # Closer might arrive in a later chunk -- defer.
+                        return i
+                    # Validate the inline-math regex's ``(?!\$)`` on the
+                    # closer: a ``$`` immediately followed by another ``$``
+                    # isn't a real closer.
+                    if close == n - 1:
+                        # Can't see the next char yet -- defer.
+                        return i
+                    if buffer[close + 1] == "$":
+                        # Closer is followed by ``$``, so the regex would
+                        # reject this span. Opener is literal; advance one.
+                        i += 1
+                        continue
+                    if _has_orphan_backtick(probe, close):
                         return i
                     i = close + 1
                     continue

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -1,0 +1,217 @@
+"""Normalize assistant message text for user-facing output.
+
+The LLM occasionally emits LaTeX-flavoured math markup such as ``$\\rightarrow$``
+or ``\\alpha`` in prose. None of our delivery surfaces (Telegram, plain-text
+email, the current React frontend) parse LaTeX, so users see the raw markup.
+
+``normalize_latex_to_unicode`` rewrites known LaTeX commands to their Unicode
+equivalents and strips surrounding math delimiters when their contents look
+like math. It is intentionally conservative: text without a backslash is
+returned unchanged, currency mentions like ``$100`` are left alone, and
+unknown commands are preserved.
+"""
+
+from __future__ import annotations
+
+import re
+
+_LATEX_COMMANDS: dict[str, str] = {
+    # Arrows
+    "rightarrow": "→",
+    "to": "→",
+    "longrightarrow": "⟶",
+    "Rightarrow": "⇒",
+    "implies": "⇒",
+    "Longrightarrow": "⟹",
+    "leftarrow": "←",
+    "gets": "←",
+    "longleftarrow": "⟵",
+    "Leftarrow": "⇐",
+    "Longleftarrow": "⟸",
+    "leftrightarrow": "↔",
+    "longleftrightarrow": "⟷",
+    "Leftrightarrow": "⇔",
+    "iff": "⇔",
+    "Longleftrightarrow": "⟺",
+    "uparrow": "↑",
+    "downarrow": "↓",
+    "Uparrow": "⇑",
+    "Downarrow": "⇓",
+    "updownarrow": "↕",
+    "mapsto": "↦",
+    "hookrightarrow": "↪",
+    "hookleftarrow": "↩",
+    # Lowercase Greek
+    "alpha": "α",
+    "beta": "β",
+    "gamma": "γ",
+    "delta": "δ",
+    "epsilon": "ε",
+    "varepsilon": "ε",
+    "zeta": "ζ",
+    "eta": "η",
+    "theta": "θ",
+    "vartheta": "ϑ",
+    "iota": "ι",
+    "kappa": "κ",
+    "lambda": "λ",
+    "mu": "μ",
+    "nu": "ν",
+    "xi": "ξ",
+    "omicron": "ο",
+    "pi": "π",
+    "varpi": "ϖ",
+    "rho": "ρ",
+    "varrho": "ϱ",
+    "sigma": "σ",
+    "varsigma": "ς",
+    "tau": "τ",
+    "upsilon": "υ",
+    "phi": "φ",
+    "varphi": "φ",
+    "chi": "χ",
+    "psi": "ψ",
+    "omega": "ω",
+    # Uppercase Greek
+    "Gamma": "Γ",
+    "Delta": "Δ",
+    "Theta": "Θ",
+    "Lambda": "Λ",
+    "Xi": "Ξ",
+    "Pi": "Π",
+    "Sigma": "Σ",
+    "Upsilon": "Υ",
+    "Phi": "Φ",
+    "Psi": "Ψ",
+    "Omega": "Ω",
+    # Binary operators
+    "times": "×",
+    "div": "÷",
+    "pm": "±",
+    "mp": "∓",
+    "cdot": "·",
+    "ast": "∗",
+    "star": "⋆",
+    "circ": "∘",
+    "bullet": "•",
+    "oplus": "⊕",
+    "ominus": "⊖",
+    "otimes": "⊗",
+    "odot": "⊙",
+    # Relations
+    "le": "≤",
+    "leq": "≤",
+    "ge": "≥",
+    "geq": "≥",
+    "ne": "≠",
+    "neq": "≠",
+    "equiv": "≡",
+    "approx": "≈",
+    "sim": "∼",
+    "simeq": "≃",
+    "cong": "≅",
+    "propto": "∝",
+    "subset": "⊂",
+    "supset": "⊃",
+    "subseteq": "⊆",
+    "supseteq": "⊇",
+    "in": "∈",
+    "notin": "∉",
+    "ni": "∋",
+    "perp": "⊥",
+    "parallel": "∥",
+    # Set / logic
+    "cup": "∪",
+    "cap": "∩",
+    "emptyset": "∅",
+    "varnothing": "∅",
+    "forall": "∀",
+    "exists": "∃",
+    "nexists": "∄",
+    "neg": "¬",
+    "lnot": "¬",
+    "land": "∧",
+    "wedge": "∧",
+    "lor": "∨",
+    "vee": "∨",
+    # Big operators
+    "sum": "∑",
+    "prod": "∏",
+    "coprod": "∐",
+    "int": "∫",
+    "iint": "∬",
+    "iiint": "∭",
+    "oint": "∮",
+    # Miscellaneous
+    "infty": "∞",
+    "partial": "∂",
+    "nabla": "∇",
+    "hbar": "ℏ",
+    "ell": "ℓ",
+    "Re": "ℜ",
+    "Im": "ℑ",
+    "aleph": "ℵ",
+    "dagger": "†",
+    "ddagger": "‡",
+    "ldots": "…",
+    "dots": "…",
+    "cdots": "⋯",
+    "vdots": "⋮",
+    "ddots": "⋱",
+    "degree": "°",
+    "checkmark": "✓",
+}
+
+_LATEX_COMMAND_RE = re.compile(r"\\([a-zA-Z]+)")
+
+_INLINE_DOLLAR_MATH_RE = re.compile(
+    r"(?<!\\)\$(?!\$)([^$\n]*?\\[a-zA-Z]+[^$\n]*?)(?<!\\)\$(?!\$)"
+)
+
+_DISPLAY_DOLLAR_MATH_RE = re.compile(
+    r"\$\$(.*?\\[a-zA-Z]+.*?)\$\$",
+    re.DOTALL,
+)
+
+_PAREN_MATH_RE = re.compile(r"\\\(([^\n]*?\\[a-zA-Z]+[^\n]*?)\\\)")
+
+_BRACKET_MATH_RE = re.compile(
+    r"\\\[(.*?\\[a-zA-Z]+.*?)\\\]",
+    re.DOTALL,
+)
+
+
+def _replace_command(match: re.Match[str]) -> str:
+    name = match.group(1)
+    replacement = _LATEX_COMMANDS.get(name)
+    if replacement is None:
+        return match.group(0)
+    return replacement
+
+
+def _convert_commands(text: str) -> str:
+    return _LATEX_COMMAND_RE.sub(_replace_command, text)
+
+
+def _strip_delims(match: re.Match[str]) -> str:
+    return _convert_commands(match.group(1))
+
+
+def normalize_latex_to_unicode(text: str) -> str:
+    """Replace LaTeX math markup with Unicode equivalents.
+
+    Returns ``text`` unchanged when no backslash is present so the common case
+    is essentially free. Known commands (e.g. ``\\rightarrow``, ``\\alpha``) are
+    replaced with their glyphs; unknown commands are left intact. Math
+    delimiters (``$...$``, ``$$...$$``, ``\\(...\\)``, ``\\[...\\]``) are
+    stripped only when their contents contain a backslash command, so prose
+    like ``"$100 fee"`` is unaffected.
+    """
+    if not text or "\\" not in text:
+        return text
+
+    text = _DISPLAY_DOLLAR_MATH_RE.sub(_strip_delims, text)
+    text = _INLINE_DOLLAR_MATH_RE.sub(_strip_delims, text)
+    text = _BRACKET_MATH_RE.sub(_strip_delims, text)
+    text = _PAREN_MATH_RE.sub(_strip_delims, text)
+    return _convert_commands(text)

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -204,12 +204,12 @@ def _strip_delims(match: re.Match[str]) -> str:
 
 
 # Markdown code spans whose contents must be preserved verbatim. CommonMark
-# allows code spans to be delimited by any number of backticks; the closing
-# string must have the same count and contents must be non-empty (otherwise
-# ``  `` would match as an empty span between two adjacent backticks).
-# ``(`+)[\s\S]+?\1`` captures the opener and matches a closer of equal length;
-# this also covers fenced ``` ```...``` ``` blocks.
-_CODE_SPAN_RE = re.compile(r"(`+)[\s\S]+?\1")
+# requires the opener and closer to be standalone "backtick strings" of equal
+# length -- a run of N backticks not preceded or followed by another backtick.
+# The ``(?<!`)`` / ``(?!`)`` boundary checks prevent the regex from
+# backtracking the opener inside a longer fence (e.g. treating the first ``
+# of ``` as a single-backtick code span).
+_CODE_SPAN_RE = re.compile(r"(?<!`)(`+)(?!`)[\s\S]+?(?<!`)\1(?!`)")
 
 
 def _normalize_segment(text: str) -> str:

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -203,12 +203,12 @@ def _strip_delims(match: re.Match[str]) -> str:
     return _convert_commands(match.group(1)).strip()
 
 
-# Markdown code spans whose contents must be preserved verbatim. Fenced blocks
-# come first so a stray backtick inside a fence doesn't terminate it early.
-_CODE_SPAN_RE = re.compile(
-    r"```[\s\S]*?```"  # fenced code block
-    r"|`[^`\n]+`"  # inline code span
-)
+# Markdown code spans whose contents must be preserved verbatim. CommonMark
+# allows code spans to be delimited by any number of backticks; the closing
+# string must have the same count. ``(`+)([\s\S]*?)\1`` captures the opener
+# and matches a closer of equal length, which also covers fenced
+# ``` ```...``` ``` blocks.
+_CODE_SPAN_RE = re.compile(r"(`+)[\s\S]*?\1")
 
 
 def _normalize_segment(text: str) -> str:
@@ -327,21 +327,20 @@ def _streaming_safe_split(buffer: str) -> int:
                 i = close + 1
                 continue
 
-        # Inline code span: `...` on the same line.
+        # Code span: ``+``...``+`` where opener and closer have matching
+        # backtick count (CommonMark). Covers single-backtick inline spans
+        # and multi-backtick spans the LLM emits when the code itself
+        # contains backticks. Fenced blocks already matched above, but a
+        # short ``` ```x``` ``` on one line is also handled here.
         if ch == "`":
-            j = i + 1
-            close = -1
-            while j < n:
-                cj = buffer[j]
-                if cj == "\n":
-                    break
-                if cj == "`":
-                    close = j
-                    break
-                j += 1
+            count = 0
+            while i + count < n and buffer[i + count] == "`":
+                count += 1
+            closer = "`" * count
+            close = buffer.find(closer, i + count)
             if close < 0:
                 return i
-            i = close + 1
+            i = close + count
             continue
 
         # Bare backslash command. A backslash followed by letters is a

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -164,8 +164,12 @@ _LATEX_COMMANDS: dict[str, str] = {
 
 _LATEX_COMMAND_RE = re.compile(r"\\([a-zA-Z]+)")
 
+# Inline ``$...$`` is only treated as math when the content starts with a
+# backslash command. This avoids corrupting currency mentions like
+# ``"Price $5 and \alpha cost $10."`` where the dollars are not math
+# delimiters.
 _INLINE_DOLLAR_MATH_RE = re.compile(
-    r"(?<!\\)\$(?!\$)([^$\n]*?\\[a-zA-Z]+[^$\n]*?)(?<!\\)\$(?!\$)"
+    r"(?<!\\)\$(?!\$)(\\[a-zA-Z]+[^$\n]*?)(?<!\\)\$(?!\$)"
 )
 
 _DISPLAY_DOLLAR_MATH_RE = re.compile(

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -5,15 +5,22 @@ or ``\\alpha`` in prose. None of our delivery surfaces (Telegram, plain-text
 email, the current React frontend) parse LaTeX, so users see the raw markup.
 
 ``normalize_latex_to_unicode`` rewrites known LaTeX commands to their Unicode
-equivalents and strips surrounding math delimiters when their contents look
-like math. It is intentionally conservative: text without a backslash is
-returned unchanged, currency mentions like ``$100`` are left alone, and
-unknown commands are preserved.
+equivalents, strips surrounding math delimiters when their contents look
+like math, and preserves markdown code spans verbatim. ``StreamingLatexNormalizer``
+is the streaming counterpart used by the SSE chat endpoint.
+
+Both paths share one tokenizer (``_consume``) that recognises constructs in a
+single left-to-right pass. The streaming case is the same tokenizer with
+``eof=False``; an incomplete trailing token (a partial backslash command,
+an open math span, an unclosed code span) makes the tokenizer return
+``None`` and the caller buffers the tail until more input arrives.
+
+The tokeniser is intentionally conservative: text without a backslash, ``$``,
+or backtick is returned unchanged, currency mentions like ``$100`` are left
+alone, and unknown commands are preserved.
 """
 
 from __future__ import annotations
-
-import re
 
 _LATEX_COMMANDS: dict[str, str] = {
     # Arrows
@@ -162,336 +169,451 @@ _LATEX_COMMANDS: dict[str, str] = {
     "checkmark": "✓",
 }
 
-_LATEX_COMMAND_RE = re.compile(r"\\([a-zA-Z]+)")
 
-# Inline ``$...$`` is only treated as math when the content (after optional
-# leading whitespace) starts with a backslash command. This avoids corrupting
-# currency mentions like ``"Price $5 and \alpha cost $10."`` while still
-# normalizing common LLM output such as ``"$ \alpha + \beta $"``.
-_INLINE_DOLLAR_MATH_RE = re.compile(
-    r"(?<!\\)\$(?!\$)([ \t]*\\[a-zA-Z]+[^$\n]*?)(?<!\\)\$(?!\$)"
-)
-
-_DISPLAY_DOLLAR_MATH_RE = re.compile(
-    r"\$\$(.*?\\[a-zA-Z]+.*?)\$\$",
-    re.DOTALL,
-)
-
-_PAREN_MATH_RE = re.compile(r"\\\(([^\n]*?\\[a-zA-Z]+[^\n]*?)\\\)")
-
-_BRACKET_MATH_RE = re.compile(
-    r"\\\[(.*?\\[a-zA-Z]+.*?)\\\]",
-    re.DOTALL,
-)
-
-# Single combined regex used by ``_normalize_segment``. Applying each math
-# pattern in turn would let earlier substitutions create new match
-# opportunities for later patterns -- e.g. ``$$\alpha$$`` collapsing to
-# ``α`` could turn a previously-rejected ``$...$`` pair into valid inline
-# math. That cascading behaviour is impossible to reproduce in the
-# streaming scan, which can only see the buffer as one snapshot. Combining
-# all alternatives into one ``re.sub`` ensures both code paths agree.
-_MATH_PATTERN_RE = re.compile(
-    r"(?<!\\)\$\$(?P<display>.*?\\[a-zA-Z]+.*?)\$\$"
-    r"|(?<!\\)\$(?!\$)(?P<inline>[ \t]*\\[a-zA-Z]+[^$\n]*?)(?<!\\)\$(?!\$)"
-    r"|\\\[(?P<bracket>.*?\\[a-zA-Z]+.*?)\\\]"
-    r"|\\\((?P<paren>[^\n]*?\\[a-zA-Z]+[^\n]*?)\\\)",
-    re.DOTALL,
-)
-
-
-def _replace_command(match: re.Match[str]) -> str:
-    name = match.group(1)
-    replacement = _LATEX_COMMANDS.get(name)
-    if replacement is None:
-        return match.group(0)
-    return replacement
+def _is_ascii_letter(ch: str) -> bool:
+    """ASCII a-zA-Z. Matches what LaTeX accepts in a control sequence name."""
+    return ch.isascii() and ch.isalpha()
 
 
 def _convert_commands(text: str) -> str:
-    return _LATEX_COMMAND_RE.sub(_replace_command, text)
+    """Replace every ``\\letter+`` run with its Unicode glyph (or pass through).
 
-
-def _strip_math_delims(match: re.Match[str]) -> str:
-    for name in ("display", "inline", "bracket", "paren"):
-        content = match.group(name)
-        if content is not None:
-            return _convert_commands(content).strip()
-    return match.group(0)
-
-
-# Markdown code spans whose contents must be preserved verbatim. CommonMark
-# requires the opener and closer to be standalone "backtick strings" of equal
-# length -- a run of N backticks not preceded or followed by another backtick.
-# The ``(?<!`)`` / ``(?!`)`` boundary checks prevent the regex from
-# backtracking the opener inside a longer fence (e.g. treating the first ``
-# of ``` as a single-backtick code span).
-_CODE_SPAN_RE = re.compile(r"(?<!`)(`+)(?!`)[\s\S]+?(?<!`)\1(?!`)")
-
-
-def _normalize_segment(text: str) -> str:
-    """Apply math/command substitutions to a non-code segment."""
-    if not text or "\\" not in text:
+    Used for content inside math delimiters; in the prose tokenizer the
+    same conversion happens via ``_consume_command``.
+    """
+    if "\\" not in text:
         return text
-    text = _MATH_PATTERN_RE.sub(_strip_math_delims, text)
-    return _convert_commands(text)
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "\\" and i + 1 < n and _is_ascii_letter(text[i + 1]):
+            j = i + 1
+            while j < n and _is_ascii_letter(text[j]):
+                j += 1
+            name = text[i + 1 : j]
+            out.append(_LATEX_COMMANDS.get(name, text[i:j]))
+            i = j
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+#
+# ``_consume(text, i, eof)`` returns either ``(rendered, new_i)`` or ``None``.
+# A ``None`` return means the construct starting at ``i`` is incomplete and
+# the caller (a streaming buffer) should wait for more input.  With
+# ``eof=True`` the tokenizer treats an unfinished construct as literal text
+# instead, so callers can flush at end of stream.
+#
+# Each consumer handles a specific construct.  ``_consume`` dispatches based
+# on the character at ``i``; everything else falls through to a plain text
+# run via ``_consume_text``.
+
+
+def _is_code_span_opener(text: str, i: int, n: int, *, eof: bool) -> bool | None:
+    """Return True if backticks at ``text[i]`` open a *confirmed* code span.
+
+    A confirmed code span is one whose closer is visible in the buffer and
+    whose boundaries can be verified (no following backtick run). Used by
+    math consumers to abort: a math closer that sits inside a code span
+    would be extracted away before the math regex ran, so the math
+    construct can't be finalised.
+
+    Returns:
+        ``True``  — a real code span begins here; the caller should abort.
+        ``False`` — not a code span (just literal backticks in content).
+        ``None`` — streaming mode, can't tell yet; caller should defer.
+    """
+    if i >= n or text[i] != "`":
+        return False
+    count = 0
+    while i + count < n and text[i + count] == "`":
+        count += 1
+    end_open = i + count
+    if end_open == n:
+        return None if not eof else False
+    closer = "`" * count
+    search = end_open
+    while True:
+        candidate = text.find(closer, search)
+        if candidate < 0:
+            return None if not eof else False
+        end_close = candidate + count
+        if end_close < n and text[end_close] == "`":
+            search = candidate + 1
+            continue
+        if end_close == n and not eof:
+            return None
+        if candidate == end_open:
+            search = candidate + 1
+            continue
+        return True
+
+
+def _consume_text(text: str, i: int, n: int) -> tuple[str, int]:
+    """Consume a plain text run up to the next potentially-significant char.
+
+    Stops on ``$``, ``\\``, or `` ` `` so the dispatcher can route to the
+    right consumer.
+    """
+    start = i
+    while i < n and text[i] not in "`$\\":
+        i += 1
+    return text[start:i], i
+
+
+def _consume_command(text: str, i: int, n: int, *, eof: bool) -> tuple[str, int] | None:
+    """Consume ``\\letter+``.
+
+    Returns ``None`` in streaming mode when the letters extend to end of
+    buffer (a following chunk might add more letters and rename the
+    command).  In eof mode the command is rendered with whatever letters
+    are available.
+    """
+    j = i + 1
+    while j < n and _is_ascii_letter(text[j]):
+        j += 1
+    if j == n and not eof:
+        return None
+    name = text[i + 1 : j]
+    return _LATEX_COMMANDS.get(name, text[i:j]), j
+
+
+def _consume_code_span(
+    text: str, i: int, n: int, *, eof: bool
+) -> tuple[str, int] | None:
+    """Consume `` `code` ``, `` ``code`` ``, ``` ```code``` ``` etc.
+
+    CommonMark code spans are delimited by a "backtick string" of N
+    backticks; the closer must be a backtick string of equal length not
+    flanked by additional backticks. The contents are preserved verbatim.
+
+    Returns ``None`` in streaming mode if the opener extends to end of
+    buffer (might still grow), no closer is yet visible, or the closer
+    sits at end of buffer (we can't yet check it isn't part of a longer
+    run).
+    """
+    count = 0
+    while i + count < n and text[i + count] == "`":
+        count += 1
+    end_open = i + count
+    if end_open == n:
+        if not eof:
+            return None
+        # Trailing backticks with no closer -- literal.
+        return text[i:end_open], end_open
+
+    closer = "`" * count
+    search = end_open
+    while True:
+        candidate = text.find(closer, search)
+        if candidate < 0:
+            if not eof:
+                return None
+            return text[i:end_open], end_open
+        end_close = candidate + count
+        # Reject if the closer is part of a longer backtick run.
+        if end_close < n and text[end_close] == "`":
+            search = candidate + 1
+            continue
+        if end_close == n and not eof:
+            # Can't verify the boundary yet.
+            return None
+        # CommonMark code spans require non-empty content.
+        if candidate == end_open:
+            search = candidate + 1
+            continue
+        return text[i:end_close], end_close
+
+
+def _consume_display_math(
+    text: str, i: int, n: int, *, eof: bool
+) -> tuple[str, int] | None:
+    """Consume ``$$...$$`` where the content contains a ``\\command``.
+
+    Caller must have verified ``text[i:i+2] == "$$"`` and that the opener
+    isn't preceded by ``\\``.
+    """
+    j = i + 2
+    has_command = False
+    while j < n:
+        ch = text[j]
+        if ch == "`":
+            verdict = _is_code_span_opener(text, j, n, eof=eof)
+            if verdict is None:
+                return None
+            if verdict:
+                # The would-be ``$$`` closer would sit inside a code span
+                # after extraction, so this math span doesn't exist.
+                return "$$", i + 2
+            # Just literal backticks; skip them as content.
+            while j < n and text[j] == "`":
+                j += 1
+            continue
+        if ch == "\\" and j + 1 < n:
+            nxt = text[j + 1]
+            if _is_ascii_letter(nxt):
+                has_command = True
+            # Skip the escaped char so e.g. ``\$`` doesn't trigger a
+            # spurious closer.
+            j += 2
+            continue
+        if ch == "$" and j + 1 < n and text[j + 1] == "$":
+            if has_command:
+                content = text[i + 2 : j]
+                return _convert_commands(content).strip(), j + 2
+            # Inner ``$$`` without a command yet -- treat as content and
+            # keep looking for the real closer.
+            j += 2
+            continue
+        j += 1
+    if not eof:
+        return None
+    # No closer in buffer -- opener is literal.
+    return "$$", i + 2
+
+
+def _consume_inline_dollar(
+    text: str, i: int, n: int, *, eof: bool
+) -> tuple[str, int] | None:
+    """Consume ``$[ \\t]*\\command...$`` on a single line.
+
+    Caller has verified ``text[i] == "$"``, ``text[i+1] != "$"`` and that
+    the opener isn't preceded by ``\\``.
+    """
+    probe = i + 1
+    while probe < n and text[probe] in " \t":
+        probe += 1
+    if probe == n:
+        if not eof:
+            return None
+        return "$", i + 1
+    if text[probe] != "\\":
+        # ``$5`` etc. -- currency / prose, not math.
+        return "$", i + 1
+    if probe + 1 == n:
+        if not eof:
+            return None
+        return "$", i + 1
+    if not _is_ascii_letter(text[probe + 1]):
+        # ``$\$`` etc. -- the backslash escapes something, not a command.
+        return "$", i + 1
+
+    j = probe
+    while j < n:
+        ch = text[j]
+        if ch == "\n":
+            # ``[^$\n]*?`` in the regex forbids newlines.
+            return "$", i + 1
+        if ch == "`":
+            verdict = _is_code_span_opener(text, j, n, eof=eof)
+            if verdict is None:
+                return None
+            if verdict:
+                # Closer would land inside the code span -- opener is literal.
+                return "$", i + 1
+            while j < n and text[j] == "`":
+                j += 1
+            continue
+        if ch == "\\" and j + 1 < n:
+            j += 2
+            continue
+        if ch == "$":
+            # Closer can't be immediately followed by another ``$``.
+            if j + 1 < n and text[j + 1] == "$":
+                return "$", i + 1
+            if j + 1 == n and not eof:
+                # Can't verify the trailing ``(?!\$)`` yet.
+                return None
+            content = text[i + 1 : j]
+            return _convert_commands(content).strip(), j + 1
+        j += 1
+    if not eof:
+        return None
+    return "$", i + 1
+
+
+def _consume_paren_math(
+    text: str, i: int, n: int, *, eof: bool
+) -> tuple[str, int] | None:
+    """Consume ``\\(...\\)`` where the content contains a ``\\command``.
+
+    Caller has verified ``text[i:i+2] == "\\("``.
+    """
+    j = i + 2
+    has_command = False
+    while j < n:
+        ch = text[j]
+        if ch == "\n":
+            # ``[^\n]*?`` in the regex forbids newlines.
+            return text[i : i + 2], i + 2
+        if ch == "`":
+            verdict = _is_code_span_opener(text, j, n, eof=eof)
+            if verdict is None:
+                return None
+            if verdict:
+                return text[i : i + 2], i + 2
+            while j < n and text[j] == "`":
+                j += 1
+            continue
+        if ch == "\\" and j + 1 < n:
+            nxt = text[j + 1]
+            if nxt == ")":
+                if has_command:
+                    content = text[i + 2 : j]
+                    return _convert_commands(content).strip(), j + 2
+                # No command inside -- opener is literal.
+                return text[i : i + 2], i + 2
+            if _is_ascii_letter(nxt):
+                has_command = True
+            j += 2
+            continue
+        j += 1
+    if not eof:
+        return None
+    return text[i : i + 2], i + 2
+
+
+def _consume_bracket_math(
+    text: str, i: int, n: int, *, eof: bool
+) -> tuple[str, int] | None:
+    """Consume ``\\[...\\]`` where the content contains a ``\\command``.
+
+    Caller has verified ``text[i:i+2] == "\\["``. Content may span newlines
+    (the regex uses DOTALL).
+    """
+    j = i + 2
+    has_command = False
+    while j < n:
+        ch = text[j]
+        if ch == "`":
+            verdict = _is_code_span_opener(text, j, n, eof=eof)
+            if verdict is None:
+                return None
+            if verdict:
+                return text[i : i + 2], i + 2
+            while j < n and text[j] == "`":
+                j += 1
+            continue
+        if ch == "\\" and j + 1 < n:
+            nxt = text[j + 1]
+            if nxt == "]":
+                if has_command:
+                    content = text[i + 2 : j]
+                    return _convert_commands(content).strip(), j + 2
+                return text[i : i + 2], i + 2
+            if _is_ascii_letter(nxt):
+                has_command = True
+            j += 2
+            continue
+        j += 1
+    if not eof:
+        return None
+    return text[i : i + 2], i + 2
+
+
+def _consume(text: str, i: int, n: int, *, eof: bool) -> tuple[str, int] | None:
+    """Consume one token starting at ``text[i]``.
+
+    Dispatches to the appropriate per-construct consumer. ``None`` means
+    the construct is incomplete and the caller should wait for more input.
+    """
+    if i >= n:
+        return "", i
+
+    ch = text[i]
+
+    if ch == "`":
+        return _consume_code_span(text, i, n, eof=eof)
+
+    if ch == "$":
+        # Escaped opener -- ``\$`` was already consumed by the previous
+        # ``\``-handling branch, so if we got here ``text[i-1]`` is the
+        # last "real" character.
+        if i > 0 and text[i - 1] == "\\":
+            return "$", i + 1
+        if i + 1 < n and text[i + 1] == "$":
+            return _consume_display_math(text, i, n, eof=eof)
+        if i + 1 == n:
+            if not eof:
+                return None
+            return "$", i + 1
+        return _consume_inline_dollar(text, i, n, eof=eof)
+
+    if ch == "\\":
+        if i + 1 == n:
+            if not eof:
+                return None
+            return "\\", i + 1
+        nxt = text[i + 1]
+        if nxt == "(":
+            return _consume_paren_math(text, i, n, eof=eof)
+        if nxt == "[":
+            return _consume_bracket_math(text, i, n, eof=eof)
+        if _is_ascii_letter(nxt):
+            return _consume_command(text, i, n, eof=eof)
+        # ``\$``, ``\\``, ``\@`` etc. -- consume both characters as text.
+        return text[i : i + 2], i + 2
+
+    return _consume_text(text, i, n)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 def normalize_latex_to_unicode(text: str) -> str:
     """Replace LaTeX math markup with Unicode equivalents.
 
-    Returns ``text`` unchanged when no backslash is present so the common case
-    is essentially free. Known commands (e.g. ``\\rightarrow``, ``\\alpha``) are
-    replaced with their glyphs; unknown commands are left intact. Math
-    delimiters (``$...$``, ``$$...$$``, ``\\(...\\)``, ``\\[...\\]``) are
-    stripped only when their contents contain a backslash command, so prose
-    like ``"$100 fee"`` is unaffected. Markdown code spans -- fenced
-    ``` ```...``` ``` blocks and inline `` `...` `` -- are preserved verbatim,
-    so explanations of LaTeX syntax aren't corrupted.
+    Returns ``text`` unchanged when no backslash is present so the common
+    case is essentially free. Known commands (e.g. ``\\rightarrow``,
+    ``\\alpha``) are replaced with their glyphs; unknown commands are left
+    intact. Math delimiters (``$...$``, ``$$...$$``, ``\\(...\\)``,
+    ``\\[...\\]``) are stripped only when their contents contain a
+    backslash command, so prose like ``"$100 fee"`` is unaffected. Markdown
+    code spans -- fenced ``` ```...``` ``` blocks and inline `` `...` `` --
+    are preserved verbatim, so explanations of LaTeX syntax aren't
+    corrupted.
     """
     if not text or "\\" not in text:
         return text
-
-    pieces: list[str] = []
-    cursor = 0
-    for match in _CODE_SPAN_RE.finditer(text):
-        pieces.append(_normalize_segment(text[cursor : match.start()]))
-        pieces.append(match.group(0))
-        cursor = match.end()
-    pieces.append(_normalize_segment(text[cursor:]))
-    return "".join(pieces)
-
-
-def _streaming_safe_split(buffer: str) -> int:
-    """Find the position up to which ``buffer`` can be normalized in isolation.
-
-    Walks the buffer left-to-right at the top level, skipping over closed
-    constructs (fenced code, ``\\[...\\]``, ``\\(...\\)``, ``$\\command...$``,
-    inline ``` `...` ```) as opaque units so their interiors don't interact
-    with the outer scan. Returns the start position of the first unclosed
-    construct, or ``len(buffer)`` if the entire buffer is safe to emit.
-    """
-    n = len(buffer)
-    # Find all closed code spans first. ``normalize_latex_to_unicode`` removes
-    # these before applying math/command substitutions, so the scan must
-    # treat code spans as opaque -- a math closer (e.g. ``\]``) sitting
-    # inside a code span isn't a real closer.
-    # Drop matches whose closer sits at end-of-buffer: ``_CODE_SPAN_RE``
-    # requires the closer not to be followed by another backtick
-    # (``(?!`)``); end-of-buffer satisfies that vacuously, but a future
-    # chunk could add a backtick and invalidate the match. Deferring is
-    # the safe choice.
-    code_span_ranges = [
-        (m.start(), m.end()) for m in _CODE_SPAN_RE.finditer(buffer) if m.end() < n
-    ]
-    code_span_starts = {start: end for start, end in code_span_ranges}
-
-    def _in_code_span(pos: int) -> bool:
-        for start, end in code_span_ranges:
-            if start <= pos < end:
-                return True
-            if start > pos:
-                break
-        return False
-
-    def _find_outside_code(needle: str, start: int) -> int:
-        pos = buffer.find(needle, start)
-        while pos >= 0 and _in_code_span(pos):
-            pos = buffer.find(needle, pos + 1)
-        return pos
-
-    def _has_orphan_backtick(start: int, end: int) -> bool:
-        """Return True if any backtick in ``buffer[start:end]`` is not part
-        of a confirmed code span. Such a backtick could open a code span in
-        a later chunk and swallow the math closer we just found, so the
-        math construct can't be finalised yet.
-        """
-        return any(buffer[j] == "`" and not _in_code_span(j) for j in range(start, end))
-
-    def _has_command(start: int, end: int) -> bool:
-        """Return True if ``buffer[start:end]`` contains ``\\letter+``."""
-        j = start
-        while j < end - 1:
-            if (
-                buffer[j] == "\\"
-                and buffer[j + 1].isascii()
-                and buffer[j + 1].isalpha()
-            ):
-                return True
-            j += 1
-        return False
-
-    def _next_code_span_start(after: int) -> int:
-        """Return the start of the first code span at or after ``after``,
-        or ``n`` if none exists. Math constructs can't extend past a code
-        span boundary because ``normalize_latex_to_unicode`` extracts code
-        spans before applying math substitutions.
-        """
-        for span_start, _span_end in code_span_ranges:
-            if span_start >= after:
-                return span_start
-        return n
-
-    def _find_math_close(content_start: int, closer: str) -> int:
-        """Find the first ``closer`` after ``content_start`` whose preceding
-        content contains a ``\\command`` (matching the math regex's
-        ``\\[a-zA-Z]+`` requirement). The search is bounded by the next
-        code span so math doesn't pair across code-span boundaries.
-        Returns -1 if no valid closer exists.
-        """
-        boundary = _next_code_span_start(content_start)
-        search_from = content_start
-        while True:
-            candidate = buffer.find(closer, search_from)
-            if candidate < 0 or candidate >= boundary:
-                return -1
-            if _has_command(content_start, candidate):
-                return candidate
-            search_from = candidate + 1
-
+    n = len(text)
+    out: list[str] = []
     i = 0
     while i < n:
-        # Closed code span starts here -- skip its whole length atomically.
-        if i in code_span_starts:
-            i = code_span_starts[i]
+        result = _consume(text, i, n, eof=True)
+        if result is None:
+            # ``eof=True`` should always return a value; if a consumer
+            # bails defensively, emit the byte and keep going.
+            out.append(text[i])
+            i += 1
             continue
-
-        ch = buffer[i]
-
-        # Display dollar math: $$...$$ (must be checked before single ``$``
-        # so the first ``$`` isn't consumed as a non-opener literal).
-        if buffer.startswith("$$", i) and (i == 0 or buffer[i - 1] != "\\"):
-            close = _find_math_close(i + 2, "$$")
-            if close < 0:
-                return i
-            if _has_orphan_backtick(i + 2, close):
-                return i
-            i = close + 2
+        rendered, next_i = result
+        if next_i == i:
+            # Shouldn't happen, but guard against an infinite loop.
+            out.append(text[i])
+            i += 1
             continue
-
-        # Display math: \[...\]
-        if buffer.startswith("\\[", i):
-            close = _find_math_close(i + 2, "\\]")
-            if close < 0:
-                return i
-            if _has_orphan_backtick(i + 2, close):
-                return i
-            i = close + 2
-            continue
-
-        # Inline math: \(...\)
-        if buffer.startswith("\\(", i):
-            close = _find_math_close(i + 2, "\\)")
-            if close < 0:
-                return i
-            if _has_orphan_backtick(i + 2, close):
-                return i
-            i = close + 2
-            continue
-
-        # Dollar math: ``$[ \t]*\command...$`` on the same line. A bare ``$``
-        # is only a delimiter when the content (after optional whitespace)
-        # starts with ``\letter`` -- this matches the inline-math regex and
-        # preserves currency mentions like ``$5``. When the buffer ends with
-        # ``$``, ``$ ``, or ``$\`` we can't yet decide whether the next chunk
-        # turns it into a math opener, so hold back from that position.
-        if ch == "$" and (i == 0 or buffer[i - 1] != "\\"):
-            probe = i + 1
-            while probe < n and buffer[probe] in " \t":
-                probe += 1
-            if probe == n:
-                # Trailing ``$`` (possibly with whitespace) -- defer.
-                return i
-            if buffer[probe] == "\\":
-                if probe + 1 == n:
-                    # Trailing ``$\`` -- defer, the next char decides.
-                    return i
-                if buffer[probe + 1].isascii() and buffer[probe + 1].isalpha():
-                    j = probe
-                    close = -1
-                    hit_newline = False
-                    hit_code_span = False
-                    while j < n:
-                        cj = buffer[j]
-                        if cj == "\n":
-                            # Inline math regex's ``[^$\n]*?`` forbids
-                            # newlines; once we see one the opener can never
-                            # become valid math. Treat as literal.
-                            hit_newline = True
-                            break
-                        if _in_code_span(j):
-                            # Math closer would be in a different segment
-                            # than the opener once the code span is
-                            # extracted; this opener is literal.
-                            hit_code_span = True
-                            break
-                        if cj == "\\" and j + 1 < n:
-                            j += 2
-                            continue
-                        if cj == "$":
-                            close = j
-                            break
-                        j += 1
-                    if close < 0:
-                        if hit_newline or hit_code_span:
-                            # Opener can't form a math span -- it's literal.
-                            i += 1
-                            continue
-                        # Closer might arrive in a later chunk -- defer.
-                        return i
-                    # Validate the inline-math regex's ``(?!\$)`` on the
-                    # closer: a ``$`` immediately followed by another ``$``
-                    # isn't a real closer.
-                    if close == n - 1:
-                        # Can't see the next char yet -- defer.
-                        return i
-                    if buffer[close + 1] == "$":
-                        # Closer is followed by ``$``, so the regex would
-                        # reject this span. Opener is literal; advance one.
-                        i += 1
-                        continue
-                    if _has_orphan_backtick(probe, close):
-                        return i
-                    i = close + 1
-                    continue
-            # Otherwise: $ is followed by a non-math character -- literal.
-
-        # Code span opener that didn't form a closed span (otherwise the
-        # ``code_span_starts`` skip above would have caught it). The buffer
-        # is mid-code-span; defer until the closer arrives.
-        if ch == "`":
-            return i
-
-        # Bare backslash command. A backslash followed by letters is a
-        # candidate command; only the trailing one matters because anything
-        # before it has a non-letter terminator and is therefore complete.
-        if ch == "\\" and i + 1 < n:
-            j = i + 1
-            while j < n and buffer[j].isascii() and buffer[j].isalpha():
-                j += 1
-            if j == n:
-                # Trailing partial command -- hold back from the backslash.
-                return i
-            i = j
-            continue
-
-        # A lone trailing backslash could be the start of a command.
-        if ch == "\\":
-            return i
-
-        i += 1
-
-    return n
+        out.append(rendered)
+        i = next_i
+    return "".join(out)
 
 
 class StreamingLatexNormalizer:
     """Stateful normalizer for chunked text streams.
 
     Token-streamed text can split LaTeX commands, math delimiters, or code
-    spans across chunks. Per-chunk normalization would leak partially-rewritten
-    markup. This buffer holds back the tail of each chunk while it might still
-    extend an incomplete construct, normalizes the safe prefix, and flushes
-    the remainder at end of stream.
+    spans across chunks. This buffer accumulates chunks, tokenizes as far
+    as is safe (the same tokenizer the batch path uses), emits the
+    rendered tokens, and keeps any incomplete trailing construct in the
+    buffer until ``feed`` or ``flush`` resolves it.
     """
 
     def __init__(self) -> None:
@@ -502,15 +624,47 @@ class StreamingLatexNormalizer:
         if not chunk:
             return ""
         self._buffer += chunk
-        split = _streaming_safe_split(self._buffer)
-        if split <= 0:
-            return ""
-        emit = self._buffer[:split]
-        self._buffer = self._buffer[split:]
-        return normalize_latex_to_unicode(emit)
+        rendered, consumed = _tokenize(self._buffer, eof=False)
+        self._buffer = self._buffer[consumed:]
+        return rendered
 
     def flush(self) -> str:
-        """Return any remaining buffered text normalized at end of stream."""
-        remaining = self._buffer
+        """Return any remaining buffered text, normalized at end of stream."""
+        if not self._buffer:
+            return ""
+        rendered, _ = _tokenize(self._buffer, eof=True)
         self._buffer = ""
-        return normalize_latex_to_unicode(remaining)
+        return rendered
+
+
+def _tokenize(text: str, *, eof: bool) -> tuple[str, int]:
+    """Run the tokenizer until either the input is exhausted or an
+    incomplete construct is hit (only in ``eof=False`` mode).
+
+    Returns ``(rendered, consumed)`` where ``consumed`` is the number of
+    input characters successfully tokenized.
+    """
+    n = len(text)
+    if not text:
+        return "", 0
+    if "\\" not in text and "$" not in text and "`" not in text:
+        # Pure prose -- short-circuit the per-character loop.
+        return text, n
+
+    out: list[str] = []
+    i = 0
+    while i < n:
+        result = _consume(text, i, n, eof=eof)
+        if result is None:
+            return "".join(out), i
+        rendered, next_i = result
+        if next_i == i:
+            # Shouldn't happen; guard.
+            if eof:
+                out.append(text[i])
+                i += 1
+                continue
+            return "".join(out), i
+        out.append(rendered)
+        i = next_i
+    return "".join(out), i

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -321,15 +321,29 @@ def _streaming_safe_split(buffer: str) -> int:
             j += 1
         return False
 
+    def _next_code_span_start(after: int) -> int:
+        """Return the start of the first code span at or after ``after``,
+        or ``n`` if none exists. Math constructs can't extend past a code
+        span boundary because ``normalize_latex_to_unicode`` extracts code
+        spans before applying math substitutions.
+        """
+        for span_start, _span_end in code_span_ranges:
+            if span_start >= after:
+                return span_start
+        return n
+
     def _find_math_close(content_start: int, closer: str) -> int:
         """Find the first ``closer`` after ``content_start`` whose preceding
         content contains a ``\\command`` (matching the math regex's
-        ``\\[a-zA-Z]+`` requirement). Returns -1 if no valid closer exists.
+        ``\\[a-zA-Z]+`` requirement). The search is bounded by the next
+        code span so math doesn't pair across code-span boundaries.
+        Returns -1 if no valid closer exists.
         """
+        boundary = _next_code_span_start(content_start)
         search_from = content_start
         while True:
-            candidate = _find_outside_code(closer, search_from)
-            if candidate < 0:
+            candidate = buffer.find(closer, search_from)
+            if candidate < 0 or candidate >= boundary:
                 return -1
             if _has_command(content_start, candidate):
                 return candidate
@@ -396,6 +410,7 @@ def _streaming_safe_split(buffer: str) -> int:
                     j = probe
                     close = -1
                     hit_newline = False
+                    hit_code_span = False
                     while j < n:
                         cj = buffer[j]
                         if cj == "\n":
@@ -405,8 +420,11 @@ def _streaming_safe_split(buffer: str) -> int:
                             hit_newline = True
                             break
                         if _in_code_span(j):
-                            j += 1
-                            continue
+                            # Math closer would be in a different segment
+                            # than the opener once the code span is
+                            # extracted; this opener is literal.
+                            hit_code_span = True
+                            break
                         if cj == "\\" and j + 1 < n:
                             j += 2
                             continue
@@ -415,7 +433,7 @@ def _streaming_safe_split(buffer: str) -> int:
                             break
                         j += 1
                     if close < 0:
-                        if hit_newline:
+                        if hit_newline or hit_code_span:
                             # Opener can't form a math span -- it's literal.
                             i += 1
                             continue

--- a/src/family_assistant/utils/text_normalization.py
+++ b/src/family_assistant/utils/text_normalization.py
@@ -245,126 +245,110 @@ def normalize_latex_to_unicode(text: str) -> str:
     return "".join(pieces)
 
 
-# Patterns describing where the trailing edge of a buffered stream might still
-# be inside an incomplete construct that must not be normalized in isolation.
-_TRAILING_BARE_COMMAND_RE = re.compile(r"\\[a-zA-Z]*\Z")
-_TRAILING_OPEN_PAREN_MATH_RE = re.compile(r"\\\([^\n]*\Z")
-_TRAILING_OPEN_BRACKET_MATH_RE = re.compile(r"\\\[[\s\S]*\Z")
-
-
-def _last_unmatched(text: str, marker: str, *, line_scoped: bool) -> int:
-    """Return the position of the last unmatched ``marker`` occurrence.
-
-    ``line_scoped`` resets the open/close state at every newline (matches
-    Markdown inline conventions for inline backticks).
-    """
-    open_pos = -1
-    in_span = False
-    for i, ch in enumerate(text):
-        if line_scoped and ch == "\n":
-            open_pos = -1
-            in_span = False
-            continue
-        if ch == "\\" and i + 1 < len(text):
-            # Skip escaped character.
-            continue
-        if ch == marker:
-            if in_span:
-                in_span = False
-            else:
-                in_span = True
-                open_pos = i
-    return open_pos if in_span else -1
-
-
-# Matches a literal ``$`` that's followed by ``\letters`` (a candidate inline
-# math opener). The negative lookbehind rejects escaped ``\$``, and the
-# lookahead requires the content to start with a backslash command -- the same
-# rule ``_INLINE_DOLLAR_MATH_RE`` enforces for closed spans.
-_INLINE_MATH_OPENER_RE = re.compile(r"(?<!\\)\$(?=\\[a-zA-Z])")
-
-
-def _last_unclosed_inline_math_dollar(text: str) -> int:
-    """Return the position of the last ``$`` that opens an unclosed math span.
-
-    Unlike a naive toggle, this treats a ``$`` as a math delimiter only when
-    it is immediately followed by a ``\\command`` (matching the production
-    inline-math rule). Currency mentions like ``$5`` are not paired with a
-    later ``$\\command`` opener, so streamed text like
-    ``"cost $5 and $\\alpha$ end"`` is split correctly.
-    """
-    # Closed inline math spans found by the production regex -- positions
-    # inside these are safe (the closing ``$`` is already paired).
-    closed_ranges = [
-        (m.start(), m.end()) for m in _INLINE_DOLLAR_MATH_RE.finditer(text)
-    ]
-
-    def is_closed(pos: int) -> bool:
-        return any(start <= pos < end for start, end in closed_ranges)
-
-    last_open = -1
-    for opener_match in _INLINE_MATH_OPENER_RE.finditer(text):
-        pos = opener_match.start()
-        if is_closed(pos):
-            continue
-        # An opener with no closing ``$`` before EOL is the boundary we care
-        # about. Look for the next unescaped ``$`` on the same line.
-        i = pos + 1
-        end = text.find("\n", i)
-        line_end = len(text) if end < 0 else end
-        closer_pos = -1
-        j = i
-        while j < line_end:
-            ch = text[j]
-            if ch == "\\" and j + 1 < line_end:
-                j += 2
-                continue
-            if ch == "$":
-                closer_pos = j
-                break
-            j += 1
-        if closer_pos == -1:
-            last_open = pos
-    return last_open
-
-
 def _streaming_safe_split(buffer: str) -> int:
     """Find the position up to which ``buffer`` can be normalized in isolation.
 
-    Anything after the returned position may still be inside an open math
-    span, code span, or partial backslash command, so it must wait for more
-    input. Returns ``len(buffer)`` when the entire buffer is safe to emit.
+    Walks the buffer left-to-right at the top level, skipping over closed
+    constructs (fenced code, ``\\[...\\]``, ``\\(...\\)``, ``$\\command...$``,
+    inline ``` `...` ```) as opaque units so their interiors don't interact
+    with the outer scan. Returns the start position of the first unclosed
+    construct, or ``len(buffer)`` if the entire buffer is safe to emit.
     """
-    if not buffer:
-        return 0
+    n = len(buffer)
+    i = 0
+    while i < n:
+        ch = buffer[i]
 
-    candidates: list[int] = [len(buffer)]
+        # Fenced code block: ```...```
+        if buffer.startswith("```", i):
+            close = buffer.find("```", i + 3)
+            if close < 0:
+                return i
+            i = close + 3
+            continue
 
-    bare = _TRAILING_BARE_COMMAND_RE.search(buffer)
-    if bare:
-        candidates.append(bare.start())
+        # Display math: \[...\]
+        if buffer.startswith("\\[", i):
+            close = buffer.find("\\]", i + 2)
+            if close < 0:
+                return i
+            i = close + 2
+            continue
 
-    paren = _TRAILING_OPEN_PAREN_MATH_RE.search(buffer)
-    if paren and r"\)" not in paren.group(0):
-        candidates.append(paren.start())
+        # Inline math: \(...\)
+        if buffer.startswith("\\(", i):
+            close = buffer.find("\\)", i + 2)
+            if close < 0:
+                return i
+            i = close + 2
+            continue
 
-    bracket = _TRAILING_OPEN_BRACKET_MATH_RE.search(buffer)
-    if bracket and r"\]" not in bracket.group(0):
-        candidates.append(bracket.start())
+        # Dollar math: $\command...$ on the same line. A bare ``$`` is only a
+        # delimiter when followed by ``\letter`` (matches the inline-math
+        # rule that preserves currency mentions like ``$5``).
+        if (
+            ch == "$"
+            and (i == 0 or buffer[i - 1] != "\\")
+            and i + 2 < n
+            and buffer[i + 1] == "\\"
+            and buffer[i + 2].isascii()
+            and buffer[i + 2].isalpha()
+        ):
+            j = i + 1
+            close = -1
+            while j < n:
+                cj = buffer[j]
+                if cj == "\n":
+                    break
+                if cj == "\\" and j + 1 < n:
+                    j += 2
+                    continue
+                if cj == "$":
+                    close = j
+                    break
+                j += 1
+            if close < 0:
+                return i
+            i = close + 1
+            continue
 
-    dollar = _last_unclosed_inline_math_dollar(buffer)
-    if dollar >= 0:
-        candidates.append(dollar)
+        # Inline code span: `...` on the same line.
+        if ch == "`":
+            j = i + 1
+            close = -1
+            while j < n:
+                cj = buffer[j]
+                if cj == "\n":
+                    break
+                if cj == "`":
+                    close = j
+                    break
+                j += 1
+            if close < 0:
+                return i
+            i = close + 1
+            continue
 
-    backtick = _last_unmatched(buffer, "`", line_scoped=True)
-    if backtick >= 0:
-        candidates.append(backtick)
+        # Bare backslash command. A backslash followed by letters is a
+        # candidate command; only the trailing one matters because anything
+        # before it has a non-letter terminator and is therefore complete.
+        if ch == "\\" and i + 1 < n:
+            j = i + 1
+            while j < n and buffer[j].isascii() and buffer[j].isalpha():
+                j += 1
+            if j == n:
+                # Trailing partial command -- hold back from the backslash.
+                return i
+            i = j
+            continue
 
-    fence_positions = [m.start() for m in re.finditer(r"```", buffer)]
-    if len(fence_positions) % 2 == 1:
-        candidates.append(fence_positions[-1])
+        # A lone trailing backslash could be the start of a command.
+        if ch == "\\":
+            return i
 
-    return min(candidates)
+        i += 1
+
+    return n
 
 
 class StreamingLatexNormalizer:

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -1329,6 +1329,12 @@ async def api_chat_send_message_stream(
                         yield f"event: tool_result\ndata: {json.dumps(tool_result_data)}\n\n"
 
                     elif event.type == "done":
+                        # Flush any buffered LaTeX text from this turn so
+                        # trailing ambiguous bytes (e.g. ``$``) aren't
+                        # merged with the next turn's opening tokens.
+                        trailing = latex_normalizer.flush()
+                        if trailing:
+                            yield f"event: text\ndata: {json.dumps({'content': trailing})}\n\n"
                         # Handle attachment IDs from attach_to_response tool calls
                         if event.metadata and "attachment_ids" in event.metadata:
                             # Get attachment registry to fetch attachment metadata

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -41,6 +41,7 @@ from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.tools import MCPToolsProvider, find_provider_by_type
 from family_assistant.tools.infrastructure import ToolDescriptorProvider
 from family_assistant.tools.types import ConfirmationOutcome, ToolExecutionContext
+from family_assistant.utils.text_normalization import StreamingLatexNormalizer
 from family_assistant.web.confirmation_manager import web_confirmation_manager
 from family_assistant.web.dependencies import (
     get_attachment_registry,
@@ -1243,6 +1244,7 @@ async def api_chat_send_message_stream(
 
         last_reasoning_info: MessageReasoningInfo | None = None
         send_close_event = True
+        latex_normalizer = StreamingLatexNormalizer()
 
         try:
             # Process events from queue and yield SSE events
@@ -1286,13 +1288,14 @@ async def api_chat_send_message_stream(
                     event = queue_event["event"]
                     # Process normal stream events
                     if event.type == "content":
-                        # Send text content chunks. LaTeX normalization is
-                        # intentionally NOT applied here: streaming chunks can
-                        # split a single LaTeX command (e.g. "$\alp" then
-                        # "ha$"), so per-chunk normalization would leak raw
-                        # markup. The finalized AssistantMessage is normalized
-                        # in ProcessingService before persistence.
-                        yield f"event: text\ndata: {json.dumps({'content': event.content})}\n\n"
+                        # The streaming normalizer buffers the trailing bytes
+                        # of each chunk while they might still extend a LaTeX
+                        # command, math span, or code span, then flushes the
+                        # remainder at end of stream. This keeps live tokens
+                        # consistent with the persisted (normalized) message.
+                        content = latex_normalizer.feed(event.content or "")
+                        if content:
+                            yield f"event: text\ndata: {json.dumps({'content': content})}\n\n"
 
                     elif event.type == "tool_call":
                         # Convert tool_call to dict for JSON serialization
@@ -1376,6 +1379,10 @@ async def api_chat_send_message_stream(
                         yield f"event: error\ndata: {json.dumps(error_data)}\n\n"
 
                 elif queue_event["type"] == "stream_end":
+                    # Flush any text the LaTeX normalizer was holding back.
+                    trailing = latex_normalizer.flush()
+                    if trailing:
+                        yield f"event: text\ndata: {json.dumps({'content': trailing})}\n\n"
                     # Send the end event once at the true end of the stream
                     # ast-grep-ignore: no-dict-any - SSE end event payload optionally includes provider-specific reasoning_info
                     done_data: dict[str, Any] = {}

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -41,6 +41,7 @@ from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.tools import MCPToolsProvider, find_provider_by_type
 from family_assistant.tools.infrastructure import ToolDescriptorProvider
 from family_assistant.tools.types import ConfirmationOutcome, ToolExecutionContext
+from family_assistant.utils.text_normalization import normalize_latex_to_unicode
 from family_assistant.web.confirmation_manager import web_confirmation_manager
 from family_assistant.web.dependencies import (
     get_attachment_registry,
@@ -1287,7 +1288,12 @@ async def api_chat_send_message_stream(
                     # Process normal stream events
                     if event.type == "content":
                         # Send text content chunks
-                        yield f"event: text\ndata: {json.dumps({'content': event.content})}\n\n"
+                        content = (
+                            normalize_latex_to_unicode(event.content)
+                            if event.content
+                            else event.content
+                        )
+                        yield f"event: text\ndata: {json.dumps({'content': content})}\n\n"
 
                     elif event.type == "tool_call":
                         # Convert tool_call to dict for JSON serialization

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -1392,6 +1392,12 @@ async def api_chat_send_message_stream(
                     break
 
                 elif queue_event["type"] == "error":
+                    # Flush any text the LaTeX normalizer was holding back
+                    # before reporting the error -- otherwise partial output
+                    # generated before the failure would be silently dropped.
+                    trailing = latex_normalizer.flush()
+                    if trailing:
+                        yield f"event: text\ndata: {json.dumps({'content': trailing})}\n\n"
                     error_id = str(uuid.uuid4())
                     logger.error(f"Streaming error {error_id}: {queue_event['error']}")
                     yield f"event: error\ndata: {json.dumps({'error': queue_event['error'], 'error_id': error_id})}\n\n"
@@ -1403,6 +1409,11 @@ async def api_chat_send_message_stream(
         except Exception as e:
             error_id = str(uuid.uuid4())
             logger.error(f"Streaming error {error_id}: {e}", exc_info=True)
+            # Flush buffered normalizer text so partial assistant output
+            # isn't lost when the stream fails mid-construct.
+            trailing = latex_normalizer.flush()
+            if trailing:
+                yield f"event: text\ndata: {json.dumps({'content': trailing})}\n\n"
             # Send error event to client
             error_msg = "An error occurred while processing your request"
             if getattr(request.app.state, "debug_mode", False):

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -41,7 +41,6 @@ from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.tools import MCPToolsProvider, find_provider_by_type
 from family_assistant.tools.infrastructure import ToolDescriptorProvider
 from family_assistant.tools.types import ConfirmationOutcome, ToolExecutionContext
-from family_assistant.utils.text_normalization import normalize_latex_to_unicode
 from family_assistant.web.confirmation_manager import web_confirmation_manager
 from family_assistant.web.dependencies import (
     get_attachment_registry,
@@ -1287,13 +1286,13 @@ async def api_chat_send_message_stream(
                     event = queue_event["event"]
                     # Process normal stream events
                     if event.type == "content":
-                        # Send text content chunks
-                        content = (
-                            normalize_latex_to_unicode(event.content)
-                            if event.content
-                            else event.content
-                        )
-                        yield f"event: text\ndata: {json.dumps({'content': content})}\n\n"
+                        # Send text content chunks. LaTeX normalization is
+                        # intentionally NOT applied here: streaming chunks can
+                        # split a single LaTeX command (e.g. "$\alp" then
+                        # "ha$"), so per-chunk normalization would leak raw
+                        # markup. The finalized AssistantMessage is normalized
+                        # in ProcessingService before persistence.
+                        yield f"event: text\ndata: {json.dumps({'content': event.content})}\n\n"
 
                     elif event.type == "tool_call":
                         # Convert tool_call to dict for JSON serialization

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -256,6 +256,17 @@ class TestCodeSpansPreserved:
             == r"`\alpha`, `\beta`, plain γ"
         )
 
+    def test_double_backtick_code_span_preserved(self) -> None:
+        # Multi-backtick spans are used when the code contains backticks; the
+        # contents must stay verbatim too.
+        assert normalize_latex_to_unicode(r"``\alpha``") == r"``\alpha``"
+
+    def test_triple_backtick_inline_code_span_preserved(self) -> None:
+        assert (
+            normalize_latex_to_unicode(r"see ```\beta``` here")
+            == r"see ```\beta``` here"
+        )
+
 
 class TestStreamingLatexNormalizer:
     """Buffered normalization for chunked / streamed text."""
@@ -316,6 +327,16 @@ class TestStreamingLatexNormalizer:
         chunks = [r"\[\alpha `", r"\]"]
         out = self._drain(n, chunks)
         assert out == normalize_latex_to_unicode("".join(chunks))
+
+    def test_multi_backtick_code_span_split(self) -> None:
+        # Regression: a double-backtick code span split across chunks must
+        # be held back until the matching closer arrives so the contents
+        # aren't normalized as bare commands.
+        n = StreamingLatexNormalizer()
+        chunks = [r"``\alp", r"ha``"]
+        out = self._drain(n, chunks)
+        assert out == normalize_latex_to_unicode("".join(chunks))
+        assert out == r"``\alpha``"
 
     def test_inline_math_with_inner_whitespace_split(self) -> None:
         # ``$ \alpha$`` (LLM-emitted padding) split across chunks should

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import pytest
 
-from family_assistant.utils.text_normalization import normalize_latex_to_unicode
+from family_assistant.utils.text_normalization import (
+    StreamingLatexNormalizer,
+    normalize_latex_to_unicode,
+)
 
 
 class TestNoOpCases:
@@ -217,3 +220,83 @@ class TestCurrencyNotCorrupted:
             normalize_latex_to_unicode(r"Spent $5 and saved $\rightarrow$ all good")
             == r"Spent $5 and saved → all good"
         )
+
+
+class TestCodeSpansPreserved:
+    """LaTeX inside markdown code spans must be left verbatim."""
+
+    def test_inline_code_preserved(self) -> None:
+        assert (
+            normalize_latex_to_unicode(r"Use `\alpha` for greek alpha")
+            == r"Use `\alpha` for greek alpha"
+        )
+
+    def test_inline_code_alongside_normal_math(self) -> None:
+        # Code keeps `\alpha`; surrounding `$\beta$` is converted.
+        assert (
+            normalize_latex_to_unicode(r"Type `\alpha` to get $\beta$")
+            == r"Type `\alpha` to get β"
+        )
+
+    def test_fenced_code_block_preserved(self) -> None:
+        source = "Block:\n```\n\\alpha + \\beta\n```\nafter"
+        assert normalize_latex_to_unicode(source) == source
+
+    def test_multiple_code_spans_preserved(self) -> None:
+        assert (
+            normalize_latex_to_unicode(r"`\alpha`, `\beta`, plain \gamma")
+            == r"`\alpha`, `\beta`, plain γ"
+        )
+
+
+class TestStreamingLatexNormalizer:
+    """Buffered normalization for chunked / streamed text."""
+
+    def _drain(self, normalizer: StreamingLatexNormalizer, chunks: list[str]) -> str:
+        emitted = "".join(normalizer.feed(chunk) for chunk in chunks)
+        return emitted + normalizer.flush()
+
+    def test_single_complete_chunk(self) -> None:
+        n = StreamingLatexNormalizer()
+        assert self._drain(n, [r"A $\rightarrow$ B"]) == "A → B"
+
+    def test_command_split_across_chunks(self) -> None:
+        # The reviewer's example: `"$\alp"` then `"ha$"` must produce `α`.
+        n = StreamingLatexNormalizer()
+        assert self._drain(n, [r"$\alp", r"ha$"]) == "α"
+
+    def test_dollar_open_across_chunks(self) -> None:
+        # Math opens in one chunk and closes in the next.
+        n = StreamingLatexNormalizer()
+        assert self._drain(n, [r"start $\rig", r"htarrow$ end"]) == "start → end"
+
+    def test_code_span_inside_stream_preserved(self) -> None:
+        n = StreamingLatexNormalizer()
+        assert (
+            self._drain(n, [r"use `\al", r"pha` for ", r"$\beta$"])
+            == r"use `\alpha` for β"
+        )
+
+    def test_trailing_backslash_held_until_complete(self) -> None:
+        n = StreamingLatexNormalizer()
+        # First feed ends with a bare backslash -- must hold back.
+        assert n.feed("hi \\") == "hi "
+        # Next feed completes the command.
+        assert n.feed("rightarrow done") == "→ done"
+        assert not n.flush()
+
+    def test_currency_dollars_in_stream_preserved(self) -> None:
+        n = StreamingLatexNormalizer()
+        # Even with a backslash later in the buffer, the currency $ shouldn't
+        # pair with it because the math content wouldn't start with `\command`.
+        out = self._drain(n, [r"Price $5 and ", r"\alpha cost $10."])
+        assert out == r"Price $5 and α cost $10."
+
+    def test_empty_chunks_are_noop(self) -> None:
+        n = StreamingLatexNormalizer()
+        assert not n.feed("")
+        assert not n.flush()
+
+    def test_plain_text_passes_through(self) -> None:
+        n = StreamingLatexNormalizer()
+        assert self._drain(n, ["Hello, ", "world!"]) == "Hello, world!"

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -300,6 +300,15 @@ class TestStreamingLatexNormalizer:
         out = self._drain(n, [r"cost $5 and $\alp", r"ha$ end"])
         assert out == r"cost $5 and α end"
 
+    def test_backtick_inside_bracket_math_does_not_split(self) -> None:
+        # Regression: a backtick inside a \[...\] math span must not be
+        # treated as an unclosed inline-code opener -- it's consumed by the
+        # bracket-math substitution. Streamed output must match persisted.
+        n = StreamingLatexNormalizer()
+        chunks = [r"\[\alpha `", r"\]"]
+        out = self._drain(n, chunks)
+        assert out == normalize_latex_to_unicode("".join(chunks))
+
     def test_empty_chunks_are_noop(self) -> None:
         n = StreamingLatexNormalizer()
         assert not n.feed("")

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -111,6 +111,14 @@ class TestMathDelimiterStripping:
             == "Spent $5 then $7 then $3."
         )
 
+    def test_inline_math_with_leading_whitespace(self) -> None:
+        # ``$ \alpha$`` -- LLM padding before the command -- should still be
+        # recognized as math and the literal dollars dropped.
+        assert normalize_latex_to_unicode(r"$ \alpha$") == "α"
+
+    def test_inline_math_with_padded_whitespace(self) -> None:
+        assert normalize_latex_to_unicode(r"$ \alpha + \beta $") == "α + β"
+
 
 class TestBareCommands:
     def test_bare_command_without_delimiters(self) -> None:
@@ -308,6 +316,16 @@ class TestStreamingLatexNormalizer:
         chunks = [r"\[\alpha `", r"\]"]
         out = self._drain(n, chunks)
         assert out == normalize_latex_to_unicode("".join(chunks))
+
+    def test_inline_math_with_inner_whitespace_split(self) -> None:
+        # ``$ \alpha$`` (LLM-emitted padding) split across chunks should
+        # produce normalized ``α`` in the stream, matching the persisted
+        # output rather than leaking the literal ``$`` delimiters.
+        n = StreamingLatexNormalizer()
+        chunks = [r"$ \al", r"pha$ end"]
+        out = self._drain(n, chunks)
+        assert out == normalize_latex_to_unicode("".join(chunks))
+        assert out == "α end"
 
     def test_display_dollar_math_split_across_chunks(self) -> None:
         # Regression: ``$$...$$`` display math must be atomic in the stream

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -309,6 +309,17 @@ class TestStreamingLatexNormalizer:
         out = self._drain(n, chunks)
         assert out == normalize_latex_to_unicode("".join(chunks))
 
+    def test_display_dollar_math_split_across_chunks(self) -> None:
+        # Regression: ``$$...$$`` display math must be atomic in the stream
+        # scan. If we treated the opener as two single-``$`` literals, the
+        # first ``$`` would be emitted early and the rest of the buffer would
+        # be normalized as inline math, leaving ``$α$`` instead of ``α``.
+        n = StreamingLatexNormalizer()
+        chunks = [r"$$\alp", r"ha$$"]
+        out = self._drain(n, chunks)
+        assert out == normalize_latex_to_unicode("".join(chunks))
+        assert out == "α"
+
     def test_empty_chunks_are_noop(self) -> None:
         n = StreamingLatexNormalizer()
         assert not n.feed("")

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -1,0 +1,184 @@
+"""Tests for ``family_assistant.utils.text_normalization``."""
+
+from __future__ import annotations
+
+import pytest
+
+from family_assistant.utils.text_normalization import normalize_latex_to_unicode
+
+
+class TestNoOpCases:
+    """The function should be a no-op when there's nothing LaTeX-ish to do."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "Plain text with no markup.",
+            "Hello, world!",
+            "Numbers like 1, 2, 3 and 4.5 should pass through.",
+            "Multi\nline\ntext.",
+        ],
+    )
+    def test_returns_input_unchanged(self, text: str) -> None:
+        assert normalize_latex_to_unicode(text) == text
+
+    def test_currency_amount_preserved(self) -> None:
+        assert (
+            normalize_latex_to_unicode("It costs $100 and saves $50 monthly.")
+            == "It costs $100 and saves $50 monthly."
+        )
+
+    def test_two_dollar_amounts_preserved(self) -> None:
+        # Two stand-alone amounts shouldn't be treated as math delimiters,
+        # because there's no \command between them.
+        assert (
+            normalize_latex_to_unicode("Paid $50 today, $25 yesterday.")
+            == "Paid $50 today, $25 yesterday."
+        )
+
+    def test_backslash_without_letters_unchanged(self) -> None:
+        # Markdown-style backslash escapes shouldn't get touched.
+        assert (
+            normalize_latex_to_unicode(r"escaped \* asterisk") == r"escaped \* asterisk"
+        )
+
+    def test_unknown_command_unchanged(self) -> None:
+        assert (
+            normalize_latex_to_unicode(r"some \madeupcommand here")
+            == r"some \madeupcommand here"
+        )
+
+
+class TestArrowConversions:
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            (r"A $\rightarrow$ B", "A → B"),
+            (r"A $\to$ B", "A → B"),
+            (r"A $\Rightarrow$ B", "A ⇒ B"),
+            (r"A $\implies$ B", "A ⇒ B"),
+            (r"A $\leftarrow$ B", "A ← B"),
+            (r"A $\leftrightarrow$ B", "A ↔ B"),
+            (r"A $\Leftrightarrow$ B", "A ⇔ B"),
+            (r"A $\mapsto$ B", "A ↦ B"),
+        ],
+    )
+    def test_inline_arrows(self, source: str, expected: str) -> None:
+        assert normalize_latex_to_unicode(source) == expected
+
+
+class TestGreekLetters:
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            (r"$\alpha$ is a constant", "α is a constant"),
+            (r"angle $\theta$", "angle θ"),
+            (r"sum of $\pi$ and $\phi$", "sum of π and φ"),
+            (r"$\Delta$ T", "Δ T"),
+            (r"$\Omega$ resistance", "Ω resistance"),
+        ],
+    )
+    def test_greek_inline_math(self, source: str, expected: str) -> None:
+        assert normalize_latex_to_unicode(source) == expected
+
+
+class TestMathDelimiterStripping:
+    def test_paren_delimiters_stripped(self) -> None:
+        assert (
+            normalize_latex_to_unicode(r"State \(\alpha\) means start")
+            == "State α means start"
+        )
+
+    def test_bracket_delimiters_stripped(self) -> None:
+        assert (
+            normalize_latex_to_unicode(r"Display: \[\sum x_i\] end")
+            == "Display: ∑ x_i end"
+        )
+
+    def test_double_dollar_delimiters_stripped(self) -> None:
+        assert (
+            normalize_latex_to_unicode(r"Block: $$\int f$$ done") == "Block: ∫ f done"
+        )
+
+    def test_inline_dollars_without_command_preserved(self) -> None:
+        # No LaTeX command inside, so the dollars stay.
+        assert (
+            normalize_latex_to_unicode("Spent $5 then $7 then $3.")
+            == "Spent $5 then $7 then $3."
+        )
+
+
+class TestBareCommands:
+    def test_bare_command_without_delimiters(self) -> None:
+        assert (
+            normalize_latex_to_unicode(r"Use \alpha and \beta freely.")
+            == "Use α and β freely."
+        )
+
+    def test_command_inside_sentence(self) -> None:
+        assert normalize_latex_to_unicode(r"so 2 \times 3 = 6") == "so 2 × 3 = 6"
+
+    def test_multiple_commands_in_one_line(self) -> None:
+        result = normalize_latex_to_unicode(r"$\alpha \rightarrow \beta$ then $\gamma$")
+        assert result == "α → β then γ"
+
+
+class TestRelationsAndOperators:
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            (r"x $\le$ y", "x ≤ y"),
+            (r"x $\geq$ 0", "x ≥ 0"),
+            (r"a $\ne$ b", "a ≠ b"),
+            (r"a $\approx$ b", "a ≈ b"),
+            (r"$\infty$", "∞"),
+            (r"$\pm$", "±"),
+            (r"$\cdot$", "·"),
+        ],
+    )
+    def test_relations(self, source: str, expected: str) -> None:
+        assert normalize_latex_to_unicode(source) == expected
+
+
+class TestEdgeCases:
+    def test_empty_string(self) -> None:
+        assert not normalize_latex_to_unicode("")
+
+    def test_text_with_no_backslash_short_circuits(self) -> None:
+        # This is a behaviour assertion: even with dollars present, if there's
+        # no backslash we return the input unchanged.
+        s = "Just $100 here."
+        assert normalize_latex_to_unicode(s) is s
+
+    def test_multiline_text_with_mixed_content(self) -> None:
+        source = (
+            "Recipe:\n"
+            r"- mix $\alpha$ with $\beta$" + "\n"
+            r"- heat to 100\degree" + "\n"
+            "- cost: $5"
+        )
+        expected = "Recipe:\n- mix α with β\n- heat to 100°\n- cost: $5"
+        assert normalize_latex_to_unicode(source) == expected
+
+    def test_inline_math_must_be_on_one_line(self) -> None:
+        # A stray $ on one line and another on a different line shouldn't be
+        # treated as math delimiters.
+        source = "First line has $5.\nSecond line has \\alpha cost: $10."
+        # \alpha is converted as a bare command; the dollars stay put.
+        assert (
+            normalize_latex_to_unicode(source)
+            == "First line has $5.\nSecond line has α cost: $10."
+        )
+
+    def test_unknown_command_inside_math_preserved(self) -> None:
+        # Inside delimiters, unknown commands stay as-is and dollars are
+        # stripped because the inner content contains a command.
+        assert normalize_latex_to_unicode(r"$\foo \alpha$") == r"\foo α"
+
+    def test_no_double_processing_of_escaped_dollar(self) -> None:
+        # An escaped dollar in markdown shouldn't act as a math delimiter.
+        assert (
+            normalize_latex_to_unicode(r"price is \$100 plus \$50")
+            == r"price is \$100 plus \$50"
+        )

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -328,6 +328,31 @@ class TestStreamingLatexNormalizer:
         out = self._drain(n, chunks)
         assert out == normalize_latex_to_unicode("".join(chunks))
 
+    def test_trailing_dollar_held_until_intent_known(self) -> None:
+        # Regression: when a chunk ends with a bare ``$``, the streamer
+        # can't yet decide whether the next chunk turns it into a math
+        # opener. It must defer instead of emitting the literal dollar.
+        n = StreamingLatexNormalizer()
+        out = self._drain(n, ["$", r"\alp", r"ha$"])
+        assert out == normalize_latex_to_unicode("$\\alpha$")
+        assert out == "α"
+
+    def test_trailing_dollar_with_whitespace_then_command(self) -> None:
+        # Same as above but with whitespace after the ``$`` -- still a
+        # potential math opener, so we must defer.
+        n = StreamingLatexNormalizer()
+        out = self._drain(n, ["$ ", r"\alpha$"])
+        assert out == normalize_latex_to_unicode(r"$ \alpha$")
+        assert out == "α"
+
+    def test_trailing_dollar_backslash_split(self) -> None:
+        # Buffer ending with ``$\`` -- the next char (letter? non-letter?)
+        # determines whether this is math. Defer.
+        n = StreamingLatexNormalizer()
+        out = self._drain(n, ["$\\", r"alpha$"])
+        assert out == normalize_latex_to_unicode(r"$\alpha$")
+        assert out == "α"
+
     def test_multi_backtick_code_span_split(self) -> None:
         # Regression: a double-backtick code span split across chunks must
         # be held back until the matching closer arrives so the contents

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -182,3 +182,38 @@ class TestEdgeCases:
             normalize_latex_to_unicode(r"price is \$100 plus \$50")
             == r"price is \$100 plus \$50"
         )
+
+
+class TestCurrencyNotCorrupted:
+    """Regression: ``$...$`` must not be stripped across prose.
+
+    The original regex matched whenever any ``\\command`` appeared between
+    two ``$`` characters on the same line, which corrupted currency mentions.
+    The fix requires the math content to start with a backslash command.
+    """
+
+    def test_currency_with_bare_command_between(self) -> None:
+        assert (
+            normalize_latex_to_unicode(r"Price $5 and \alpha cost $10.")
+            == r"Price $5 and α cost $10."
+        )
+
+    def test_dollar_amounts_with_command_first(self) -> None:
+        # The first $ opens what looks like math, but content starts with
+        # "5 ..." not "\command", so the dollars stay put.
+        assert (
+            normalize_latex_to_unicode(r"Saved $50 thanks to \alpha-testing!")
+            == r"Saved $50 thanks to α-testing!"
+        )
+
+    def test_dollar_followed_by_text_then_command(self) -> None:
+        # `$abc\alpha$` -- content doesn't start with a backslash command,
+        # so we treat the dollars as literal and only convert the command.
+        assert normalize_latex_to_unicode(r"$abc\alpha$") == r"$abcα$"
+
+    def test_proper_math_still_converts(self) -> None:
+        # Sanity check that valid `$\command$` math still works after the fix.
+        assert (
+            normalize_latex_to_unicode(r"Spent $5 and saved $\rightarrow$ all good")
+            == r"Spent $5 and saved → all good"
+        )

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -292,6 +292,14 @@ class TestStreamingLatexNormalizer:
         out = self._drain(n, [r"Price $5 and ", r"\alpha cost $10."])
         assert out == r"Price $5 and α cost $10."
 
+    def test_currency_followed_by_split_math_span(self) -> None:
+        # Regression: the safe-split logic must not pair a currency `$` with
+        # a later math opener. Streaming "cost $5 and $\alp" then "ha$ end"
+        # should produce "cost $5 and α end", matching the persisted message.
+        n = StreamingLatexNormalizer()
+        out = self._drain(n, [r"cost $5 and $\alp", r"ha$ end"])
+        assert out == r"cost $5 and α end"
+
     def test_empty_chunks_are_noop(self) -> None:
         n = StreamingLatexNormalizer()
         assert not n.feed("")

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -380,6 +380,18 @@ class TestStreamingLatexNormalizer:
         assert out == normalize_latex_to_unicode("".join(chunks))
         assert out == r"``\alpha``"
 
+    def test_triple_backtick_fence_split(self) -> None:
+        # Regression: a fenced span split as ``` ```\\a `` + ``lpha``` ```
+        # must hold back until the closing ``` arrives. The old regex
+        # backtracked the opener from ``` to `, treating the first three
+        # backticks as a "closed" single-backtick span and normalizing the
+        # body as prose.
+        n = StreamingLatexNormalizer()
+        chunks = [r"```\a", r"lpha```"]
+        out = self._drain(n, chunks)
+        assert out == normalize_latex_to_unicode("".join(chunks))
+        assert out == r"```\alpha```"
+
     def test_inline_math_with_inner_whitespace_split(self) -> None:
         # ``$ \alpha$`` (LLM-emitted padding) split across chunks should
         # produce normalized ``α`` in the stream, matching the persisted

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -267,6 +267,13 @@ class TestCodeSpansPreserved:
             == r"see ```\beta``` here"
         )
 
+    def test_bracket_math_closer_inside_code_span_not_paired(self) -> None:
+        # The ``\]`` belongs to the surrounding code span, not to ``\[``.
+        # Both the persisted and streamed paths must preserve the verbatim
+        # markup rather than collapsing ``\[`\alpha\]``` into ``\`α\```.
+        text = r"Use \[`\alpha\]` notation."
+        assert normalize_latex_to_unicode(text) == text
+
 
 class TestStreamingLatexNormalizer:
     """Buffered normalization for chunked / streamed text."""
@@ -352,6 +359,16 @@ class TestStreamingLatexNormalizer:
         out = self._drain(n, ["$\\", r"alpha$"])
         assert out == normalize_latex_to_unicode(r"$\alpha$")
         assert out == "α"
+
+    def test_bracket_math_with_interior_code_span_not_paired(self) -> None:
+        # The ``\]`` is inside a code span, so the surrounding ``\[`` is
+        # not a math opener -- the streamer must keep the markup verbatim
+        # to match ``normalize_latex_to_unicode``.
+        n = StreamingLatexNormalizer()
+        text = r"Use \[`\alpha\]` notation."
+        out = self._drain(n, [text])
+        assert out == normalize_latex_to_unicode(text)
+        assert out == text
 
     def test_multi_backtick_code_span_split(self) -> None:
         # Regression: a double-backtick code span split across chunks must

--- a/tests/unit/utils/test_text_normalization_properties.py
+++ b/tests/unit/utils/test_text_normalization_properties.py
@@ -1,0 +1,305 @@
+"""Property-based and exhaustive tests for ``text_normalization``.
+
+The non-streaming and streaming paths must agree byte-for-byte for any input:
+``"".join(normalizer.feed(c) for c in chunks) + normalizer.flush()`` must
+equal ``normalize_latex_to_unicode("".join(chunks))`` regardless of how the
+input is split. This file exercises that invariant with Hypothesis-generated
+realistic LLM-style inputs and chunkings, plus an explicit table of
+construct combinations the reviewers have surfaced and adjacent edge cases.
+
+The Hypothesis strategy intentionally separates constructs with whitespace
+so it doesn't generate adversarial chains (``$\\alpha$$\\beta$``-style)
+that no incremental algorithm could resolve without buffering the entire
+message; the explicit regression table below covers the patterns that
+actually appeared in code review.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from family_assistant.utils.text_normalization import (
+    StreamingLatexNormalizer,
+    normalize_latex_to_unicode,
+)
+
+_COMMANDS: Final = [
+    "alpha",
+    "beta",
+    "gamma",
+    "rightarrow",
+    "to",
+    "le",
+    "ge",
+    "ne",
+    "approx",
+    "infty",
+    "pi",
+    "Delta",
+    "frac",
+    "unknown",  # not in dict; must pass through
+]
+
+
+def _stream(chunks: list[str]) -> str:
+    normalizer = StreamingLatexNormalizer()
+    parts = [normalizer.feed(chunk) for chunk in chunks]
+    parts.append(normalizer.flush())
+    return "".join(parts)
+
+
+def _assert_consistent(text: str, chunks: list[str]) -> None:
+    assert "".join(chunks) == text, "chunking dropped or duplicated input"
+    streamed = _stream(chunks)
+    persisted = normalize_latex_to_unicode(text)
+    assert streamed == persisted, (
+        f"divergence for {text!r} chunked as {chunks!r}\n"
+        f"  streamed:  {streamed!r}\n"
+        f"  persisted: {persisted!r}"
+    )
+
+
+@st.composite
+def _realistic_message(draw: st.DrawFn) -> str:
+    """Build a realistic LLM-style message.
+
+    Constructs (math spans, code spans, commands, currency, prose) are
+    separated by whitespace so we don't accidentally generate adversarial
+    overlapping delimiters. This matches how an LLM actually emits text.
+    """
+    pieces: list[str] = []
+    fragment_count = draw(st.integers(min_value=0, max_value=8))
+    for index in range(fragment_count):
+        kind = draw(
+            st.sampled_from([
+                "prose",
+                "prose",
+                "prose",
+                "command",
+                "currency",
+                "math",
+                "code",
+            ])
+        )
+        if kind == "prose":
+            count = draw(st.integers(min_value=1, max_value=10))
+            chars = draw(
+                st.lists(
+                    st.sampled_from("abcdefghijklmnopqrstuvwxyz .,;:!?"),
+                    min_size=count,
+                    max_size=count,
+                )
+            )
+            pieces.append("".join(chars))
+        elif kind == "command":
+            pieces.append("\\" + draw(st.sampled_from(_COMMANDS)))
+        elif kind == "currency":
+            amount = draw(st.integers(min_value=1, max_value=9999))
+            pieces.append(f"${amount}")
+        elif kind == "math":
+            cmd = draw(st.sampled_from(_COMMANDS))
+            opener = draw(st.sampled_from(["$", "$$", "\\(", "\\["]))
+            closer = {"$": "$", "$$": "$$", "\\(": "\\)", "\\[": "\\]"}[opener]
+            pad = draw(st.sampled_from(["", " ", "  "]))
+            pieces.append(f"{opener}{pad}\\{cmd}{pad}{closer}")
+        else:  # code
+            length = draw(st.integers(min_value=1, max_value=3))
+            cmd = draw(st.sampled_from(_COMMANDS))
+            fence = "`" * length
+            pieces.append(f"{fence}\\{cmd}{fence}")
+        if index < fragment_count - 1:
+            pieces.append(draw(st.sampled_from([" ", "  ", " \n", "\n"])))
+    return "".join(pieces)
+
+
+@st.composite
+def _chunkings(draw: st.DrawFn, text: str) -> list[str]:
+    """Split ``text`` into 1..N non-empty contiguous chunks."""
+    if len(text) < 2:
+        return [text] if text else [""]
+    n = len(text)
+    max_splits = min(n - 1, 6)
+    num_splits = draw(st.integers(min_value=0, max_value=max_splits))
+    if num_splits == 0:
+        return [text]
+    cuts = sorted(
+        draw(
+            st.lists(
+                st.integers(min_value=1, max_value=n - 1),
+                min_size=num_splits,
+                max_size=num_splits,
+                unique=True,
+            )
+        )
+    )
+    chunks: list[str] = []
+    prev = 0
+    for cut in cuts:
+        chunks.append(text[prev:cut])
+        prev = cut
+    chunks.append(text[prev:])
+    return chunks
+
+
+class TestStreamingMatchesPersisted:
+    """The core invariant: streamed output must equal persisted normalization
+    for any chunking of realistic LLM-style input.
+    """
+
+    @given(_realistic_message())
+    @settings(
+        max_examples=400,
+        deadline=None,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    def test_single_chunk_round_trip(self, text: str) -> None:
+        _assert_consistent(text, [text] if text else [""])
+
+    @given(st.data())
+    @settings(
+        max_examples=600,
+        deadline=None,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    def test_arbitrary_chunking(self, data: st.DataObject) -> None:
+        text = data.draw(_realistic_message())
+        chunks = data.draw(_chunkings(text))
+        _assert_consistent(text, chunks)
+
+    @given(_realistic_message())
+    @settings(
+        max_examples=300,
+        deadline=None,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    def test_char_by_char_streaming(self, text: str) -> None:
+        # Worst case: every character is its own chunk. Stresses the
+        # construct-deferral logic the hardest.
+        chunks = list(text) if text else [""]
+        _assert_consistent(text, chunks)
+
+
+# Hand-picked inputs covering the reviewer's case set plus adjacent shapes.
+# Each is tested under three chunkings: whole, mid-construct, char-by-char.
+_REGRESSION_INPUTS: Final = [
+    # Currency and math interaction
+    "Price $5 and \\alpha cost $10.",
+    "Saved $50 thanks to \\alpha-testing!",
+    "Spent $5 and saved $\\rightarrow$ all good",
+    "cost $5 and $\\alpha$ end",
+    # Inline math
+    "A $\\rightarrow$ B",
+    "$\\alpha + \\beta$",
+    "$ \\alpha$",
+    "$ \\alpha + \\beta $",
+    "$\\foo \\alpha$",  # unknown command inside math
+    # Display math
+    "$$\\int f \\, dx$$",
+    "$$\\alpha + \\beta$$",
+    # \( \) and \[ \]
+    "Use \\(\\alpha\\) here.",
+    "Display: \\[\\sum x_i\\] end.",
+    # Code spans
+    "Use `\\alpha` for greek.",
+    "``\\alpha``",
+    "```\\beta```",
+    "Block:\n```\nalpha = \\frac{1}{2}\n``` end",
+    # Code span containing math closer (must not be paired)
+    "Use \\[`\\alpha\\]` notation.",
+    "Code: `\\]` standalone.",
+    # Currency
+    "Just $100 here.",
+    "Paid $50 today, $25 yesterday.",
+    "price is \\$100 plus \\$50",
+    # Multiple constructs
+    "$\\alpha$ then `\\beta` plus \\gamma",
+    "`\\alpha`, `\\beta`, plain \\gamma",
+    # Multiline
+    "Line1: $\\alpha$\nLine2: $5\nLine3: $\\beta$",
+    # Empty / boundary
+    "",
+    " ",
+    "\\",
+    "$",
+    "`",
+    "$\\",
+    "``",
+    "```",
+    # Adjacent backticks
+    "``a``",
+    "`a` `b` `c`",
+    # Embedded
+    "Outer ``has `inner` backticks`` more",
+    # Currency near $$ display
+    "I owe $$\\alpha$$ to you and $5 in cash",
+    # Pathological backslashes
+    "\\\\alpha",  # escaped backslash then alpha
+    "\\$\\alpha\\$",  # escaped dollars
+]
+
+
+@pytest.mark.parametrize("text", _REGRESSION_INPUTS)
+class TestRegressionInputs:
+    def test_whole_chunk(self, text: str) -> None:
+        _assert_consistent(text, [text] if text else [""])
+
+    def test_char_by_char(self, text: str) -> None:
+        chunks = list(text) if text else [""]
+        _assert_consistent(text, chunks)
+
+    def test_split_after_every_other_char(self, text: str) -> None:
+        if len(text) < 2:
+            chunks = [text] if text else [""]
+        else:
+            chunks = [text[i : i + 2] for i in range(0, len(text), 2)]
+        _assert_consistent(text, chunks)
+
+
+class TestNormalizeProperties:
+    """Properties of the non-streaming function itself."""
+
+    @given(st.text(alphabet="abcde ", max_size=40))
+    def test_plain_text_unchanged(self, text: str) -> None:
+        assert normalize_latex_to_unicode(text) == text
+
+    @given(st.text(alphabet="abcde$ 1234567890.", max_size=40))
+    def test_text_without_backslash_unchanged(self, text: str) -> None:
+        # No backslash means no LaTeX -- short-circuit must preserve input.
+        assert normalize_latex_to_unicode(text) == text
+
+    @given(_realistic_message())
+    @settings(max_examples=200, deadline=None)
+    def test_idempotent(self, text: str) -> None:
+        once = normalize_latex_to_unicode(text)
+        twice = normalize_latex_to_unicode(once)
+        assert once == twice
+
+
+class TestStreamingProperties:
+    """Properties of the streaming normalizer itself."""
+
+    @given(_realistic_message())
+    @settings(max_examples=200, deadline=None)
+    def test_feed_returns_persisted_after_flush(self, text: str) -> None:
+        # The streaming output (after flush) must equal the persisted output.
+        streamed = _stream([text])
+        persisted = normalize_latex_to_unicode(text)
+        assert streamed == persisted
+
+    def test_flush_after_no_feed_is_empty(self) -> None:
+        normalizer = StreamingLatexNormalizer()
+        assert not normalizer.flush()
+
+    def test_flush_is_idempotent(self) -> None:
+        normalizer = StreamingLatexNormalizer()
+        normalizer.feed("hello")
+        normalizer.flush()
+        assert not normalizer.flush()
+
+    def test_empty_feed_returns_empty(self) -> None:
+        normalizer = StreamingLatexNormalizer()
+        assert not normalizer.feed("")

--- a/tests/unit/utils/test_text_normalization_properties.py
+++ b/tests/unit/utils/test_text_normalization_properties.py
@@ -211,6 +211,11 @@ _REGRESSION_INPUTS: Final = [
     # Code span containing math closer (must not be paired)
     "Use \\[`\\alpha\\]` notation.",
     "Code: `\\]` standalone.",
+    # Math opener and would-be closer separated by a code span -- the
+    # math regex would only see each side as a separate segment, so the
+    # streaming scan must too.
+    "$\\alpha`x`$\\beta$",
+    "\\[\\alpha`x`\\]\\beta\\)",
     # Currency
     "Just $100 here.",
     "Paid $50 today, $25 yesterday.",

--- a/uv.lock
+++ b/uv.lock
@@ -1823,6 +1823,11 @@ pgserver = [
     { name = "pixeltable-pgserver" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "hypothesis" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.0" },
@@ -1954,7 +1959,7 @@ requires-dist = [
 provides-extras = ["dev", "local-embeddings", "pgserver"]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "hypothesis", specifier = ">=6.152.9" }]
 
 [[package]]
 name = "fastapi"
@@ -2802,6 +2807,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/e6/bb064537288eee2be97f3e0fcad8e7242bc5bbe9664ae57c7d29b3fa18c2/hupper-1.12.1.tar.gz", hash = "sha256:06bf54170ff4ecf4c84ad5f188dee3901173ab449c2608ad05b9bfd6b13e32eb", size = 43231, upload-time = "2024-01-26T09:14:57.294Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/7d/3888833e4f5ea56af4a9935066ec09a83228e533d7b8877f65889d706ee4/hupper-1.12.1-py3-none-any.whl", hash = "sha256:e872b959f09d90be5fb615bd2e62de89a0b57efc037bdf9637fb09cdf8552b19", size = 22830, upload-time = "2024-01-26T09:14:55.176Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.152.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/fb/a5651eb0cd03ecee644e8f4d8cd2027b40a08bf1488f46201e794aebe9b5/hypothesis-6.152.9.tar.gz", hash = "sha256:de4711d69ce3a18009047c3b44882810fd0c0348c1558e920a4b0d2c45f59e1e", size = 472009, upload-time = "2026-05-19T17:10:19.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/d9/40ef7ed22f0c45c2316467edb9afb8fc172cd089cb329c0ee6da6b74416c/hypothesis-6.152.9-py3-none-any.whl", hash = "sha256:9c4fdccb1eac0b12ec740c12290d0e6a0bea3526a3f0bf812b7643bb563c2d8b", size = 538148, upload-time = "2026-05-19T17:10:16.131Z" },
 ]
 
 [[package]]
@@ -6024,6 +6041,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/83/acef455bd45428b512148db8c67ffdbb5e3460ab4e036dd896de15db0e7b/snitun-0.44.0.tar.gz", hash = "sha256:b9f693568ea6a7da6a9fa459597a404c1657bfb9259eb076005a8eb1247df087", size = 41098, upload-time = "2025-07-22T21:42:19.373Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/77/6b58e87ea1ced25cd90bb90e1def088485fae8e35771255943a4bd9c72ab/snitun-0.44.0-py3-none-any.whl", hash = "sha256:8c351ed936c9768d68b1dc5a33ad91c1b8d57cad09f29e73e0b19df0e573c08b", size = 48365, upload-time = "2025-07-22T21:42:18.013Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1770,6 +1770,7 @@ dev = [
     { name = "homeassistant", version = "2025.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13.2' and platform_python_implementation == 'PyPy'" },
     { name = "homeassistant", version = "2025.10.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13.2' and platform_python_implementation != 'PyPy'" },
     { name = "hupper" },
+    { name = "hypothesis" },
     { name = "llm-fragments-github" },
     { name = "llm-fragments-reader" },
     { name = "llm-gemini" },
@@ -1823,11 +1824,6 @@ pgserver = [
     { name = "pixeltable-pgserver" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "hypothesis" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.0" },
@@ -1859,6 +1855,7 @@ requires-dist = [
     { name = "homeassistant-api", specifier = ">=5.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "hupper", marker = "extra == 'dev'", specifier = ">=1.12.1" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.152.9" },
     { name = "icalendar", specifier = ">=6.0.0" },
     { name = "itsdangerous", specifier = ">=2.1.0" },
     { name = "janus", specifier = ">=1.0.0" },
@@ -1957,9 +1954,6 @@ requires-dist = [
     { name = "yt-dlp", specifier = ">=2024.0.0" },
 ]
 provides-extras = ["dev", "local-embeddings", "pgserver"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "hypothesis", specifier = ">=6.152.9" }]
 
 [[package]]
 name = "fastapi"


### PR DESCRIPTION
The assistant sometimes emits LaTeX-flavoured snippets like
``$\rightarrow$`` or ``\alpha`` in prose. None of the delivery surfaces
(Telegram, plain-text email, the React frontend without KaTeX) render
LaTeX, so users see raw markup.

Add ``normalize_latex_to_unicode`` and apply it where assistant text
becomes user-visible:

- ``ProcessingService.handle_chat_interaction`` and its streaming
  counterpart normalize ``AssistantMessage.content`` before persistence,
  so the final ``text_reply`` and stored history are consistent across
  every interface.
- The web SSE streaming endpoint normalizes each text chunk so live
  tokens match the finalized message.

The conversion is conservative: text without a backslash is returned
unchanged, math delimiters (``$...$``, ``\(...\)``, ``\[...\]``) are
stripped only when they wrap a backslash command (so ``$100 fee`` is
left alone), and unknown commands pass through untouched.