### PR TITLE
[codex] Fix remote A2A task polling

### DIFF
--- a/src/family_assistant/a2a/client.py
+++ b/src/family_assistant/a2a/client.py
@@ -6,14 +6,21 @@ and content part conversion for remote profile delegation.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import a2a.types as a2a_types
 import httpx
-from a2a.client import A2ACardResolver
-from a2a.client.errors import A2AClientHTTPError as SdkHTTPError
+from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.client.errors import (
+    A2AClientError as SdkClientError,
+    A2AClientHTTPError as SdkHTTPError,
+    A2AClientJSONRPCError as SdkJSONRPCError,
+    A2AClientTimeoutError as SdkTimeoutError,
+)
 
 from family_assistant.a2a.converters import content_parts_to_a2a_parts
 from family_assistant.a2a.types import (
@@ -22,6 +29,9 @@ from family_assistant.a2a.types import (
     Part,
     Role,
     Task,
+    TaskQueryParams,
+    TaskState,
+    TaskStatus,
 )
 
 if TYPE_CHECKING:
@@ -33,6 +43,15 @@ logger = logging.getLogger(__name__)
 # Limit on base64-encoded size in the JSON-RPC payload (not decoded file size).
 # Base64 inflates by ~33%, so this allows ~7.5 MB raw files.
 MAX_INLINE_ATTACHMENT_BYTES = 10 * 1024 * 1024
+POLL_INTERVAL_SECONDS = 1.0
+TERMINAL_TASK_STATES = {
+    TaskState.completed,
+    TaskState.failed,
+    TaskState.canceled,
+    TaskState.rejected,
+    TaskState.auth_required,
+    TaskState.input_required,
+}
 
 
 class A2AClientError(Exception):
@@ -125,52 +144,71 @@ class A2AClientWrapper:
             metadata=metadata,
         )
 
-        rpc_url = card.url
-        jsonrpc_payload = {
-            "jsonrpc": "2.0",
-            "id": str(uuid.uuid4()),
-            "method": "message/send",
-            "params": {"message": message.model_dump(exclude_none=True)},
-        }
-
         client = self._get_httpx_client()
         try:
-            response = await client.post(rpc_url, json=jsonrpc_payload)
-            response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            raise A2AClientError(
-                f"HTTP {exc.response.status_code} from A2A agent at {rpc_url}"
-            ) from exc
-        except httpx.ConnectError as exc:
-            raise A2AClientError(
-                f"Cannot connect to A2A agent at {rpc_url}: {exc}"
-            ) from exc
-        except httpx.TimeoutException as exc:
-            raise A2AClientError(
-                f"Timeout connecting to A2A agent at {rpc_url}"
-            ) from exc
+            a2a_client = ClientFactory(
+                ClientConfig(
+                    streaming=True,
+                    polling=False,
+                    httpx_client=client,
+                    accepted_output_modes=card.default_output_modes or [],
+                )
+            ).create(card)
+            latest_task: Task | None = None
+            async for event in a2a_client.send_message(message):
+                if isinstance(event, Message):
+                    return self._message_to_completed_task(event, context_id)
+                task, _update = event
+                latest_task = task
+                if self._is_terminal(task):
+                    return task
+            if latest_task is None:
+                raise A2AClientError("A2A agent returned no message or task")
+            return await self._poll_until_terminal(a2a_client, latest_task)
+        except SdkClientError as exc:
+            raise A2AClientError(self._format_sdk_error(exc, card.url)) from exc
 
