### PR TITLE
Fix CVE-2026-48710: Starlette Host header auth bypass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
     # "apscheduler>=3.10.0", # APScheduler seems unused now? Remove if not needed.
     "PyYAML>=6.0",
     # For loading prompts.yaml
+    "starlette>=1.0.1",
+    # Pinned to >= 1.0.1 for CVE-2026-48710 (Host header validation bypass)
     "fastapi>=0.111.0",
     # Web framework
     "uvicorn[standard]>=0.29.0",

--- a/src/family_assistant/web/auth.py
+++ b/src/family_assistant/web/auth.py
@@ -336,9 +336,12 @@ class AuthMiddleware:
             return
 
         request = Request(scope, receive=receive)
+        # Use scope["path"] instead of request.url.path to avoid
+        # CVE-2026-48710 Host header poisoning of the parsed URL path.
+        request_path: str = scope["path"]
 
         for pattern in self.public_paths:
-            if pattern.match(request.url.path):
+            if pattern.match(request_path):
                 await self.app(scope, receive, send)
                 return
 
@@ -403,7 +406,7 @@ class AuthMiddleware:
                         request.session["user"] = api_user
                     user = api_user  # Update user for the current request flow
                     logger.debug(
-                        f"User authenticated via API token for path {request.url.path}"
+                        f"User authenticated via API token for path {request_path}"
                     )
 
         if not user:
