### PR TITLE
[codex] Add opt-in rootless Podman worker security context

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1495,6 +1495,7 @@ ai_worker_config:
     service_account: "ai-worker"
     runtime_class: "gvisor"
     job_ttl_seconds: 3600
+    enable_rootless_podman: false
   docker:
     image: "ghcr.io/werdnum/ai-coding-base:latest"
     network: "bridge"

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -802,6 +802,7 @@ class KubernetesBackendConfig(BaseModel):
     run_as_user: int | None = 1000
     run_as_group: int | None = 1000
     fs_group: int | None = 1000
+    enable_rootless_podman: bool = False
 
     # Additional volumes and volume mounts to attach to worker pods
     extra_volumes: list[k8s_models.Volume] | None = None

--- a/src/family_assistant/services/backends/kubernetes.py
+++ b/src/family_assistant/services/backends/kubernetes.py
@@ -209,7 +209,10 @@ class KubernetesBackend:
         if self._config.enable_rootless_podman:
             return V1SecurityContext(
                 allow_privilege_escalation=True,
-                capabilities=V1Capabilities(add=["SETUID", "SETGID"]),
+                capabilities=V1Capabilities(
+                    add=["SETUID", "SETGID"],
+                    drop=["ALL"],
+                ),
                 read_only_root_filesystem=False,
                 seccomp_profile=V1SeccompProfile(type="Unconfined"),
             )

--- a/src/family_assistant/services/backends/kubernetes.py
+++ b/src/family_assistant/services/backends/kubernetes.py
@@ -33,6 +33,7 @@ from kubernetes_asyncio.client import (
     V1PodSpec,
     V1PodTemplateSpec,
     V1ResourceRequirements,
+    V1SeccompProfile,
     V1SecretEnvSource,
     V1SecurityContext,
     V1Volume,
@@ -202,6 +203,22 @@ class KubernetesBackend:
     def resources(self) -> WorkerResourceLimits:
         """Get the resource limits for worker containers."""
         return self._config.resources
+
+    def _worker_container_security_context(self) -> V1SecurityContext:
+        """Build the worker container security context."""
+        if self._config.enable_rootless_podman:
+            return V1SecurityContext(
+                allow_privilege_escalation=True,
+                capabilities=V1Capabilities(add=["SETUID", "SETGID"]),
+                read_only_root_filesystem=False,
+                seccomp_profile=V1SeccompProfile(type="Unconfined"),
+            )
+
+        return V1SecurityContext(
+            allow_privilege_escalation=False,
+            capabilities=V1Capabilities(drop=["ALL"]),
+            read_only_root_filesystem=False,
+        )
 
     async def _ensure_config_loaded(self) -> None:
         """Ensure Kubernetes configuration is loaded (once)."""
@@ -436,10 +453,8 @@ class KubernetesBackend:
                                 env=env_vars,
                                 env_from=env_from,
                                 volume_mounts=volume_mounts,
-                                security_context=V1SecurityContext(
-                                    allow_privilege_escalation=False,
-                                    capabilities=V1Capabilities(drop=["ALL"]),
-                                    read_only_root_filesystem=False,
+                                security_context=(
+                                    self._worker_container_security_context()
                                 ),
                                 resources=V1ResourceRequirements(
                                     requests={

--- a/tests/unit/services/backends/test_kubernetes_backend.py
+++ b/tests/unit/services/backends/test_kubernetes_backend.py
@@ -275,6 +275,34 @@ class TestKubernetesBackendBuildJobManifest:
         container_security = pod_spec.containers[0].security_context
         assert container_security.allow_privilege_escalation is False
         assert container_security.capabilities.drop == ["ALL"]
+        assert container_security.seccomp_profile is None
+
+    def test_build_manifest_rootless_podman_security_context(self) -> None:
+        """Test rootless Podman support is explicitly opt-in."""
+        config = KubernetesBackendConfig(
+            namespace="test-namespace",
+            ai_coder_image="test-image:latest",
+            service_account="test-sa",
+            enable_rootless_podman=True,
+        )
+        custom_backend = KubernetesBackend(config=config)
+        custom_backend._config_loaded = True
+
+        manifest = custom_backend._build_job_manifest(
+            job_name="ai-worker-task-123",
+            task_id="task-123",
+            prompt_path="tasks/task-123/prompt.md",
+            output_dir="tasks/task-123/output",
+            webhook_url="http://localhost:8000/webhook/event",
+            model="claude",
+            timeout_minutes=30,
+        )
+
+        container_security = manifest.spec.template.spec.containers[0].security_context
+        assert container_security.allow_privilege_escalation is True
+        assert container_security.capabilities.add == ["SETUID", "SETGID"]
+        assert container_security.capabilities.drop is None
+        assert container_security.seccomp_profile.type == "Unconfined"
 
     def test_build_manifest_custom_uid_gid(self) -> None:
         """Test job manifest uses custom uid/gid from config."""

--- a/tests/unit/services/backends/test_kubernetes_backend.py
+++ b/tests/unit/services/backends/test_kubernetes_backend.py
@@ -301,7 +301,7 @@ class TestKubernetesBackendBuildJobManifest:
         container_security = manifest.spec.template.spec.containers[0].security_context
         assert container_security.allow_privilege_escalation is True
         assert container_security.capabilities.add == ["SETUID", "SETGID"]
-        assert container_security.capabilities.drop is None
+        assert container_security.capabilities.drop == ["ALL"]
         assert container_security.seccomp_profile.type == "Unconfined"
 
     def test_build_manifest_custom_uid_gid(self) -> None:


### PR DESCRIPTION
## Summary

Adds an explicit `enable_rootless_podman` switch to the Kubernetes ai-worker backend. The default worker container security context stays locked down with `allowPrivilegeEscalation: false` and `drop: [ALL]`; when the switch is enabled, the worker container keeps `drop: [ALL]`, re-adds only `SETUID`/`SETGID`, sets `allowPrivilegeEscalation: true`, and uses unconfined seccomp for rootless Podman `newuidmap`/`newgidmap` inside a Kata microVM.

## Why

Rootless Podman in the `ai-coding-base` worker image needs the setuid helper path to map the configured subordinate UID/GID range. With `no_new_privs` from `allowPrivilegeEscalation: false`, `newuidmap` fails with `Operation not permitted`. This must be opt-in because it is only appropriate when the runtime class provides a separate microVM boundary.

## Validation

- `uvx ruff check --preview --ignore=E501 src/family_assistant/config_models.py src/family_assistant/services/backends/kubernetes.py tests/unit/services/backends/test_kubernetes_backend.py`
- `uvx ruff format --check --preview src/family_assistant/config_models.py src/family_assistant/services/backends/kubernetes.py tests/unit/services/backends/test_kubernetes_backend.py`
- `git diff --check`

Full local test setup did not complete in this container: `uv sync --extra dev --extra pgserver` failed building `lru-dict` because `cc` is unavailable, and the repository pre-commit environment stalled during setup. Opening this PR so CI can run the canonical checks.