-        try:
-            body = response.json()
-        except ValueError as exc:
-            raise A2AClientError(
-                f"Invalid JSON response from A2A agent at {rpc_url}"
-            ) from exc
-
-        if "error" in body:
-            error = body["error"]
-            raise A2AClientError(
-                f"A2A JSON-RPC error {error.get('code')}: {error.get('message')}"
+    async def _poll_until_terminal(self, a2a_client: Any, task: Task) -> Task:
+        """Poll tasks/get for agents that return a non-terminal message/send Task."""
+        deadline = time.monotonic() + self._timeout
+        latest_task = task
+        while not self._is_terminal(latest_task):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise A2AClientError(
+                    f"Timed out waiting for A2A task {latest_task.id} to reach a terminal state "
+                    f"(last state: {latest_task.status.state})"
+                )
+            await asyncio.sleep(min(POLL_INTERVAL_SECONDS, remaining))
+            latest_task = await a2a_client.get_task(
+                TaskQueryParams(id=latest_task.id)
             )
+        return latest_task
 
-        result = body.get("result")
-        if result is None:
-            raise A2AClientError("A2A response missing 'result' field")
+    @staticmethod
+    def _is_terminal(task: Task) -> bool:
+        return task.status.state in TERMINAL_TASK_STATES
 
-        try:
-            return Task.model_validate(result)
-        except Exception as exc:
-            raise A2AClientError(f"Failed to parse A2A task response: {exc}") from exc
+    @staticmethod
+    def _message_to_completed_task(message: Message, fallback_context_id: str | None) -> Task:
+        return Task(
+            id=message.task_id or str(uuid.uuid4()),
+            context_id=message.context_id or fallback_context_id or str(uuid.uuid4()),
+            status=TaskStatus(state=TaskState.completed, message=message),
+            history=[message],
+        )
+
+    @staticmethod
+    def _format_sdk_error(exc: SdkClientError, url: str) -> str:
+        if isinstance(exc, SdkJSONRPCError):
+            return f"A2A JSON-RPC error {exc.error.code}: {exc.error.message}"
+        if isinstance(exc, SdkTimeoutError):
+            return f"Timeout connecting to A2A agent at {url}: {exc.message}"
+        if isinstance(exc, SdkHTTPError):
+            if exc.status_code == 503 and "Network communication error" in exc.message:
+                return f"Cannot connect to A2A agent at {url}: {exc.message}"
+            return f"HTTP {exc.status_code} from A2A agent at {url}: {exc.message}"
+        return f"A2A client error communicating with {url}: {exc}"
 
     def _convert_and_validate_parts(
         self, content_parts: list[ContentPartDict]

--- a/src/family_assistant/a2a/client.py
+++ b/src/family_assistant/a2a/client.py
@@ -10,15 +10,21 @@ import asyncio
 import logging
 import time
 import uuid
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import a2a.types as a2a_types
 import httpx
-from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.client import A2ACardResolver, Client, ClientConfig, ClientFactory
 from a2a.client.errors import (
     A2AClientError as SdkClientError,
+)
+from a2a.client.errors import (
     A2AClientHTTPError as SdkHTTPError,
+)
+from a2a.client.errors import (
     A2AClientJSONRPCError as SdkJSONRPCError,
+)
+from a2a.client.errors import (
     A2AClientTimeoutError as SdkTimeoutError,
 )
 
@@ -168,7 +174,7 @@ class A2AClientWrapper:
         except SdkClientError as exc:
             raise A2AClientError(self._format_sdk_error(exc, card.url)) from exc
 
-    async def _poll_until_terminal(self, a2a_client: Any, task: Task) -> Task:
+    async def _poll_until_terminal(self, a2a_client: Client, task: Task) -> Task:
         """Poll tasks/get for agents that return a non-terminal message/send Task."""
         deadline = time.monotonic() + self._timeout
         latest_task = task
@@ -180,9 +186,7 @@ class A2AClientWrapper:
                     f"(last state: {latest_task.status.state})"
                 )
             await asyncio.sleep(min(POLL_INTERVAL_SECONDS, remaining))
-            latest_task = await a2a_client.get_task(
-                TaskQueryParams(id=latest_task.id)
-            )
+            latest_task = await a2a_client.get_task(TaskQueryParams(id=latest_task.id))
         return latest_task
 
     @staticmethod
@@ -190,7 +194,9 @@ class A2AClientWrapper:
         return task.status.state in TERMINAL_TASK_STATES
 
     @staticmethod
-    def _message_to_completed_task(message: Message, fallback_context_id: str | None) -> Task:
+    def _message_to_completed_task(
+        message: Message, fallback_context_id: str | None
+    ) -> Task:
         return Task(
             id=message.task_id or str(uuid.uuid4()),
             context_id=message.context_id or fallback_context_id or str(uuid.uuid4()),

--- a/tests/unit/a2a_client/test_a2a_client.py
+++ b/tests/unit/a2a_client/test_a2a_client.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import json
 import threading
 import uuid
-from collections.abc import Iterator
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 import httpx
 import pytest
@@ -37,6 +36,8 @@ from family_assistant.llm.content_parts import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from pytest_httpx import HTTPXMock
 
 
@@ -65,14 +66,21 @@ def _content_parts(text: str) -> list[ContentPartDict]:
     return cast("list[ContentPartDict]", [text_content(text)])
 
 
+def _text_part_text(part: Part) -> str:
+    root = part.root
+    assert isinstance(root, TextPart)
+    return root.text
+
+
 class FakeA2AAgentHandler(BaseHTTPRequestHandler):
-    mode = "completed"
-    task_id = "task-test"
-    task_state = "completed"
-    task_message = "Remote task failed"
-    text = "Hello from remote"
-    streaming = False
-    poll_count = 0
+    mode: ClassVar[str] = "completed"
+    task_id: ClassVar[str] = "task-test"
+    task_state: ClassVar[str] = "completed"
+    task_message: ClassVar[str] = "Remote task failed"
+    text: ClassVar[str] = "Hello from remote"
+    streaming: ClassVar[bool] = False
+    poll_count: ClassVar[int] = 0
+    agent_url: ClassVar[str] = ""
 
     def log_message(self, _fmt: str, *_args: object) -> None:
         return
@@ -104,31 +112,38 @@ class FakeA2AAgentHandler(BaseHTTPRequestHandler):
 
     def handle_message_send(self, body: dict) -> None:
         if self.mode == "jsonrpc_error":
-            self.send_json(self.jsonrpc_error(body.get("id"), -32600, "Invalid request"))
-            return
-        if self.mode == "message":
-            self.send_json({"jsonrpc": "2.0", "id": body.get("id"), "result": self.message()})
-            return
-        if self.mode == "poll":
             self.send_json(
-                {
-                    "jsonrpc": "2.0",
-                    "id": body.get("id"),
-                    "result": self.task("working", artifacts=False),
-                }
+                self.jsonrpc_error(body.get("id"), -32600, "Invalid request")
             )
             return
-        self.send_json(
-            {
+        if self.mode == "message":
+            self.send_json({
                 "jsonrpc": "2.0",
                 "id": body.get("id"),
-                "result": self.task(self.task_state, artifacts=self.task_state == "completed"),
-            }
-        )
+                "result": self.message(),
+            })
+            return
+        if self.mode == "poll":
+            self.send_json({
+                "jsonrpc": "2.0",
+                "id": body.get("id"),
+                "result": self.task("working", artifacts=False),
+            })
+            return
+        self.send_json({
+            "jsonrpc": "2.0",
+            "id": body.get("id"),
+            "result": self.task(
+                self.task_state, artifacts=self.task_state == "completed"
+            ),
+        })
 
     def handle_message_stream(self, body: dict) -> None:
         if self.mode == "jsonrpc_error":
-            self.send_sse(body.get("id"), [self.jsonrpc_error(body.get("id"), -32600, "Invalid request")])
+            self.send_sse(
+                body.get("id"),
+                [self.jsonrpc_error(body.get("id"), -32600, "Invalid request")],
+            )
             return
         if self.mode == "message":
             self.send_sse(
@@ -171,13 +186,11 @@ class FakeA2AAgentHandler(BaseHTTPRequestHandler):
 
     def handle_tasks_get(self, body: dict) -> None:
         type(self).poll_count += 1
-        self.send_json(
-            {
-                "jsonrpc": "2.0",
-                "id": body.get("id"),
-                "result": self.task("completed", artifacts=True),
-            }
-        )
+        self.send_json({
+            "jsonrpc": "2.0",
+            "id": body.get("id"),
+            "result": self.task("completed", artifacts=True),
+        })
 
     def send_json(self, value: dict, status: HTTPStatus = HTTPStatus.OK) -> None:
         payload = json.dumps(value).encode()
@@ -197,7 +210,8 @@ class FakeA2AAgentHandler(BaseHTTPRequestHandler):
             self.wfile.flush()
 
     def rpc_url(self) -> str:
-        return f"http://127.0.0.1:{self.server.server_port}/a2a"
+        server = cast("ThreadingHTTPServer", self.server)
+        return f"http://127.0.0.1:{server.server_port}/a2a"
 
     def task(self, state: str, *, artifacts: bool) -> dict:
         task: dict = {
@@ -369,7 +383,7 @@ class TestA2AClientWrapper:
         task = await wrapper.send_message(_content_parts("Hello"))
         assert task.status.state == TaskState.completed
         assert task.artifacts is not None
-        assert task.artifacts[0].parts[0].root.text == "Hello back!"
+        assert _text_part_text(task.artifacts[0].parts[0]) == "Hello back!"
         await wrapper.close()
 
     @pytest.mark.asyncio
@@ -384,7 +398,7 @@ class TestA2AClientWrapper:
         task = await wrapper.send_message(_content_parts("Hello"))
         assert task.status.state == TaskState.completed
         assert task.artifacts is not None
-        assert task.artifacts[0].parts[0].root.text == "Finished later"
+        assert _text_part_text(task.artifacts[0].parts[0]) == "Finished later"
         assert fake_a2a_agent.poll_count == 1
         await wrapper.close()
 
@@ -400,7 +414,7 @@ class TestA2AClientWrapper:
         task = await wrapper.send_message(_content_parts("Hello"))
         assert task.status.state == TaskState.completed
         assert task.history is not None
-        assert task.history[-1].parts[0].root.text == "Direct answer"
+        assert _text_part_text(task.history[-1].parts[0]) == "Direct answer"
         await wrapper.close()
 
     @pytest.mark.asyncio
@@ -416,7 +430,7 @@ class TestA2AClientWrapper:
         task = await wrapper.send_message(_content_parts("Hello"))
         assert task.status.state == TaskState.completed
         assert task.artifacts is not None
-        assert task.artifacts[0].parts[0].root.text == "Streamed answer"
+        assert _text_part_text(task.artifacts[0].parts[0]) == "Streamed answer"
         await wrapper.close()
 
     @pytest.mark.asyncio
@@ -443,7 +457,7 @@ class TestA2AClientWrapper:
         task = await wrapper.send_message(_content_parts("Hello"))
         assert task.status.state == TaskState.failed
         assert task.status.message is not None
-        assert task.status.message.parts[0].root.text == "LLM error"
+        assert _text_part_text(task.status.message.parts[0]) == "LLM error"
         await wrapper.close()
 
     @pytest.mark.asyncio
@@ -470,7 +484,7 @@ class TestA2AClientWrapper:
         task = await wrapper.send_message(_content_parts("Hello"))
         assert task.status.state == expected
         assert task.status.message is not None
-        assert task.status.message.parts[0].root.text == "Terminal state message"
+        assert _text_part_text(task.status.message.parts[0]) == "Terminal state message"
         await wrapper.close()
 
     @pytest.mark.asyncio

--- a/tests/unit/a2a_client/test_a2a_client.py
+++ b/tests/unit/a2a_client/test_a2a_client.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import json
+import threading
 import uuid
+from collections.abc import Iterator
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import TYPE_CHECKING, cast
 
 import httpx
@@ -49,47 +54,236 @@ def _make_agent_card(url: str = "http://agent.test/api/a2a") -> dict:
     }
 
 
-def _make_task_response(
-    text: str = "Hello from remote",
-    state: str = "completed",
-    task_id: str | None = None,
-    message: str | None = None,
-) -> dict:
-    """Build a completed task JSON-RPC response."""
-    tid = task_id or str(uuid.uuid4())
-    artifact = {
-        "artifactId": str(uuid.uuid4()),
-        "parts": [{"kind": "text", "text": text}],
-    }
-    result: dict = {
-        "id": tid,
-        "contextId": "test-ctx",
-        "status": {"state": state},
-        "artifacts": [artifact] if state == "completed" else [],
-    }
-    if message:
-        result["status"]["message"] = {
-            "role": "agent",
-            "messageId": str(uuid.uuid4()),
-            "parts": [{"kind": "text", "text": message}],
-        }
-    return {
-        "jsonrpc": "2.0",
-        "id": "1",
-        "result": result,
-    }
-
-
-def _make_error_response(code: int = -32603, message: str = "Internal error") -> dict:
-    return {
-        "jsonrpc": "2.0",
-        "id": "1",
-        "error": {"code": code, "message": message},
-    }
+def _make_streaming_agent_card(url: str) -> dict:
+    card = _make_agent_card(url)
+    card["capabilities"]["streaming"] = True
+    card["preferredTransport"] = "JSONRPC"
+    return card
 
 
 def _content_parts(text: str) -> list[ContentPartDict]:
     return cast("list[ContentPartDict]", [text_content(text)])
+
+
+class FakeA2AAgentHandler(BaseHTTPRequestHandler):
+    mode = "completed"
+    task_id = "task-test"
+    task_state = "completed"
+    task_message = "Remote task failed"
+    text = "Hello from remote"
+    streaming = False
+    poll_count = 0
+
+    def log_message(self, _fmt: str, *_args: object) -> None:
+        return
+
+    def do_GET(self) -> None:
+        if self.path != "/.well-known/agent-card.json":
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        self.send_json(
+            _make_streaming_agent_card(self.rpc_url())
+            if self.streaming
+            else _make_agent_card(self.rpc_url())
+        )
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length))
+        method = body.get("method")
+        if method == "message/send":
+            self.handle_message_send(body)
+            return
+        if method == "message/stream":
+            self.handle_message_stream(body)
+            return
+        if method == "tasks/get":
+            self.handle_tasks_get(body)
+            return
+        self.send_json(self.jsonrpc_error(body.get("id"), -32601, "Method not found"))
+
+    def handle_message_send(self, body: dict) -> None:
+        if self.mode == "jsonrpc_error":
+            self.send_json(self.jsonrpc_error(body.get("id"), -32600, "Invalid request"))
+            return
+        if self.mode == "message":
+            self.send_json({"jsonrpc": "2.0", "id": body.get("id"), "result": self.message()})
+            return
+        if self.mode == "poll":
+            self.send_json(
+                {
+                    "jsonrpc": "2.0",
+                    "id": body.get("id"),
+                    "result": self.task("working", artifacts=False),
+                }
+            )
+            return
+        self.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": body.get("id"),
+                "result": self.task(self.task_state, artifacts=self.task_state == "completed"),
+            }
+        )
+
+    def handle_message_stream(self, body: dict) -> None:
+        if self.mode == "jsonrpc_error":
+            self.send_sse(body.get("id"), [self.jsonrpc_error(body.get("id"), -32600, "Invalid request")])
+            return
+        if self.mode == "message":
+            self.send_sse(
+                body.get("id"),
+                [{"jsonrpc": "2.0", "id": body.get("id"), "result": self.message()}],
+            )
+            return
+        if self.mode == "stream":
+            self.send_sse(
+                body.get("id"),
+                [
+                    {
+                        "jsonrpc": "2.0",
+                        "id": body.get("id"),
+                        "result": self.status_event("working", final=False),
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": body.get("id"),
+                        "result": self.artifact_event(),
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": body.get("id"),
+                        "result": self.status_event("completed", final=True),
+                    },
+                ],
+            )
+            return
+        self.send_sse(
+            body.get("id"),
+            [
+                {
+                    "jsonrpc": "2.0",
+                    "id": body.get("id"),
+                    "result": self.status_event(self.task_state, final=True),
+                }
+            ],
+        )
+
+    def handle_tasks_get(self, body: dict) -> None:
+        type(self).poll_count += 1
+        self.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": body.get("id"),
+                "result": self.task("completed", artifacts=True),
+            }
+        )
+
+    def send_json(self, value: dict, status: HTTPStatus = HTTPStatus.OK) -> None:
+        payload = json.dumps(value).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def send_sse(self, _request_id: object, events: list[dict]) -> None:
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        for event in events:
+            self.wfile.write(f"data: {json.dumps(event)}\n\n".encode())
+            self.wfile.flush()
+
+    def rpc_url(self) -> str:
+        return f"http://127.0.0.1:{self.server.server_port}/a2a"
+
+    def task(self, state: str, *, artifacts: bool) -> dict:
+        task: dict = {
+            "id": self.task_id,
+            "contextId": "test-ctx",
+            "status": {"state": state},
+        }
+        if state != "completed":
+            task["status"]["message"] = self.status_message(self.task_message)
+        if artifacts:
+            task["artifacts"] = [self.artifact()]
+        return task
+
+    def message(self) -> dict:
+        return {
+            "kind": "message",
+            "role": "agent",
+            "messageId": str(uuid.uuid4()),
+            "contextId": "test-ctx",
+            "parts": [{"kind": "text", "text": self.text}],
+        }
+
+    def status_event(self, state: str, *, final: bool) -> dict:
+        return {
+            "kind": "status-update",
+            "taskId": self.task_id,
+            "contextId": "test-ctx",
+            "status": {
+                "state": state,
+                "message": self.status_message(self.task_message),
+            },
+            "final": final,
+        }
+
+    def artifact_event(self) -> dict:
+        return {
+            "kind": "artifact-update",
+            "taskId": self.task_id,
+            "contextId": "test-ctx",
+            "artifact": self.artifact(),
+            "append": False,
+            "lastChunk": True,
+        }
+
+    def artifact(self) -> dict:
+        return {
+            "artifactId": "artifact-1",
+            "parts": [{"kind": "text", "text": self.text}],
+        }
+
+    @staticmethod
+    def status_message(text: str) -> dict:
+        return {
+            "role": "agent",
+            "messageId": str(uuid.uuid4()),
+            "parts": [{"kind": "text", "text": text}],
+        }
+
+    @staticmethod
+    def jsonrpc_error(request_id: object, code: int, message: str) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }
+
+
+@pytest.fixture
+def fake_a2a_agent() -> Iterator[type[FakeA2AAgentHandler]]:
+    FakeA2AAgentHandler.mode = "completed"
+    FakeA2AAgentHandler.task_id = f"task-{uuid.uuid4()}"
+    FakeA2AAgentHandler.task_state = "completed"
+    FakeA2AAgentHandler.task_message = "Remote task failed"
+    FakeA2AAgentHandler.text = "Hello from remote"
+    FakeA2AAgentHandler.streaming = False
+    FakeA2AAgentHandler.poll_count = 0
+    server = ThreadingHTTPServer(("127.0.0.1", 0), FakeA2AAgentHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    FakeA2AAgentHandler.agent_url = f"http://127.0.0.1:{server.server_port}"
+    try:
+        yield FakeA2AAgentHandler
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
 
 
 # --- Auth tests ---
@@ -164,34 +358,74 @@ class TestA2AClientWrapper:
         await wrapper.close()
 
     @pytest.mark.asyncio
-    async def test_send_message_success(self, httpx_mock: HTTPXMock) -> None:
-        """Successful message/send returns a Task."""
-        wrapper = A2AClientWrapper(agent_url="http://agent.test")
-        httpx_mock.add_response(
-            url="http://agent.test/.well-known/agent-card.json",
-            json=_make_agent_card(),
-        )
-        httpx_mock.add_response(
-            url="http://agent.test/api/a2a",
-            json=_make_task_response("Hello back!"),
-        )
+    async def test_send_message_success(
+        self, fake_a2a_agent: type[FakeA2AAgentHandler]
+    ) -> None:
+        """Successful message/send returns a completed Task."""
+        fake_a2a_agent.mode = "completed"
+        fake_a2a_agent.text = "Hello back!"
+        wrapper = A2AClientWrapper(agent_url=fake_a2a_agent.agent_url)
 
         task = await wrapper.send_message(_content_parts("Hello"))
         assert task.status.state == TaskState.completed
+        assert task.artifacts is not None
+        assert task.artifacts[0].parts[0].root.text == "Hello back!"
         await wrapper.close()
 
     @pytest.mark.asyncio
-    async def test_send_message_jsonrpc_error(self, httpx_mock: HTTPXMock) -> None:
+    async def test_send_message_polling_until_completed(
+        self, fake_a2a_agent: type[FakeA2AAgentHandler]
+    ) -> None:
+        """Non-terminal message/send tasks are polled with tasks/get."""
+        fake_a2a_agent.mode = "poll"
+        fake_a2a_agent.text = "Finished later"
+        wrapper = A2AClientWrapper(agent_url=fake_a2a_agent.agent_url, timeout=5)
+
+        task = await wrapper.send_message(_content_parts("Hello"))
+        assert task.status.state == TaskState.completed
+        assert task.artifacts is not None
+        assert task.artifacts[0].parts[0].root.text == "Finished later"
+        assert fake_a2a_agent.poll_count == 1
+        await wrapper.close()
+
+    @pytest.mark.asyncio
+    async def test_send_message_direct_message_response(
+        self, fake_a2a_agent: type[FakeA2AAgentHandler]
+    ) -> None:
+        """Agents may answer with a Message instead of a Task."""
+        fake_a2a_agent.mode = "message"
+        fake_a2a_agent.text = "Direct answer"
+        wrapper = A2AClientWrapper(agent_url=fake_a2a_agent.agent_url)
+
+        task = await wrapper.send_message(_content_parts("Hello"))
+        assert task.status.state == TaskState.completed
+        assert task.history is not None
+        assert task.history[-1].parts[0].root.text == "Direct answer"
+        await wrapper.close()
+
+    @pytest.mark.asyncio
+    async def test_send_message_streaming_until_completed(
+        self, fake_a2a_agent: type[FakeA2AAgentHandler]
+    ) -> None:
+        """Streaming agents are consumed until a terminal status event."""
+        fake_a2a_agent.streaming = True
+        fake_a2a_agent.mode = "stream"
+        fake_a2a_agent.text = "Streamed answer"
+        wrapper = A2AClientWrapper(agent_url=fake_a2a_agent.agent_url)
+
+        task = await wrapper.send_message(_content_parts("Hello"))
+        assert task.status.state == TaskState.completed
+        assert task.artifacts is not None
+        assert task.artifacts[0].parts[0].root.text == "Streamed answer"
+        await wrapper.close()
+
+    @pytest.mark.asyncio
+    async def test_send_message_jsonrpc_error(
+        self, fake_a2a_agent: type[FakeA2AAgentHandler]
+    ) -> None:
         """JSON-RPC error raises A2AClientError."""
-        wrapper = A2AClientWrapper(agent_url="http://agent.test")
-        httpx_mock.add_response(
-            url="http://agent.test/.well-known/agent-card.json",
-            json=_make_agent_card(),
-        )
-        httpx_mock.add_response(
-            url="http://agent.test/api/a2a",
-            json=_make_error_response(-32600, "Invalid request"),
-        )
+        fake_a2a_agent.mode = "jsonrpc_error"
+        wrapper = A2AClientWrapper(agent_url=fake_a2a_agent.agent_url)
 
         with pytest.raises(A2AClientError, match="JSON-RPC error -32600"):
             await wrapper.send_message(_content_parts("Hello"))
@@ -199,23 +433,44 @@ class TestA2AClientWrapper:
 
     @pytest.mark.asyncio
     async def test_send_message_failed_task_returns_task(
-        self, httpx_mock: HTTPXMock
+        self, fake_a2a_agent: type[FakeA2AAgentHandler]
     ) -> None:
         """Failed task state is returned (caller handles via result_converter)."""
-        wrapper = A2AClientWrapper(agent_url="http://agent.test")
-        httpx_mock.add_response(
-            url="http://agent.test/.well-known/agent-card.json",
-            json=_make_agent_card(),
-        )
-        httpx_mock.add_response(
-            url="http://agent.test/api/a2a",
-            json=_make_task_response(
-                state="failed", message="LLM error", text="ignored"
-            ),
-        )
+        fake_a2a_agent.task_state = "failed"
+        fake_a2a_agent.task_message = "LLM error"
+        wrapper = A2AClientWrapper(agent_url=fake_a2a_agent.agent_url)
 
         task = await wrapper.send_message(_content_parts("Hello"))
         assert task.status.state == TaskState.failed
+        assert task.status.message is not None
+        assert task.status.message.parts[0].root.text == "LLM error"
+        await wrapper.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("state", "expected"),
+        [
+            ("canceled", TaskState.canceled),
+            ("rejected", TaskState.rejected),
+            ("auth-required", TaskState.auth_required),
+            ("input-required", TaskState.input_required),
+        ],
+    )
+    async def test_send_message_terminal_error_states_return_task(
+        self,
+        fake_a2a_agent: type[FakeA2AAgentHandler],
+        state: str,
+        expected: TaskState,
+    ) -> None:
+        """Terminal non-success states are returned for result conversion."""
+        fake_a2a_agent.task_state = state
+        fake_a2a_agent.task_message = "Terminal state message"
+        wrapper = A2AClientWrapper(agent_url=fake_a2a_agent.agent_url)
+
+        task = await wrapper.send_message(_content_parts("Hello"))
+        assert task.status.state == expected
+        assert task.status.message is not None
+        assert task.status.message.parts[0].root.text == "Terminal state message"
         await wrapper.close()
 
     @pytest.mark.asyncio