@@ -412,7 +415,7 @@ class AuthMiddleware:
             with contextlib.suppress(AssertionError):
                 request.session["redirect_after_login"] = str(request.url)
             logger.debug(
-                f"No user session or valid API token for protected path {request.url.path}, redirecting to OIDC login."
+                f"No user session or valid API token for protected path {request_path}, redirecting to OIDC login."
             )
             redirect_response = RedirectResponse(
                 url=request.url_for("login"),

--- a/src/family_assistant/web/routers/context_viewer.py
+++ b/src/family_assistant/web/routers/context_viewer.py
@@ -64,9 +64,9 @@ async def view_context_page(
         )
 
         return templates.TemplateResponse(
+            request,
             "context_viewer.html.j2",
-            {
-                "request": request,
+            context={
                 "aggregated_context": aggregated_context,
                 "context_fragments": context_fragments,
                 "system_prompt_template": system_prompt_template,

--- a/src/family_assistant/web/routers/documents_api.py
+++ b/src/family_assistant/web/routers/documents_api.py
@@ -217,9 +217,6 @@ async def upload_document(
             description="Unique identifier for the document within its source type.",
         ),
     ],
-    source_uri: Annotated[
-        str, Form(..., description="Canonical URI/URL of the original document.")
-    ],
     title: Annotated[
         str,
         Form(
@@ -230,6 +227,10 @@ async def upload_document(
     # Other dependencies
     db_context: Annotated[DatabaseContext, Depends(get_db)],
     # Optional Form fields
+    source_uri: Annotated[
+        str | None,
+        Form(description="Canonical URI/URL of the original document."),
+    ] = None,
     content_parts_json: Annotated[
         str | None,
         Form(

--- a/src/family_assistant/web/routers/errors.py
+++ b/src/family_assistant/web/routers/errors.py
@@ -47,9 +47,9 @@ async def error_list(
     total_pages = (total_count + limit - 1) // limit
 
     return templates.TemplateResponse(
+        request,
         "errors.html",
-        {
-            "request": request,
+        context={
             "errors": errors,
             "page": page,
             "total_pages": total_pages,
@@ -76,6 +76,7 @@ async def error_detail(
         raise HTTPException(404, "Error log not found")
 
     return templates.TemplateResponse(
+        request,
         "error_detail.html",
-        {"request": request, "error": error, "now_utc": datetime.now(UTC)},
+        context={"error": error, "now_utc": datetime.now(UTC)},
     )

--- a/src/family_assistant/web/routers/vector_search.py
+++ b/src/family_assistant/web/routers/vector_search.py
@@ -95,9 +95,9 @@ async def vector_search_form(
         # Continue without pre-populated dropdowns
 
     return templates.TemplateResponse(
+        request,
         "vector_search.html.j2",
-        {
-            "request": request,
+        context={
             "results": None,
             "search_params": {},  # Empty for initial GET
             "error": error,
@@ -184,9 +184,9 @@ async def document_detail_view(
         error = f"An error occurred while fetching document details: {e}"
 
     return templates.TemplateResponse(
+        request,
         "document_detail.html.j2",
-        {
-            "request": request,
+        context={
             "document": document,
             "error": error,
             "full_text": full_text,
@@ -500,9 +500,9 @@ async def handle_vector_search(
             error = "Could not load filter options from database."
 
     return templates.TemplateResponse(
+        request,
         "vector_search.html.j2",
-        {
-            "request": request,
+        context={
             "results": results,
             "search_params": search_params,  # Pass back params
             "error": error,

--- a/uv.lock
+++ b/uv.lock
@@ -548,6 +548,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1751,6 +1760,7 @@ dependencies = [
     { name = "sqlalchemy", version = "2.0.40", source = { registry = "https://pypi.org/simple" }, extra = ["asyncio"], marker = "python_full_version >= '3.13.2' and platform_python_implementation == 'PyPy'" },
     { name = "sqlalchemy", version = "2.0.41", source = { registry = "https://pypi.org/simple" }, extra = ["asyncio"], marker = "python_full_version >= '3.13.2' and platform_python_implementation != 'PyPy'" },
     { name = "sqlparse" },
+    { name = "starlette" },
     { name = "telegramify-markdown" },
     { name = "toons" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1934,6 +1944,7 @@ requires-dist = [
     { name = "soxr", specifier = ">=0.5.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "sqlparse", specifier = ">=0.5.5" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "symbex", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "telegram-bot-api-mock", extras = ["dev"], marker = "extra == 'dev'", git = "https://github.com/werdnum/telegram-bot-api-mock" },
     { name = "telegramify-markdown", specifier = ">=0.5.1" },
@@ -1957,16 +1968,18 @@ provides-extras = ["dev", "local-embeddings", "pgserver"]
 
 [[package]]
 name = "fastapi"
-version = "0.117.1"
+version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/7e/d9788300deaf416178f61fb3c2ceb16b7d0dc9f82a08fdb87a5e64ee3cc7/fastapi-0.117.1.tar.gz", hash = "sha256:fb2d42082d22b185f904ca0ecad2e195b851030bd6c5e4c032d1c981240c631a", size = 307155, upload-time = "2025-09-20T20:16:56.663Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/45/d9d3e8eeefbe93be1c50060a9d9a9f366dba66f288bb518a9566a23a8631/fastapi-0.117.1-py3-none-any.whl", hash = "sha256:33c51a0d21cab2b9722d4e56dbb9316f3687155be6b276191790d8da03507552", size = 95959, upload-time = "2025-09-20T20:16:53.661Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
@@ -6270,14 +6283,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.46.2"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Upgrade Starlette from 0.46.2 to 1.1.0** (>= 1.0.1) to fix CVE-2026-48710 ("BadHost"), a Host header validation bypass that allows attackers to poison `request.url.path` and bypass path-based authentication middleware
- **Harden AuthMiddleware** to use `scope["path"]` instead of `request.url.path` for public path matching as defense-in-depth against Host header poisoning
- **Update TemplateResponse calls** to new Starlette 1.x API signature (`request, name, context={}` instead of `name, {"request": request, ...}`)
- **Make `source_uri` optional** in document upload endpoint to handle FastAPI/Pydantic behavior change where empty form strings are now treated as missing

## Test plan

- [x] All linters pass (`scripts/format-and-lint.sh`)
- [x] basedpyright type checking passes (previously failed due to TemplateResponse signature change)
- [x] Previously failing document upload tests pass with `source_uri` fix
- [x] Full test suite (`poe test`) passes (1 flaky Playwright timeout unrelated to changes)
- [x] Verified Starlette 1.1.0 and FastAPI 0.136.3 installed correctly

https://claude.ai/code/session_018JzDhkARcJJebXjAyhuG9A

---
_Generated by [Claude Code](https://claude.ai/code/session_018JzDhkARcJJebXjAyhuG9A)_