### PR TITLE
Fix remote_a2a config silently dropped during profile resolution

### DIFF
--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -766,6 +766,10 @@ def resolve_service_profile(
     ):
         resolved["visibility_grants"] = profile_def["visibility_grants"]
 
+    # Handle remote_a2a (replace if present)
+    if "remote_a2a" in profile_def:
+        resolved["remote_a2a"] = profile_def["remote_a2a"]
+
     return resolved
 
 

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -2137,6 +2137,57 @@ class TestLoadConfig:
         assert "brave" in servers
         assert "custom" in servers
 
+    def test_remote_a2a_profile_survives_full_config_load(self, tmp_path: Path) -> None:
+        """End-to-end: remote_a2a config in YAML produces a ServiceProfile with remote_a2a set."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            yaml.dump({
+                "service_profiles": [
+                    {
+                        "id": "k8s_agent",
+                        "description": "Remote Kubernetes agent",
+                        "remote_a2a": {
+                            "agent_url": "http://k8s-agent:9000/a2a",
+                            "auth": {
+                                "type": "bearer",
+                                "token_env": "K8S_AGENT_TOKEN",
+                            },
+                            "timeout_seconds": 60.0,
+                            "skills_description": "Kubernetes operations",
+                        },
+                    }
+                ]
+            })
+        )
+        prompts_file = tmp_path / "prompts.yaml"
+        prompts_file.write_text(yaml.dump({"system_prompt": "test"}))
+
+        env_to_clear = [m.env_var for m in ENV_VAR_MAPPINGS]
+        env_to_clear.extend([
+            "CALDAV_USERNAME",
+            "CALDAV_PASSWORD",
+            "CALDAV_CALENDAR_URLS",
+            "ICAL_URLS",
+            "MCP_CONFIG_PATH",
+            "INDEXING_PIPELINE_CONFIG_JSON",
+        ])
+        clean_env = {k: v for k, v in os.environ.items() if k not in env_to_clear}
+
+        with mock.patch.dict(os.environ, clean_env, clear=True):
+            config = load_config(
+                config_file_path=str(config_file),
+                prompts_file_path=str(prompts_file),
+                load_dotenv_file=False,
+            )
+
+        k8s_profile = next(p for p in config.service_profiles if p.id == "k8s_agent")
+        assert k8s_profile.remote_a2a is not None
+        assert k8s_profile.remote_a2a.agent_url == "http://k8s-agent:9000/a2a"
+        assert k8s_profile.remote_a2a.auth.type == "bearer"
+        assert k8s_profile.remote_a2a.auth.token_env == "K8S_AGENT_TOKEN"
+        assert k8s_profile.remote_a2a.timeout_seconds == 60.0
+        assert k8s_profile.remote_a2a.skills_description == "Kubernetes operations"
+
 
 class TestEnvVarMappingsComplete:
     """Tests to ensure environment variable mappings are complete and correct."""

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1668,7 +1668,20 @@ class TestLoadConfig:
                         "id": "test_profile",
                         "description": "A test profile",
                         "processing_config": {"max_iterations": 25},
-                    }
+                    },
+                    {
+                        "id": "k8s_agent",
+                        "description": "Remote Kubernetes agent",
+                        "remote_a2a": {
+                            "agent_url": "http://k8s-agent:9000/a2a",
+                            "auth": {
+                                "type": "bearer",
+                                "token_env": "K8S_AGENT_TOKEN",
+                            },
+                            "timeout_seconds": 60.0,
+                            "skills_description": "Kubernetes operations",
+                        },
+                    },
                 ]
             })
         )
@@ -1702,6 +1715,13 @@ class TestLoadConfig:
             p for p in config.service_profiles if p.id == "test_profile"
         )
         assert test_profile.processing_config.max_iterations == 25
+        # remote_a2a config survives the full load_config pipeline
+        k8s_profile = next(p for p in config.service_profiles if p.id == "k8s_agent")
+        assert k8s_profile.remote_a2a is not None
+        assert k8s_profile.remote_a2a.agent_url == "http://k8s-agent:9000/a2a"
+        assert k8s_profile.remote_a2a.auth.type == "bearer"
+        assert k8s_profile.remote_a2a.auth.token_env == "K8S_AGENT_TOKEN"
+        assert k8s_profile.remote_a2a.timeout_seconds == 60.0
 
     def test_profile_inherits_timezone_from_defaults(self, tmp_path: Path) -> None:
         """Regression: profile without explicit timezone inherits from defaults.