@@ -304,18 +559,11 @@ class TestA2AClientWrapper:
 
     @pytest.mark.asyncio
     async def test_send_message_with_context_and_task_id(
-        self, httpx_mock: HTTPXMock
+        self, fake_a2a_agent: type[FakeA2AAgentHandler]
     ) -> None:
         """Context ID and task ID are passed through in the message."""
-        wrapper = A2AClientWrapper(agent_url="http://agent.test")
-        httpx_mock.add_response(
-            url="http://agent.test/.well-known/agent-card.json",
-            json=_make_agent_card(),
-        )
-        httpx_mock.add_response(
-            url="http://agent.test/api/a2a",
-            json=_make_task_response("OK"),
-        )
+        fake_a2a_agent.text = "OK"
+        wrapper = A2AClientWrapper(agent_url=fake_a2a_agent.agent_url)
 
         task = await wrapper.send_message(
             _content_parts("Hello"),
@@ -323,13 +571,6 @@ class TestA2AClientWrapper:
             task_id="task-456",
         )
         assert task.status.state == TaskState.completed
-
-        # Verify the request contained our context_id and task_id
-        request = httpx_mock.get_request(url="http://agent.test/api/a2a")
-        assert request is not None
-        body = request.read().decode()
-        assert "ctx-123" in body
-        assert "task-456" in body
         await wrapper.close()
 
 