@@ -2136,57 +2156,6 @@ class TestLoadConfig:
         assert "time" in servers
         assert "brave" in servers
         assert "custom" in servers
-
-    def test_remote_a2a_profile_survives_full_config_load(self, tmp_path: Path) -> None:
-        """End-to-end: remote_a2a config in YAML produces a ServiceProfile with remote_a2a set."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text(
-            yaml.dump({
-                "service_profiles": [
-                    {
-                        "id": "k8s_agent",
-                        "description": "Remote Kubernetes agent",
-                        "remote_a2a": {
-                            "agent_url": "http://k8s-agent:9000/a2a",
-                            "auth": {
-                                "type": "bearer",
-                                "token_env": "K8S_AGENT_TOKEN",
-                            },
-                            "timeout_seconds": 60.0,
-                            "skills_description": "Kubernetes operations",
-                        },
-                    }
-                ]
-            })
-        )
-        prompts_file = tmp_path / "prompts.yaml"
-        prompts_file.write_text(yaml.dump({"system_prompt": "test"}))
-
-        env_to_clear = [m.env_var for m in ENV_VAR_MAPPINGS]
-        env_to_clear.extend([
-            "CALDAV_USERNAME",
-            "CALDAV_PASSWORD",
-            "CALDAV_CALENDAR_URLS",
-            "ICAL_URLS",
-            "MCP_CONFIG_PATH",
-            "INDEXING_PIPELINE_CONFIG_JSON",
-        ])
-        clean_env = {k: v for k, v in os.environ.items() if k not in env_to_clear}
-
-        with mock.patch.dict(os.environ, clean_env, clear=True):
-            config = load_config(
-                config_file_path=str(config_file),
-                prompts_file_path=str(prompts_file),
-                load_dotenv_file=False,
-            )
-
-        k8s_profile = next(p for p in config.service_profiles if p.id == "k8s_agent")
-        assert k8s_profile.remote_a2a is not None
-        assert k8s_profile.remote_a2a.agent_url == "http://k8s-agent:9000/a2a"
-        assert k8s_profile.remote_a2a.auth.type == "bearer"
-        assert k8s_profile.remote_a2a.auth.token_env == "K8S_AGENT_TOKEN"
-        assert k8s_profile.remote_a2a.timeout_seconds == 60.0
-        assert k8s_profile.remote_a2a.skills_description == "Kubernetes operations"
 
 
 class TestEnvVarMappingsComplete:

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1074,6 +1074,40 @@ class TestResolveServiceProfile:
             result["processing_config"]["retry_config"]["primary"]["model"] == "gpt-4o"
         )
 
+    def test_remote_a2a_copied_from_profile(self) -> None:
+        """Test that remote_a2a config is preserved in the resolved profile."""
+        default_settings: dict[str, Any] = {
+            "processing_config": {"timezone": "UTC"},
+            "tools_config": {},
+            "chat_id_to_name_map": {},
+            "slash_commands": [],
+        }
+        remote_a2a_config = {
+            "agent_url": "https://agent.example.com/a2a",
+            "auth": {"type": "bearer", "token_env": "AGENT_TOKEN"},
+            "timeout_seconds": 120.0,
+            "skills_description": "Remote agent skills",
+        }
+        profile_def = {
+            "id": "remote_agent",
+            "description": "A remote A2A agent",
+            "remote_a2a": remote_a2a_config,
+        }
+        result = resolve_service_profile(profile_def, default_settings, {})
+        assert result["remote_a2a"] == remote_a2a_config
+
+    def test_remote_a2a_absent_when_not_in_profile(self) -> None:
+        """Test that remote_a2a is not added when not in profile definition."""
+        default_settings: dict[str, Any] = {
+            "processing_config": {"timezone": "UTC"},
+            "tools_config": {},
+            "chat_id_to_name_map": {},
+            "slash_commands": [],
+        }
+        profile_def = {"id": "local_profile", "description": "A local profile"}
+        result = resolve_service_profile(profile_def, default_settings, {})
+        assert "remote_a2a" not in result
+
 
 class TestResolveAllServiceProfiles:
     """Tests for resolve_all_service_profiles function."""


### PR DESCRIPTION
resolve_service_profile() never copied the remote_a2a field from the
profile definition into the resolved profile dict, so remote A2A
configurations parsed from config were lost before Assistant saw them.

https://claude.ai/code/session_01TG9H2ivkxePbAms77VCN63