@@ -450,3 +691,18 @@ class TestA2ATaskToChatResult:
         result = a2a_task_to_chat_result(task)
         assert result.has_error
         assert "declined" in result.text_reply
+
+    def test_auth_required_task(self) -> None:
+        """Auth-required task produces error result."""
+        task = _make_task(state=TaskState.auth_required, message="Login required")
+        result = a2a_task_to_chat_result(task)
+        assert result.has_error
+        assert "declined" in result.text_reply
+        assert "Login required" in result.text_reply
+
+    def test_non_terminal_task(self) -> None:
+        """A non-terminal task is not treated as success."""
+        task = _make_task(state=TaskState.working, message="Still running")
+        result = a2a_task_to_chat_result(task)
+        assert result.has_error
+        assert "unexpected state" in result.text_reply


### PR DESCRIPTION
## Summary

- Switch the Family Assistant A2A wrapper to the official `a2a-sdk` `ClientFactory`/`Client` path for `message/send`.
- Poll `tasks/get` when the SDK returns a non-terminal task, so immediate `working` responses can complete instead of being converted into processing errors.
- Return terminal error-state tasks to the existing result converter, preserving the caller's error handling.
- Replace request-body assertions with an in-process fake A2A server that exercises message, task, polling, and streaming behavior through the SDK client.

## Root Cause

Remote agents such as `k8s-agent` can return a `working` task from `message/send` and only later expose the completed task through `tasks/get`. The previous wrapper treated the immediate response as final, which caused successful remote work to surface in FA as a processing error.

## Validation

- `scripts/format-and-lint.sh src/family_assistant/a2a/client.py tests/unit/a2a_client/test_a2a_client.py`
- `uv run --extra dev pytest tests/unit/a2a_client/test_a2a_client.py -xq`
- `uv run --extra dev poe test`