### PR TITLE
Add optional browser-server integration: pluggable BrowserBackend with remote handoff

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1512,6 +1512,7 @@ browser_handoff_config:
     token_env: "BROWSER_HANDOFF_SERVICE_TOKEN"
   handoff_capable_profiles:
     - "browser_profile"
+    - "browser_visual_profile"
 otel:
   enabled: false
   service_name: "family-assistant"

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -519,7 +519,7 @@ service_profiles:
     processing_config:
       max_iterations: 25
       prompts: # MERGES with default_profile_settings.processing_config.prompts
-        system_prompt: "You browse the web via accessibility snapshots on behalf of {user_name}. Start every session with browser_open, which navigates to a URL and returns a snapshot of the page structure. Each snapshot is rendered as indented text where interactive elements are tagged with stable refs like `e12`; use those refs with browser_click, browser_fill, and browser_select. Use browser_extract when {user_name} wants the page content as Markdown, browser_wait when you need to wait for load states or a specific element, and browser_screenshot only when you need a visual to attach to your reply. When the fixed tools don't fit — shadow DOM traversal, iframes, reading JSON endpoints via fetch, or complex multi-step DOM mutation in a single turn — use browser_exec to run JavaScript in-page via page.evaluate. For tasks that can only be solved visually (canvas, image maps, drag-and-drop that doesn't target DOM nodes), call delegate_to_service with target_service_id='browser_visual_profile'; the visual profile shares the same browser tab so the session state (URL, cookies, form progress) carries over. After any tool calls, your final text response will be sent directly to {user_name}. Do NOT use the 'send_message_to_user' tool to respond to {user_name} - that tool is only for sending messages to OTHER users. Current time is {current_time}."
+        system_prompt: "You browse the web via accessibility snapshots on behalf of {user_name}. Start every session with browser_open, which navigates to a URL and returns a snapshot of the page structure. Each snapshot is rendered as indented text where interactive elements are tagged with stable refs like `e12`; use those refs with browser_click, browser_fill, and browser_select. Use browser_extract when {user_name} wants the page content as Markdown, browser_wait when you need to wait for load states or a specific element, and browser_screenshot only when you need a visual to attach to your reply. When the fixed tools don't fit — shadow DOM traversal, iframes, reading JSON endpoints via fetch, or complex multi-step DOM mutation in a single turn — use browser_exec to run JavaScript in-page via page.evaluate. For tasks that can only be solved visually (canvas, image maps, drag-and-drop that doesn't target DOM nodes), call delegate_to_service with target_service_id='browser_visual_profile'; the visual profile shares the same browser tab so the session state (URL, cookies, form progress) carries over. When a step requires the human — entering payment details, credentials, a one-time passcode, accepting legal consent, or solving a CAPTCHA — call browser_request_handoff, which returns a one-time link for {user_name} to take over the same live browser; share that link and wait. (Handoff only works when the browser-server integration is enabled; if it isn't, the tool reports that and you should ask {user_name} to do the step themselves.) After any tool calls, your final text response will be sent directly to {user_name}. Do NOT use the 'send_message_to_user' tool to respond to {user_name} - that tool is only for sending messages to OTHER users. Current time is {current_time}."
     tools_policy: # REPLACES default_profile_settings.tools_policy entirely for this profile
       default_decision: "deny"
       rules:
@@ -534,6 +534,7 @@ service_profiles:
               - "browser_wait"
               - "browser_screenshot"
               - "browser_exec"
+              - "browser_request_handoff"
               - "attach_to_response"
           decision: "allow"
           priority: 10
@@ -1498,6 +1499,19 @@ ai_worker_config:
   docker:
     image: "ghcr.io/werdnum/ai-coding-base:latest"
     network: "bridge"
+# Optional integration with an external browser-server (handoff service).
+# When enabled, the semantic DOM browser tools run against a remote browser
+# session that can be transferred to a human via noVNC. Disabled by default;
+# when off, browsing uses the in-process local Playwright backend.
+browser_handoff_config:
+  enabled: false
+  service_url: null
+  timeout_seconds: 30.0
+  auth:
+    type: "bearer"
+    token_env: "BROWSER_HANDOFF_SERVICE_TOKEN"
+  handoff_capable_profiles:
+    - "browser_profile"
 otel:
   enabled: false
   service_name: "family-assistant"

--- a/docs/design/browser-server-integration.md
+++ b/docs/design/browser-server-integration.md
@@ -1,0 +1,200 @@
+# Browser-Server Integration (optional remote browser backend)
+
+## Status
+
+Proposed → in implementation.
+
+## Motivation
+
+Family Assistant currently drives a **local, in-process, headless** Playwright browser for the
+semantic DOM tools (`browser_open`, `browser_snapshot`, `browser_click`, `browser_fill`,
+`browser_select`, `browser_wait`, `browser_extract`, `browser_screenshot`, `browser_exec`) and the
+coordinate-based Computer Use tools. A headless browser living inside the assistant process can
+**never** be handed to a human: there is no display, no remote control surface, and no lease/safety
+model. That makes warm agent→human handoff (payments, credentials, OTP, CAPTCHA, cookie consent)
+impossible today.
+
+The companion [`browser-server`](https://github.com/werdnum/browser-server) service ("Browser
+Handoff Service", designed in PR #838) already implements the hard part: it owns headed Chromium +
+Playwright + a virtual display + noVNC, enforces a lease/state machine, and exposes a narrow
+service-authenticated REST API. What's missing is the **Family Assistant adapter** (Milestone 5 of
+the standalone-service plan): a client that lets the assistant create and drive sessions on the
+service and request a human handoff.
+
+This document specifies that adapter. The integration is **optional** and **off by default**; it is
+turned on purely through configuration (in this repo's `config.yaml`, and operationally via the
+`kube-config` ConfigMap). When disabled, behavior is byte-for-byte the current local Playwright
+path.
+
+## Goals
+
+- One browsing surface. The existing semantic DOM tools work unchanged from the LLM's perspective;
+  they gain a pluggable **backend**. We do **not** add a second, parallel set of browsing tools.
+- When enabled, the same browser the agent drives can be transferred to a human via `browser-server`
+  (noVNC), unlocking `request_browser_handoff`.
+- No capability regression: the remote backend serves the same rich accessibility snapshots (with
+  stable `eN` refs) and real screenshots that the local backend does. This requires a small,
+  backward-compatible extension to `browser-server`'s agent-command protocol.
+- Fail-closed and config-gated: absent configuration, none of the remote code paths are reachable.
+
+## Non-goals (initial milestone)
+
+- Remoting the coordinate-based **Computer Use / visual** profile (`browser_visual_profile`). It
+  stays local for now; remoting it needs continuous screenshot streaming at device coordinates and
+  is tracked as a follow-up. The local backend keeps serving it.
+- Durable handoff history, family-wide claim, sanitized resume policy beyond what `browser-server`
+  already implements.
+
+## Architecture
+
+### Backend abstraction (family-assistant)
+
+Introduce a `BrowserBackend` protocol that the DOM tools call instead of touching a Playwright
+`Page` directly. Two implementations:
+
+- `LocalPlaywrightBackend` — the current behavior, extracted out of `browser_dom.py` /
+  `browser_session.py`. Owns a local `BrowserSession`, runs the `_SNAPSHOT_JS` accessibility walker,
+  resolves `eN` refs to `[data-fa-ref="eN"]` selectors, takes screenshots, runs `page.evaluate`.
+- `RemoteBrowserBackend` — an httpx client for `browser-server`'s `/v1/sessions/*` API. Maps each
+  high-level operation onto an `agent-command`. The remote worker runs the **same** accessibility
+  walker server-side and returns the same `Snapshot` JSON, so ref handling and TOON rendering stay
+  identical on the family-assistant side.
+
+The backend is selected per execution context: when `browser_handoff_config.enabled` and the active
+profile is handoff-capable, tools resolve a `RemoteBrowserBackend` keyed by `conversation_id`
+(mirroring today's per-conversation `BrowserSession`); otherwise they use `LocalPlaywrightBackend`.
+
+```text
+browser_* tools  ──▶  BrowserBackend (protocol)
+                         ├── LocalPlaywrightBackend  (default; local headless Playwright)
+                         └── RemoteBrowserBackend     (httpx → browser-server /v1/sessions/*)
+                                                          │ Bearer service token
+                                                          ▼
+                                                  browser-server (headed Chromium + noVNC + leases)
+```
+
+The `BrowserBackend` protocol surface (high level, matching the existing tool set):
+
+- `open(url, query) -> SnapshotData`
+- `snapshot(query) -> SnapshotData`
+- `click(ref) -> SnapshotData`
+- `fill(ref, text, submit) -> SnapshotData`
+- `select(ref, value) -> SnapshotData`
+- `wait(selector, state, timeout_ms) -> SnapshotData`
+- `extract(selector) -> markdown`
+- `screenshot() -> png bytes`
+- `exec(code) -> result`
+- `request_handoff(reason, note, expected_origin, allowed_resume) -> handoff_url` (remote only)
+- `close()`
+
+### Protocol extension (browser-server)
+
+`browser-server`'s `agent-command` set is deliberately narrow and its `snapshot`/`screenshot` return
+stubs (title + 500 chars; `{redacted: true}`). To let the rich tools work remotely without a
+capability regression, extend the `PlaywrightBrowserWorker` (agent-owned states only —
+human/sanitize guards are unchanged) so that:
+
+- `snapshot` returns the full accessibility tree (`{url, title, forms, elements, roots:[...]}`) by
+  running the same DOM walker that family-assistant uses; elements are tagged `data-fa-ref="eN"`.
+- `screenshot` returns base64-encoded PNG bytes (`{mime_type, image_base64}`) when the agent owns
+  the lease. Screenshots remain blocked in human/sanitize states by the existing
+  `OBSERVATION_COMMANDS` guard — the no-observation-during-human-control invariant is preserved.
+- New agent commands: `extract` (page/subtree → HTML for markdown conversion), `exec` (run
+  `page.evaluate` JS, same-origin V8 only), and `wait` (load-state / selector). `click`/`type_text`/
+  `select` already accept a `selector`, so family-assistant passes `[data-fa-ref="eN"]`.
+
+These are additive and guarded; existing fake-runtime tests and the lease/redaction model are
+unaffected for the human-controlled states.
+
+## Configuration
+
+### family-assistant config model
+
+New optional top-level section, mirroring `ai_worker_config` (off by default):
+
+```python
+class BrowserHandoffConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    enabled: bool = False
+    service_url: str | None = None          # e.g. http://browser-server.browser-server.svc.cluster.local:8000
+    auth: RemoteA2AAuthConfig = Field(default_factory=RemoteA2AAuthConfig)  # reuse existing auth model
+    timeout_seconds: float = 30.0
+    handoff_capable_profiles: list[str] = Field(default_factory=lambda: ["browser_profile"])
+```
+
+Wired into `AppConfig` as `browser_handoff_config: BrowserHandoffConfig`. Auth reuses the existing
+`RemoteA2AAuthConfig` (`type: bearer`, `token_env: BROWSER_HANDOFF_SERVICE_TOKEN`,
+`header_name: Authorization`), so the bearer token is read from the environment, never stored in
+YAML.
+
+### Env var overrides (config_loader `ENV_VAR_MAPPINGS`)
+
+```text
+BROWSER_HANDOFF_ENABLED   -> browser_handoff_config.enabled (bool)
+BROWSER_HANDOFF_URL       -> browser_handoff_config.service_url
+BROWSER_HANDOFF_TIMEOUT   -> browser_handoff_config.timeout_seconds (float)
+```
+
+The service token itself is referenced by name (`token_env`) and read at request time, consistent
+with `remote_a2a` / MCP `$VAR` handling.
+
+### defaults.yaml
+
+```yaml
+browser_handoff_config:
+  enabled: false
+  service_url: null
+  timeout_seconds: 30.0
+  auth:
+    type: "bearer"
+    token_env: "BROWSER_HANDOFF_SERVICE_TOKEN"
+  handoff_capable_profiles:
+    - "browser_profile"
+```
+
+### kube-config (the operational on/off switch)
+
+In `kubernetes/manifests/workloads/family-assistant/`:
+
+1. `ConfigMap-family-assistant-config.yaml`: add a `browser_handoff_config` block with
+   `enabled: true` and `service_url: http://browser-server.browser-server.svc.cluster.local:8000`.
+2. Deployment: add `BROWSER_HANDOFF_SERVICE_TOKEN` env, sourced from a `browser-server` secret
+   reflected into `ml-bot` (the same Stakater-reflector pattern already used for
+   `family-assistant-asterisk`) or a dedicated SealedSecret in `ml-bot`.
+3. A `NetworkPolicy` allowing egress `ml-bot/family-assistant → browser-server:8000`, plus matching
+   ingress on the `browser-server` namespace if it default-denies.
+
+The in-cluster Service call uses the **service token** and bypasses the external OIDC
+`SecurityPolicy`, which only targets the public `HTTPRoute`.
+
+## Security
+
+- The remote backend authenticates with a scoped service token; no user secrets reach the worker.
+- The no-observation-during-human-control invariant is enforced by `browser-server` (lease/state
+  guards), not by the client — the client cannot snapshot/screenshot a human-owned session because
+  the service returns `403`.
+- `browser_exec` JS continues to run only in the page's same-origin V8 context (now server-side),
+  with no access to the assistant process.
+- Rule of Two: the browser profile remains an `[AC]`-style sandboxed surface; the remote backend
+  does not widen data access.
+
+## Tooling / UX
+
+- `request_browser_handoff` is added to `browser_dom.py` and registered; it is allowed only in
+  `handoff_capable_profiles` and is a no-op error when the remote backend is not active. The
+  `browser_profile` system prompt in `prompts.yaml`/`defaults.yaml` gains a short note on when to
+  hand off to a human.
+- `docs/user/USER_GUIDE.md` documents the optional handoff capability.
+
+## Milestones
+
+1. **browser-server protocol extension** — rich snapshot, screenshot bytes, `exec`/`extract`/`wait`;
+   unit tests against the fake + real runtimes. (browser-server repo)
+2. **family-assistant config** — `BrowserHandoffConfig`, env mappings, `defaults.yaml`; config
+   tests.
+3. **family-assistant backend** — `BrowserBackend` protocol, `LocalPlaywrightBackend` (extract
+   current behavior), `RemoteBrowserBackend`, tool refactor, `request_browser_handoff`, policy +
+   prompt + user-guide; unit/functional tests with a fake browser-server.
+4. **kube-config wiring** — ConfigMap, service-token secret, NetworkPolicy, Deployment env.
+
+Each milestone is independently testable and shippable.

--- a/docs/user/browser_automation.md
+++ b/docs/user/browser_automation.md
@@ -91,6 +91,23 @@ In practice you usually don't need to think about this — start with `/browse` 
 delegate when needed. You can also invoke `/browse_visual` directly if you know the task is
 visual-only from the start.
 
+## Handing the browser to a human (optional)
+
+Some steps should never be done by the assistant: entering payment details, signing in with your
+credentials, typing a one-time passcode, accepting legal consent, or solving a CAPTCHA. When the
+optional **browser-server** integration is enabled, the assistant can hand the *live* browser
+session over to you: it calls `browser_request_handoff` and replies with a one-time link. You open
+the link, take control of the very same browser (rendered in your own window), finish the sensitive
+step, and mark it done — then control returns to the assistant.
+
+While you are in control, the assistant has **no** ability to see or drive that browser: it cannot
+take screenshots, read the page, or run actions. This keeps secrets you type (passwords, card
+numbers, OTPs) away from the model.
+
+This capability is off unless your operator has configured the browser-server integration. When it
+is not configured, the assistant will tell you it can't hand off and will ask you to do the step
+yourself instead.
+
 ## Examples by Use Case
 
 ### Online Shopping

--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -137,6 +137,12 @@ ENV_VAR_MAPPINGS: list[EnvVarMapping] = [
     ),
     EnvVarMapping("AI_WORKER_K8S_NAMESPACE", "ai_worker_config.kubernetes.namespace"),
     EnvVarMapping("AI_WORKER_K8S_IMAGE", "ai_worker_config.kubernetes.ai_coder_image"),
+    # Browser-server (handoff) integration
+    EnvVarMapping("BROWSER_HANDOFF_ENABLED", "browser_handoff_config.enabled", bool),
+    EnvVarMapping("BROWSER_HANDOFF_URL", "browser_handoff_config.service_url"),
+    EnvVarMapping(
+        "BROWSER_HANDOFF_TIMEOUT", "browser_handoff_config.timeout_seconds", float
+    ),
     # OpenTelemetry
     EnvVarMapping("OTEL_ENABLED", "otel.enabled", bool),
     EnvVarMapping("OTEL_SERVICE_NAME", "otel.service_name"),

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -182,6 +182,34 @@ class RemoteA2AConfig(BaseModel):
     skills_description: str | None = None
 
 
+class BrowserHandoffConfig(BaseModel):
+    """Optional integration with an external browser-server (handoff service).
+
+    When ``enabled`` and ``service_url`` are set, the semantic DOM browser tools
+    run against a remote ``browser-server`` session instead of a local headless
+    Playwright browser. The same rich tools (snapshot/click/fill/.../screenshot)
+    work unchanged; the difference is the browser lives on a service that can
+    transfer the live session to a human via noVNC (enabling
+    ``browser_request_handoff``). Disabled by default — when off, browsing uses
+    the in-process local Playwright backend exactly as before.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    # Cluster-internal base URL, e.g.
+    # http://browser-server.browser-server.svc.cluster.local:8000
+    service_url: str | None = None
+    # Auth reuses the remote-A2A model: bearer token read from token_env at
+    # request time (never stored in YAML).
+    auth: RemoteA2AAuthConfig = Field(default_factory=RemoteA2AAuthConfig)
+    timeout_seconds: float = 30.0
+    # Profiles permitted to use the remote backend / request a human handoff.
+    handoff_capable_profiles: list[str] = Field(
+        default_factory=lambda: ["browser_profile"]
+    )
+
+
 class ServiceProfile(BaseModel):
     """Configuration for a service profile.
 
@@ -1063,6 +1091,9 @@ class AppConfig(BaseSettings):
         default_factory=MessageBatchingConfig
     )
     ai_worker_config: AIWorkerConfig = Field(default_factory=AIWorkerConfig)
+    browser_handoff_config: BrowserHandoffConfig = Field(
+        default_factory=BrowserHandoffConfig
+    )
     notes_config: NotesConfig = Field(default_factory=NotesConfig)
     skills_config: SkillsConfig = Field(default_factory=SkillsConfig)
     mqtt_config: MQTTConfig = Field(default_factory=MQTTConfig)

--- a/src/family_assistant/tools/__init__.py
+++ b/src/family_assistant/tools/__init__.py
@@ -30,6 +30,7 @@ from family_assistant.tools.browser_dom import (
     browser_extract_tool,
     browser_fill_tool,
     browser_open_tool,
+    browser_request_handoff_tool,
     browser_screenshot_tool,
     browser_select_tool,
     browser_snapshot_tool,
@@ -383,6 +384,7 @@ __all__ = [
     "browser_extract_tool",
     "browser_fill_tool",
     "browser_open_tool",
+    "browser_request_handoff_tool",
     "browser_screenshot_tool",
     "browser_select_tool",
     "browser_snapshot_tool",
@@ -581,6 +583,7 @@ _LOCAL_TOOL_IMPLEMENTATIONS: dict[str, ToolImplementation] = {
     "browser_extract": browser_extract_tool,
     "browser_screenshot": browser_screenshot_tool,
     "browser_exec": browser_exec_tool,
+    "browser_request_handoff": browser_request_handoff_tool,
     # Workspace file tools
     "workspace_read": workspace_read_tool,
     "workspace_write": workspace_write_tool,
@@ -1118,6 +1121,11 @@ LOCAL_TOOL_METADATA_BY_NAME: dict[str, LocalToolMetadata] = {
         ToolTag.STATE_CHANGING,
         ToolTag.EXTERNAL_COMM,
         ToolTag.OUTPUT_UNTRUSTED,
+    ),
+    "browser_request_handoff": _metadata(
+        ToolTag.BROWSER,
+        ToolTag.STATE_CHANGING,
+        ToolTag.EXTERNAL_COMM,
     ),
     "workspace_read": _metadata(
         ToolTag.READ_ONLY,

--- a/src/family_assistant/tools/browser_backend.py
+++ b/src/family_assistant/tools/browser_backend.py
@@ -567,6 +567,12 @@ async def get_browser_backend(exec_context: ToolExecutionContext) -> BrowserBack
 
     Uses the remote ``browser-server`` backend when ``browser_handoff_config`` is
     enabled for the active profile; otherwise the shared local Playwright session.
+
+    Note: visual delegation (``browser_visual_profile``) still uses the local
+    Computer Use session via ``get_browser_session``, so delegating a remote-backed
+    DOM profile to the visual profile will open a separate local tab rather than
+    reusing the remote session.  Routing the visual profile through the remote
+    session is tracked as a future improvement.
     """
     config = _remote_enabled(exec_context)
     if config is not None:
@@ -587,3 +593,4 @@ async def close_browser_backend(exec_context: ToolExecutionContext) -> None:
     if remote is not None:
         await remote.close()
     await close_browser_session(exec_context)
+

--- a/src/family_assistant/tools/browser_backend.py
+++ b/src/family_assistant/tools/browser_backend.py
@@ -1,0 +1,589 @@
+"""Pluggable backend for the semantic DOM browser tools.
+
+The :mod:`browser_dom` tools used to drive a local headless Playwright page
+directly. To allow the *same* tools to run against an external
+``browser-server`` (handoff) session — a browser that can be transferred to a
+human via noVNC — the page operations are funnelled through a
+:class:`BrowserBackend`:
+
+- :class:`LocalPlaywrightBackend` wraps the shared in-process
+  :class:`~family_assistant.tools.browser_session.BrowserSession` (the previous
+  behavior, and the one shared with the visual Computer Use profile).
+- :class:`RemoteBrowserBackend` is an httpx client for ``browser-server``'s
+  ``/v1/sessions/*`` agent API. The remote worker runs the *same* accessibility
+  walker server-side and returns the same :class:`Snapshot` JSON, so ref
+  handling and TOON rendering on this side are identical.
+
+The backend is selected per conversation by :func:`get_browser_backend`: when
+``browser_handoff_config`` is enabled and the active profile is handoff-capable,
+a remote backend is used; otherwise the local backend is used. When the remote
+integration is disabled (the default), none of the remote code paths are
+reachable and behavior is byte-for-byte the previous local path.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import logging
+import os
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Protocol,
+    cast,
+    get_args,
+    runtime_checkable,
+)
+
+import httpx
+from rebrowser_playwright.async_api import Error as PlaywrightError
+
+from family_assistant.tools.browser_session import (
+    BrowserSession,
+    close_browser_session,
+    get_browser_session,
+)
+
+if TYPE_CHECKING:
+    from rebrowser_playwright.async_api import Page
+
+    from family_assistant.config_models import BrowserHandoffConfig
+    from family_assistant.tools.browser_dom import Snapshot
+    from family_assistant.tools.types import ToolExecutionContext
+
+logger = logging.getLogger(__name__)
+
+# Agent-command payloads and browser-server JSON responses are genuinely
+# arbitrary JSON shapes, so a typed structure would be misleading here.
+# ast-grep-ignore: no-dict-any - heterogeneous browser-server JSON payloads
+JsonDict = dict[str, Any]
+
+LoadState = Literal["load", "domcontentloaded", "networkidle"]
+_VALID_LOAD_STATES: tuple[LoadState, ...] = get_args(LoadState)
+
+# In-page DOM walker shared by the local backend. Tags interactive/labeled
+# elements with a stable ``data-fa-ref`` attribute and returns a nested
+# accessibility tree matching the ``Snapshot`` shape. ``browser-server`` runs an
+# identical copy server-side, so the remote backend returns the same structure.
+# The ref ``e12`` always resolves to ``[data-fa-ref="e12"]``.
+SNAPSHOT_JS = r"""
+() => {
+  document.querySelectorAll('[data-fa-ref]').forEach(el => el.removeAttribute('data-fa-ref'));
+
+  let refCounter = 0;
+  const allocRef = () => 'e' + (++refCounter);
+
+  const ROLE_MAP = {
+    A: 'link', BUTTON: 'button', SELECT: 'combobox',
+    TEXTAREA: 'textbox', FORM: 'form', NAV: 'navigation',
+    MAIN: 'main', ASIDE: 'complementary', HEADER: 'banner',
+    FOOTER: 'contentinfo', IMG: 'img',
+  };
+  const INPUT_ROLES = {
+    submit: 'button', button: 'button', reset: 'button',
+    checkbox: 'checkbox', radio: 'radio',
+    range: 'slider', file: 'textbox',
+  };
+  const HEADING_TAGS = new Set(['H1','H2','H3','H4','H5','H6']);
+  const NAME_FROM_CONTENT = new Set([
+    'A', 'BUTTON', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
+    'P', 'LI', 'SPAN', 'LABEL', 'OPTION', 'TD', 'TH', 'CAPTION',
+  ]);
+
+  function roleFor(el) {
+    const aria = el.getAttribute('role');
+    if (aria) return aria;
+    if (HEADING_TAGS.has(el.tagName)) return 'heading';
+    if (el.tagName === 'INPUT') {
+      const t = (el.getAttribute('type') || 'text').toLowerCase();
+      return INPUT_ROLES[t] || 'textbox';
+    }
+    return ROLE_MAP[el.tagName] || null;
+  }
+
+  function accName(el) {
+    const labelledBy = el.getAttribute('aria-labelledby');
+    if (labelledBy) {
+      const parts = [];
+      for (const id of labelledBy.trim().split(/\s+/)) {
+        const target = id && document.getElementById(id);
+        if (target) parts.push(target.textContent.trim());
+      }
+      if (parts.length) return parts.join(' ');
+    }
+    const aria = el.getAttribute('aria-label');
+    if (aria) return aria.trim();
+    if (el.id) {
+      const lbl = document.querySelector('label[for="' + CSS.escape(el.id) + '"]');
+      if (lbl) return lbl.textContent.trim();
+    }
+    const parentLabel = el.closest && el.closest('label');
+    if (parentLabel && parentLabel !== el) return parentLabel.textContent.trim();
+    if (el.getAttribute('alt')) return el.getAttribute('alt').trim();
+    if (el.getAttribute('title')) return el.getAttribute('title').trim();
+    if (el.getAttribute('placeholder')) return el.getAttribute('placeholder').trim();
+    if (!NAME_FROM_CONTENT.has(el.tagName)) return '';
+    const txt = (el.innerText || el.textContent || '').trim();
+    return txt.length > 120 ? txt.slice(0, 120) + '…' : txt;
+  }
+
+  function isVisible(el) {
+    if (!el.getBoundingClientRect) return false;
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return false;
+    const style = window.getComputedStyle(el);
+    if (style.visibility === 'hidden' || style.display === 'none') return false;
+    return true;
+  }
+
+  function interesting(el) {
+    const role = roleFor(el);
+    if (role) return role;
+    if (el.tagName === 'P' || el.tagName === 'LI') return 'text';
+    return null;
+  }
+
+  function walk(el, out) {
+    if (el.nodeType !== 1) return;
+    if (!isVisible(el)) return;
+    const role = interesting(el);
+    if (role) {
+      const ref = allocRef();
+      el.setAttribute('data-fa-ref', ref);
+      const node = { ref, role, name: accName(el) };
+      const href = el.getAttribute('href');
+      if (href) node.href = href;
+      const value = el.value;
+      if (typeof value === 'string' && value) node.value = value;
+      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') {
+        node.tag = el.tagName.toLowerCase();
+        const t = el.getAttribute('type');
+        if (t) node.input_type = t.toLowerCase();
+      }
+      out.push(node);
+      node.children = [];
+      for (const child of el.children) walk(child, node.children);
+      if (node.children.length === 0) delete node.children;
+    } else {
+      for (const child of el.children) walk(child, out);
+    }
+  }
+
+  const roots = [];
+  walk(document.body, roots);
+
+  const formCount = document.forms ? document.forms.length : 0;
+  return {
+    url: location.href,
+    title: document.title,
+    forms: formCount,
+    elements: refCounter,
+    roots,
+  };
+}
+"""
+
+
+def _coerce_load_state(state: str) -> LoadState:
+    """Validate and narrow a runtime string to a Playwright load state literal."""
+    for candidate in _VALID_LOAD_STATES:
+        if candidate == state:
+            return candidate
+    raise ValueError(
+        f"Invalid load state {state!r}; expected one of {_VALID_LOAD_STATES}"
+    )
+
+
+def wrap_exec_code(code: str) -> str:
+    """Wrap user-provided JS so ``page.evaluate`` can run it uniformly.
+
+    Playwright treats a function-shaped string as callable and evaluates a bare
+    expression as its value. We want both styles — ``document.title``
+    (expression) and ``return document.title`` (statement body) — to work.
+    """
+    stripped = code.strip()
+    if not stripped:
+        return "async () => null"
+    if stripped.startswith(("(", "async ", "function ")):
+        return stripped
+    if stripped.startswith("{"):
+        return f"async () => {stripped}"
+    looks_like_statements = "return " in stripped or ";" in stripped or "\n" in stripped
+    if looks_like_statements:
+        return f"async () => {{ {stripped} }}"
+    return f"async () => ({stripped})"
+
+
+class BrowserBackendError(RuntimeError):
+    """Raised when a backend operation fails (remote HTTP error, JS error, …)."""
+
+
+class HandoffUnavailableError(BrowserBackendError):
+    """Raised when a human handoff is requested but no remote backend is active."""
+
+
+@runtime_checkable
+class BrowserBackend(Protocol):
+    """Page-level operations the semantic DOM tools depend on.
+
+    ``ref_cache`` maps short refs (``e12``) to selectors; it is repopulated on
+    each snapshot and cleared on navigation / arbitrary JS execution.
+    """
+
+    @property
+    def ref_cache(self) -> dict[str, str]: ...
+
+    @property
+    def current_url(self) -> str: ...
+
+    def clear_refs(self) -> None: ...
+
+    async def goto(self, url: str) -> None: ...
+
+    async def raw_snapshot(self) -> Snapshot: ...
+
+    async def settle(self, timeout_ms: int = 5000) -> None: ...
+
+    async def click(self, selector: str) -> None: ...
+
+    async def fill(self, selector: str, text: str, submit: bool) -> None: ...
+
+    async def select(self, selector: str, value: str) -> None: ...
+
+    async def wait(self, selector: str | None, state: str, timeout_ms: int) -> None: ...
+
+    async def extract_html(self, selector: str | None) -> str: ...
+
+    async def screenshot_png(self) -> bytes: ...
+
+    # ast-grep-ignore: no-dict-any - JS return values are genuinely arbitrary JSON
+    async def evaluate(self, code: str) -> Any: ...  # noqa: ANN401
+
+    async def request_handoff(
+        self,
+        *,
+        reason: str,
+        handoff_note: str,
+        expected_origin: str | None,
+        allowed_resume: str,
+    ) -> JsonDict: ...
+
+    async def close(self) -> None: ...
+
+
+class LocalPlaywrightBackend:
+    """Backend wrapping the shared in-process Playwright ``BrowserSession``."""
+
+    def __init__(self, session: BrowserSession) -> None:
+        self._session = session
+
+    @property
+    def ref_cache(self) -> dict[str, str]:
+        return self._session.ref_cache
+
+    @property
+    def current_url(self) -> str:
+        page = self._session.page
+        return page.url if page is not None else ""
+
+    def clear_refs(self) -> None:
+        self._session.clear_refs()
+
+    async def _page(self) -> Page:
+        return await self._session.ensure_page()
+
+    async def goto(self, url: str) -> None:
+        page = await self._page()
+        await page.goto(url)
+
+    async def raw_snapshot(self) -> Snapshot:
+        page = await self._page()
+        raw = await page.evaluate(SNAPSHOT_JS)
+        return cast("Snapshot", raw)
+
+    async def settle(self, timeout_ms: int = 5000) -> None:
+        page = await self._page()
+        with contextlib.suppress(PlaywrightError):
+            await page.wait_for_load_state("domcontentloaded", timeout=timeout_ms)
+
+    async def click(self, selector: str) -> None:
+        page = await self._page()
+        await page.locator(selector).click()
+
+    async def fill(self, selector: str, text: str, submit: bool) -> None:
+        page = await self._page()
+        locator = page.locator(selector)
+        await locator.fill(text)
+        if submit:
+            await locator.press("Enter")
+
+    async def select(self, selector: str, value: str) -> None:
+        page = await self._page()
+        await page.locator(selector).select_option(value)
+
+    async def wait(self, selector: str | None, state: str, timeout_ms: int) -> None:
+        page = await self._page()
+        if selector:
+            await page.wait_for_selector(selector, timeout=timeout_ms)
+        else:
+            await page.wait_for_load_state(
+                _coerce_load_state(state), timeout=timeout_ms
+            )
+
+    async def extract_html(self, selector: str | None) -> str:
+        page = await self._page()
+        if selector:
+            return await page.locator(selector).inner_html()
+        return await page.content()
+
+    async def screenshot_png(self) -> bytes:
+        page = await self._page()
+        return await page.screenshot(type="png")
+
+    # ast-grep-ignore: no-dict-any - JS return values are genuinely arbitrary JSON
+    async def evaluate(self, code: str) -> Any:  # noqa: ANN401
+        page = await self._page()
+        try:
+            return await page.evaluate(wrap_exec_code(code))
+        except PlaywrightError as exc:
+            raise BrowserBackendError(str(exc)) from exc
+
+    async def request_handoff(
+        self,
+        *,
+        reason: str,
+        handoff_note: str,
+        expected_origin: str | None,
+        allowed_resume: str,
+    ) -> JsonDict:
+        raise HandoffUnavailableError(
+            "Human browser handoff requires browser_handoff_config to be enabled "
+            "(no remote browser-server is configured)."
+        )
+
+    async def close(self) -> None:
+        await self._session.close()
+
+
+class RemoteBrowserBackend:
+    """Backend that drives a remote ``browser-server`` session over HTTP."""
+
+    def __init__(
+        self,
+        config: BrowserHandoffConfig,
+        conversation_id: str,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if not config.service_url:
+            raise BrowserBackendError(
+                "browser_handoff_config.enabled is set but service_url is missing"
+            )
+        self._config = config
+        self._conversation_id = conversation_id
+        self._base_url = config.service_url.rstrip("/")
+        self._session_id: str | None = None
+        # ``client`` is an injection seam for tests (e.g. httpx.MockTransport).
+        self._client = client or httpx.AsyncClient(timeout=config.timeout_seconds)
+        self.ref_cache: dict[str, str] = {}
+        self._last_url: str = ""
+
+    @property
+    def current_url(self) -> str:
+        return self._last_url
+
+    def clear_refs(self) -> None:
+        self.ref_cache.clear()
+
+    def _headers(self) -> dict[str, str]:
+        auth = self._config.auth
+        if auth.type == "none" or not auth.token_env:
+            return {}
+        token = os.environ.get(auth.token_env)
+        if not token:
+            raise BrowserBackendError(
+                f"browser_handoff_config auth token env {auth.token_env!r} is not set"
+            )
+        if auth.type == "api_key":
+            return {auth.header_name: token}
+        return {auth.header_name: f"Bearer {token}"}
+
+    async def _ensure_session(self) -> str:
+        if self._session_id is not None:
+            return self._session_id
+        resp = await self._client.post(
+            f"{self._base_url}/v1/sessions",
+            headers=self._headers(),
+            json={
+                "conversation_id": self._conversation_id,
+                "interface_type": "research",
+                "initial_owner": "agent",
+            },
+        )
+        self._raise_for_status(resp, "create session")
+        self._session_id = str(resp.json()["session_id"])
+        return self._session_id
+
+    # ast-grep-ignore: no-dict-any - agent-command results are heterogeneous JSON
+    async def _command(
+        self, command_type: str, args: JsonDict | None = None
+    ) -> JsonDict:
+        session_id = await self._ensure_session()
+        resp = await self._client.post(
+            f"{self._base_url}/v1/sessions/{session_id}/agent-command",
+            headers=self._headers(),
+            json={"type": command_type, "args": args or {}},
+        )
+        self._raise_for_status(resp, f"command {command_type}")
+        result = resp.json().get("result", {})
+        url = result.get("url")
+        if isinstance(url, str) and url:
+            self._last_url = url
+        return result
+
+    def _raise_for_status(self, resp: httpx.Response, action: str) -> None:
+        if resp.is_success:
+            return
+        detail = resp.text[:300]
+        raise BrowserBackendError(
+            f"browser-server {action} failed ({resp.status_code}): {detail}"
+        )
+
+    async def goto(self, url: str) -> None:
+        await self._command("navigate", {"url": url})
+
+    async def raw_snapshot(self) -> Snapshot:
+        result = await self._command("snapshot")
+        return cast("Snapshot", result)
+
+    async def settle(self, timeout_ms: int = 5000) -> None:
+        # browser-server navigates with wait_until=domcontentloaded and settles
+        # after click/type itself, so there is nothing extra to wait for here.
+        return None
+
+    async def click(self, selector: str) -> None:
+        await self._command("click", {"selector": selector})
+
+    async def fill(self, selector: str, text: str, submit: bool) -> None:
+        await self._command("type_text", {"selector": selector, "text": text})
+        if submit:
+            await self._command("press_key", {"key": "Enter"})
+
+    async def select(self, selector: str, value: str) -> None:
+        await self._command("select", {"selector": selector, "value": value})
+
+    async def wait(self, selector: str | None, state: str, timeout_ms: int) -> None:
+        args: JsonDict = {"state": state, "timeout_ms": timeout_ms}
+        if selector:
+            args["selector"] = selector
+        await self._command("wait", args)
+
+    async def extract_html(self, selector: str | None) -> str:
+        result = await self._command(
+            "extract", {"selector": selector} if selector else {}
+        )
+        return str(result.get("html", ""))
+
+    async def screenshot_png(self) -> bytes:
+        result = await self._command("screenshot")
+        encoded = result.get("image_base64")
+        if not isinstance(encoded, str):
+            raise BrowserBackendError(
+                "browser-server screenshot returned no image data"
+            )
+        return base64.b64decode(encoded)
+
+    # ast-grep-ignore: no-dict-any - JS return values are genuinely arbitrary JSON
+    async def evaluate(self, code: str) -> Any:  # noqa: ANN401
+        result = await self._command("exec", {"code": code})
+        if "error" in result:
+            raise BrowserBackendError(str(result["error"]))
+        return result.get("result")
+
+    async def request_handoff(
+        self,
+        *,
+        reason: str,
+        handoff_note: str,
+        expected_origin: str | None,
+        allowed_resume: str,
+    ) -> JsonDict:
+        session_id = await self._ensure_session()
+        payload: JsonDict = {
+            "reason": reason,
+            "handoff_note": handoff_note,
+            "allowed_resume": allowed_resume,
+        }
+        if expected_origin is not None:
+            payload["expected_origin"] = expected_origin
+        resp = await self._client.post(
+            f"{self._base_url}/v1/sessions/{session_id}/handoff",
+            headers=self._headers(),
+            json=payload,
+        )
+        self._raise_for_status(resp, "handoff")
+        return resp.json()
+
+    async def close(self) -> None:
+        try:
+            if self._session_id is not None:
+                await self._client.post(
+                    f"{self._base_url}/v1/sessions/{self._session_id}/close",
+                    headers=self._headers(),
+                )
+        except httpx.HTTPError as exc:
+            logger.warning("browser-server session close failed: %s", exc)
+        finally:
+            await self._client.aclose()
+            self._session_id = None
+
+
+# Remote backends are keyed by conversation_id, mirroring the local
+# BrowserSession registry so each conversation drives its own remote session.
+_remote_backends: dict[str, RemoteBrowserBackend] = {}
+
+
+def _remote_enabled(exec_context: ToolExecutionContext) -> BrowserHandoffConfig | None:
+    """Return the browser-handoff config if the remote backend should be used here."""
+    service = getattr(exec_context, "processing_service", None)
+    app_config = getattr(service, "app_config", None) if service is not None else None
+    if app_config is None:
+        return None
+    config = app_config.browser_handoff_config
+    if not config.enabled or not config.service_url:
+        return None
+    profile_id = getattr(exec_context, "processing_profile_id", None)
+    if (
+        config.handoff_capable_profiles
+        and profile_id not in config.handoff_capable_profiles
+    ):
+        return None
+    return config
+
+
+async def get_browser_backend(exec_context: ToolExecutionContext) -> BrowserBackend:
+    """Resolve the browser backend for this execution context.
+
+    Uses the remote ``browser-server`` backend when ``browser_handoff_config`` is
+    enabled for the active profile; otherwise the shared local Playwright session.
+    """
+    config = _remote_enabled(exec_context)
+    if config is not None:
+        session_key = exec_context.conversation_id or "default"
+        backend = _remote_backends.get(session_key)
+        if backend is None:
+            backend = RemoteBrowserBackend(config, session_key)
+            _remote_backends[session_key] = backend
+        return backend
+    session: BrowserSession = await get_browser_session(exec_context)
+    return LocalPlaywrightBackend(session)
+
+
+async def close_browser_backend(exec_context: ToolExecutionContext) -> None:
+    """Close and remove any backend (local or remote) for this context."""
+    session_key = exec_context.conversation_id or "default"
+    remote = _remote_backends.pop(session_key, None)
+    if remote is not None:
+        await remote.close()
+    await close_browser_session(exec_context)

--- a/src/family_assistant/tools/browser_backend.py
+++ b/src/family_assistant/tools/browser_backend.py
@@ -577,7 +577,7 @@ class RemoteBrowserBackend:
 
     # ast-grep-ignore: no-dict-any - JS return values are genuinely arbitrary JSON
     async def evaluate(self, code: str) -> Any:  # noqa: ANN401
-        result = await self._command("exec", {"code": code})
+        result = await self._command("exec", {"code": wrap_exec_code(code)})
         if "error" in result:
             raise BrowserBackendError(str(result["error"]))
         return result.get("result")
@@ -707,3 +707,4 @@ async def close_browser_backend(exec_context: ToolExecutionContext) -> None:
     if remote is not None:
         await remote.close()
     await close_browser_session(exec_context)
+

--- a/src/family_assistant/tools/browser_backend.py
+++ b/src/family_assistant/tools/browser_backend.py
@@ -226,10 +226,14 @@ class HandoffUnavailableError(BrowserBackendError):
 
 @runtime_checkable
 class BrowserBackend(Protocol):
-    """Page-level operations the semantic DOM tools depend on.
+    """Page-level operations shared by semantic DOM and visual computer-use tools.
 
     ``ref_cache`` maps short refs (``e12``) to selectors; it is repopulated on
     each snapshot and cleared on navigation / arbitrary JS execution.
+
+    The ``mouse_*`` / ``keyboard_*`` / ``go_back`` / ``go_forward`` methods are
+    used by the visual (Computer Use) profile so it can share the same remote
+    browser session instead of opening a separate local tab.
     """
 
     @property
@@ -237,6 +241,12 @@ class BrowserBackend(Protocol):
 
     @property
     def current_url(self) -> str: ...
+
+    @property
+    def screen_width(self) -> int: ...
+
+    @property
+    def screen_height(self) -> int: ...
 
     def clear_refs(self) -> None: ...
 
@@ -260,6 +270,24 @@ class BrowserBackend(Protocol):
 
     # ast-grep-ignore: no-dict-any - JS return values are genuinely arbitrary JSON
     async def evaluate(self, code: str) -> Any: ...  # noqa: ANN401
+
+    async def mouse_click(self, x: float, y: float) -> None: ...
+
+    async def mouse_move(self, x: float, y: float) -> None: ...
+
+    async def mouse_down(self) -> None: ...
+
+    async def mouse_up(self) -> None: ...
+
+    async def mouse_wheel(self, delta_x: float, delta_y: float) -> None: ...
+
+    async def keyboard_type(self, text: str) -> None: ...
+
+    async def keyboard_press(self, keys: str) -> None: ...
+
+    async def go_back(self) -> None: ...
+
+    async def go_forward(self) -> None: ...
 
     async def request_handoff(
         self,
@@ -287,6 +315,14 @@ class LocalPlaywrightBackend:
     def current_url(self) -> str:
         page = self._session.page
         return page.url if page is not None else ""
+
+    @property
+    def screen_width(self) -> int:
+        return self._session.screen_width
+
+    @property
+    def screen_height(self) -> int:
+        return self._session.screen_height
 
     def clear_refs(self) -> None:
         self._session.clear_refs()
@@ -350,6 +386,46 @@ class LocalPlaywrightBackend:
         except PlaywrightError as exc:
             raise BrowserBackendError(str(exc)) from exc
 
+    async def mouse_click(self, x: float, y: float) -> None:
+        page = await self._page()
+        await page.mouse.click(x, y)
+        with contextlib.suppress(PlaywrightError):
+            await page.wait_for_load_state("domcontentloaded", timeout=2000)
+
+    async def mouse_move(self, x: float, y: float) -> None:
+        page = await self._page()
+        await page.mouse.move(x, y)
+
+    async def mouse_down(self) -> None:
+        page = await self._page()
+        await page.mouse.down()
+
+    async def mouse_up(self) -> None:
+        page = await self._page()
+        await page.mouse.up()
+
+    async def mouse_wheel(self, delta_x: float, delta_y: float) -> None:
+        page = await self._page()
+        await page.mouse.wheel(delta_x, delta_y)
+
+    async def keyboard_type(self, text: str) -> None:
+        page = await self._page()
+        await page.keyboard.type(text)
+
+    async def keyboard_press(self, keys: str) -> None:
+        page = await self._page()
+        await page.keyboard.press(keys)
+        with contextlib.suppress(PlaywrightError):
+            await page.wait_for_load_state("domcontentloaded", timeout=2000)
+
+    async def go_back(self) -> None:
+        page = await self._page()
+        await page.go_back()
+
+    async def go_forward(self) -> None:
+        page = await self._page()
+        await page.go_forward()
+
     async def request_handoff(
         self,
         *,
@@ -365,6 +441,11 @@ class LocalPlaywrightBackend:
 
     async def close(self) -> None:
         await self._session.close()
+
+
+# browser-server default viewport — must match DEFAULT_DISPLAY_WIDTH/HEIGHT in runtime.py
+_REMOTE_VIEWPORT_WIDTH = 1280
+_REMOTE_VIEWPORT_HEIGHT = 720
 
 
 class RemoteBrowserBackend:
@@ -501,6 +582,41 @@ class RemoteBrowserBackend:
             raise BrowserBackendError(str(result["error"]))
         return result.get("result")
 
+    @property
+    def screen_width(self) -> int:
+        return _REMOTE_VIEWPORT_WIDTH
+
+    @property
+    def screen_height(self) -> int:
+        return _REMOTE_VIEWPORT_HEIGHT
+
+    async def mouse_click(self, x: float, y: float) -> None:
+        await self._command("mouse_click", {"x": x, "y": y})
+
+    async def mouse_move(self, x: float, y: float) -> None:
+        await self._command("mouse_move", {"x": x, "y": y})
+
+    async def mouse_down(self) -> None:
+        await self._command("mouse_down", {})
+
+    async def mouse_up(self) -> None:
+        await self._command("mouse_up", {})
+
+    async def mouse_wheel(self, delta_x: float, delta_y: float) -> None:
+        await self._command("mouse_wheel", {"delta_x": delta_x, "delta_y": delta_y})
+
+    async def keyboard_type(self, text: str) -> None:
+        await self._command("keyboard_type", {"text": text})
+
+    async def keyboard_press(self, keys: str) -> None:
+        await self._command("keyboard_press", {"keys": keys})
+
+    async def go_back(self) -> None:
+        await self._command("navigate_back", {})
+
+    async def go_forward(self) -> None:
+        await self._command("navigate_forward", {})
+
     async def request_handoff(
         self,
         *,
@@ -566,13 +682,11 @@ async def get_browser_backend(exec_context: ToolExecutionContext) -> BrowserBack
     """Resolve the browser backend for this execution context.
 
     Uses the remote ``browser-server`` backend when ``browser_handoff_config`` is
-    enabled for the active profile; otherwise the shared local Playwright session.
-
-    Note: visual delegation (``browser_visual_profile``) still uses the local
-    Computer Use session via ``get_browser_session``, so delegating a remote-backed
-    DOM profile to the visual profile will open a separate local tab rather than
-    reusing the remote session.  Routing the visual profile through the remote
-    session is tracked as a future improvement.
+    enabled for the active profile (including ``browser_visual_profile``); otherwise
+    the shared local Playwright session.  Both the semantic DOM profile and the
+    visual Computer Use profile share the same remote session keyed by
+    ``conversation_id``, so the tab state (URL, cookies, form fills) is preserved
+    across profile delegation.
     """
     config = _remote_enabled(exec_context)
     if config is not None:
@@ -593,4 +707,3 @@ async def close_browser_backend(exec_context: ToolExecutionContext) -> None:
     if remote is not None:
         await remote.close()
     await close_browser_session(exec_context)
-

--- a/src/family_assistant/tools/browser_dom.py
+++ b/src/family_assistant/tools/browser_dom.py
@@ -20,39 +20,22 @@ the same live tab.
 
 from __future__ import annotations
 
-import contextlib
 import logging
-from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, cast, get_args
+from typing import TYPE_CHECKING, NotRequired, TypedDict, cast
 
 import toons
-from rebrowser_playwright.async_api import Error as PlaywrightError
 
-from family_assistant.tools.browser_session import (
-    BrowserSession,
-    get_browser_session,
+from family_assistant.tools.browser_backend import (
+    BrowserBackend,
+    BrowserBackendError,
+    HandoffUnavailableError,
+    get_browser_backend,
 )
 from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 from family_assistant.utils.scraping import convert_html_bytes_to_markdown
 
 if TYPE_CHECKING:
-    from rebrowser_playwright.async_api import Page
-
     from family_assistant.tools.types import ToolExecutionContext
-
-LoadState = Literal["load", "domcontentloaded", "networkidle"]
-_VALID_LOAD_STATES: tuple[LoadState, ...] = get_args(LoadState)
-
-
-def _coerce_load_state(state: str) -> LoadState:
-    """Validate and narrow a runtime string to a Playwright load state literal."""
-    if state not in _VALID_LOAD_STATES:
-        raise ValueError(
-            f"Invalid load state {state!r}; expected one of {_VALID_LOAD_STATES}"
-        )
-    for candidate in _VALID_LOAD_STATES:
-        if candidate == state:
-            return candidate
-    raise AssertionError("unreachable")
 
 
 class SnapshotNode(TypedDict):
@@ -109,155 +92,12 @@ __all__ = [
     "browser_extract_tool",
     "browser_fill_tool",
     "browser_open_tool",
+    "browser_request_handoff_tool",
     "browser_screenshot_tool",
     "browser_select_tool",
     "browser_snapshot_tool",
     "browser_wait_tool",
 ]
-
-
-# ---------------------------------------------------------------------------
-# Snapshot building
-# ---------------------------------------------------------------------------
-
-# JS that walks the DOM, tags interactive/labeled elements with a stable
-# ``data-fa-ref`` attribute, and returns a nested structure describing each
-# element's role, accessible name, and key attributes. The attribute-tagging
-# strategy means the Python side doesn't have to store a per-ref selector —
-# the ref ``e12`` always resolves to ``[data-fa-ref="e12"]``. The attribute
-# is namespaced (``data-fa-ref`` rather than ``data-ref``) so it can't
-# collide with application-owned ``data-ref`` attributes that some sites use
-# for their own runtime logic or test harnesses.
-#
-# The function is wrapped in an IIFE so it can be passed straight to
-# ``page.evaluate`` without leaking globals.
-_SNAPSHOT_JS = r"""
-() => {
-  // Clear previous refs so snapshots between navigations don't collide.
-  document.querySelectorAll('[data-fa-ref]').forEach(el => el.removeAttribute('data-fa-ref'));
-
-  let refCounter = 0;
-  const allocRef = () => 'e' + (++refCounter);
-
-  const ROLE_MAP = {
-    A: 'link', BUTTON: 'button', SELECT: 'combobox',
-    TEXTAREA: 'textbox', FORM: 'form', NAV: 'navigation',
-    MAIN: 'main', ASIDE: 'complementary', HEADER: 'banner',
-    FOOTER: 'contentinfo', IMG: 'img',
-  };
-  const INPUT_ROLES = {
-    submit: 'button', button: 'button', reset: 'button',
-    checkbox: 'checkbox', radio: 'radio',
-    range: 'slider', file: 'textbox',
-  };
-  const HEADING_TAGS = new Set(['H1','H2','H3','H4','H5','H6']);
-  // Elements whose accessible name is derived from their text content.
-  // Landmark containers (FORM, NAV, MAIN, …) deliberately fall back to the
-  // empty string — letting them pick up descendant text would produce giant
-  // concatenated names with embedded newlines.
-  const NAME_FROM_CONTENT = new Set([
-    'A', 'BUTTON', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
-    'P', 'LI', 'SPAN', 'LABEL', 'OPTION', 'TD', 'TH', 'CAPTION',
-  ]);
-
-  function roleFor(el) {
-    const aria = el.getAttribute('role');
-    if (aria) return aria;
-    if (HEADING_TAGS.has(el.tagName)) return 'heading';
-    if (el.tagName === 'INPUT') {
-      const t = (el.getAttribute('type') || 'text').toLowerCase();
-      return INPUT_ROLES[t] || 'textbox';
-    }
-    return ROLE_MAP[el.tagName] || null;
-  }
-
-  // Accessible name computation — ordered roughly per the ARIA spec so that
-  // an explicit <label for=...> outranks a placeholder fallback.
-  function accName(el) {
-    const labelledBy = el.getAttribute('aria-labelledby');
-    if (labelledBy) {
-      // aria-labelledby is a space-separated list of IDs whose text content is
-      // joined in document order — see the ARIA Accessible Name Computation
-      // spec. Dropping all but the first ID silently produces wrong names for
-      // composite labels like `<span id="a">Quantity</span><span id="b">lbs</span>`.
-      const parts = [];
-      for (const id of labelledBy.trim().split(/\s+/)) {
-        const target = id && document.getElementById(id);
-        if (target) parts.push(target.textContent.trim());
-      }
-      if (parts.length) return parts.join(' ');
-    }
-    const aria = el.getAttribute('aria-label');
-    if (aria) return aria.trim();
-    if (el.id) {
-      const lbl = document.querySelector('label[for="' + CSS.escape(el.id) + '"]');
-      if (lbl) return lbl.textContent.trim();
-    }
-    const parentLabel = el.closest && el.closest('label');
-    if (parentLabel && parentLabel !== el) return parentLabel.textContent.trim();
-    if (el.getAttribute('alt')) return el.getAttribute('alt').trim();
-    if (el.getAttribute('title')) return el.getAttribute('title').trim();
-    if (el.getAttribute('placeholder')) return el.getAttribute('placeholder').trim();
-    if (!NAME_FROM_CONTENT.has(el.tagName)) return '';
-    const txt = (el.innerText || el.textContent || '').trim();
-    return txt.length > 120 ? txt.slice(0, 120) + '…' : txt;
-  }
-
-  function isVisible(el) {
-    if (!el.getBoundingClientRect) return false;
-    const rect = el.getBoundingClientRect();
-    if (rect.width === 0 && rect.height === 0) return false;
-    const style = window.getComputedStyle(el);
-    if (style.visibility === 'hidden' || style.display === 'none') return false;
-    return true;
-  }
-
-  function interesting(el) {
-    const role = roleFor(el);
-    if (role) return role;
-    if (el.tagName === 'P' || el.tagName === 'LI') return 'text';
-    return null;
-  }
-
-  function walk(el, out) {
-    if (el.nodeType !== 1) return;
-    if (!isVisible(el)) return;
-    const role = interesting(el);
-    if (role) {
-      const ref = allocRef();
-      el.setAttribute('data-fa-ref', ref);
-      const node = { ref, role, name: accName(el) };
-      const href = el.getAttribute('href');
-      if (href) node.href = href;
-      const value = el.value;
-      if (typeof value === 'string' && value) node.value = value;
-      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') {
-        node.tag = el.tagName.toLowerCase();
-        const t = el.getAttribute('type');
-        if (t) node.input_type = t.toLowerCase();
-      }
-      out.push(node);
-      node.children = [];
-      for (const child of el.children) walk(child, node.children);
-      if (node.children.length === 0) delete node.children;
-    } else {
-      for (const child of el.children) walk(child, out);
-    }
-  }
-
-  const roots = [];
-  walk(document.body, roots);
-
-  const formCount = document.forms ? document.forms.length : 0;
-  return {
-    url: location.href,
-    title: document.title,
-    forms: formCount,
-    elements: refCounter,
-    roots,
-  };
-}
-"""
 
 
 def _node_matches(node: SnapshotNode, query: str) -> bool:
@@ -344,58 +184,30 @@ def _collect_refs(
     return out
 
 
-async def _take_snapshot(
-    session: BrowserSession, page: Page, query: str | None
-) -> SnapshotData:
-    """Run the snapshot JS, update the session ref cache, and return the snapshot."""
-    raw = await page.evaluate(_SNAPSHOT_JS)
-    # page.evaluate returns the raw JSON the JS produced; the shape is
-    # controlled entirely by ``_SNAPSHOT_JS`` above, which matches Snapshot.
-    snapshot = cast("Snapshot", raw)
-    session.ref_cache.clear()
-    session.ref_cache.update(_collect_refs(snapshot["roots"]))
+async def _take_snapshot(backend: BrowserBackend, query: str | None) -> SnapshotData:
+    """Capture a snapshot via the backend, update the ref cache, and return it."""
+    snapshot = await backend.raw_snapshot()
+    backend.ref_cache.clear()
+    backend.ref_cache.update(_collect_refs(snapshot["roots"]))
     text = _format_toon(snapshot, query=query)
     return SnapshotData(
         text=text,
-        url=snapshot["url"] or page.url,
+        url=snapshot["url"] or backend.current_url,
         title=snapshot["title"],
         counts=SnapshotCounts(forms=snapshot["forms"], elements=snapshot["elements"]),
-        refs=list(session.ref_cache.keys()),
+        refs=list(backend.ref_cache.keys()),
         roots=snapshot["roots"],
     )
 
 
-def _wrap_exec_code(code: str) -> str:
-    """Wrap user-provided JS so ``page.evaluate`` can run it uniformly.
-
-    Playwright treats a function-shaped string as callable and evaluates a
-    bare expression as its value. We want both styles — ``document.title``
-    (expression) and ``return document.title`` (statement body) — to work.
-    """
-    stripped = code.strip()
-    if not stripped:
-        return "async () => null"
-    if stripped.startswith(("(", "async ", "function ")):
-        return stripped
-    if stripped.startswith("{"):
-        return f"async () => {stripped}"
-    # Heuristic: if it looks like statements (has `return`, semicolons, or
-    # multiple lines), wrap as a function body; otherwise treat as a single
-    # expression.
-    looks_like_statements = "return " in stripped or ";" in stripped or "\n" in stripped
-    if looks_like_statements:
-        return f"async () => {{ {stripped} }}"
-    return f"async () => ({stripped})"
-
-
-def _resolve_ref(session: BrowserSession, ref: str) -> str:
+def _resolve_ref(backend: BrowserBackend, ref: str) -> str:
     """Return the selector for ``ref`` or raise a clear error."""
-    selector = session.ref_cache.get(ref)
+    selector = backend.ref_cache.get(ref)
     if selector is None:
         raise ValueError(
             f"Unknown ref {ref!r}. Refs are only valid for the most recent "
             f"snapshot; call browser_snapshot again after navigation or DOM "
-            f"changes. Known refs: {sorted(session.ref_cache.keys())[:10]}…"
+            f"changes. Known refs: {sorted(backend.ref_cache.keys())[:10]}…"
         )
     return selector
 
@@ -411,13 +223,11 @@ async def browser_open_tool(
     """Navigate to a URL and return a snapshot in one call."""
     if not url.startswith(("http://", "https://")):
         url = "https://" + url
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
+    backend = await get_browser_backend(exec_context)
     logger.info("browser_open: %s", url)
-    await page.goto(url)
-    with contextlib.suppress(PlaywrightError):
-        await page.wait_for_load_state("domcontentloaded", timeout=5000)
-    snap = await _take_snapshot(session, page, query=query)
+    await backend.goto(url)
+    await backend.settle()
+    snap = await _take_snapshot(backend, query=query)
     return ToolResult(text=snap["text"], data=dict(snap))
 
 
@@ -425,9 +235,8 @@ async def browser_snapshot_tool(
     exec_context: ToolExecutionContext, query: str | None = None
 ) -> ToolResult:
     """Re-capture an accessibility snapshot of the current page."""
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-    snap = await _take_snapshot(session, page, query=query)
+    backend = await get_browser_backend(exec_context)
+    snap = await _take_snapshot(backend, query=query)
     return ToolResult(text=snap["text"], data=dict(snap))
 
 
@@ -435,14 +244,12 @@ async def browser_click_tool(
     exec_context: ToolExecutionContext, ref: str
 ) -> ToolResult:
     """Click an element identified by a semantic ref from the latest snapshot."""
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-    selector = _resolve_ref(session, ref)
+    backend = await get_browser_backend(exec_context)
+    selector = _resolve_ref(backend, ref)
     logger.info("browser_click: %s -> %s", ref, selector)
-    await page.locator(selector).click()
-    with contextlib.suppress(PlaywrightError):
-        await page.wait_for_load_state("domcontentloaded", timeout=5000)
-    snap = await _take_snapshot(session, page, query=None)
+    await backend.click(selector)
+    await backend.settle()
+    snap = await _take_snapshot(backend, query=None)
     return ToolResult(text=snap["text"], data=dict(snap))
 
 
@@ -453,17 +260,13 @@ async def browser_fill_tool(
     submit: bool = False,
 ) -> ToolResult:
     """Fill a text input identified by ``ref``. Optionally press Enter."""
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-    selector = _resolve_ref(session, ref)
+    backend = await get_browser_backend(exec_context)
+    selector = _resolve_ref(backend, ref)
     logger.info("browser_fill: %s <- %r (submit=%s)", ref, text, submit)
-    locator = page.locator(selector)
-    await locator.fill(text)
+    await backend.fill(selector, text, submit)
     if submit:
-        await locator.press("Enter")
-        with contextlib.suppress(PlaywrightError):
-            await page.wait_for_load_state("domcontentloaded", timeout=5000)
-    snap = await _take_snapshot(session, page, query=None)
+        await backend.settle()
+    snap = await _take_snapshot(backend, query=None)
     return ToolResult(text=snap["text"], data=dict(snap))
 
 
@@ -476,12 +279,11 @@ async def browser_select_tool(
     value *or* its visible label in a single call, avoiding a 30s default
     timeout when the LLM guesses value-vs-label wrong.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-    selector = _resolve_ref(session, ref)
+    backend = await get_browser_backend(exec_context)
+    selector = _resolve_ref(backend, ref)
     logger.info("browser_select: %s <- %r", ref, value)
-    await page.locator(selector).select_option(value)
-    snap = await _take_snapshot(session, page, query=None)
+    await backend.select(selector, value)
+    snap = await _take_snapshot(backend, query=None)
     return ToolResult(text=snap["text"], data=dict(snap))
 
 
@@ -492,16 +294,12 @@ async def browser_wait_tool(
     timeout_ms: int = 5000,
 ) -> ToolResult:
     """Wait for a load state or a CSS selector to appear."""
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-    if selector:
-        logger.info("browser_wait: selector=%s timeout=%s", selector, timeout_ms)
-        await page.wait_for_selector(selector, timeout=timeout_ms)
-    else:
-        load_state = _coerce_load_state(state)
-        logger.info("browser_wait: state=%s timeout=%s", load_state, timeout_ms)
-        await page.wait_for_load_state(load_state, timeout=timeout_ms)
-    snap = await _take_snapshot(session, page, query=None)
+    backend = await get_browser_backend(exec_context)
+    logger.info(
+        "browser_wait: selector=%s state=%s timeout=%s", selector, state, timeout_ms
+    )
+    await backend.wait(selector, state, timeout_ms)
+    snap = await _take_snapshot(backend, query=None)
     return ToolResult(text=snap["text"], data=dict(snap))
 
 
@@ -509,27 +307,24 @@ async def browser_extract_tool(
     exec_context: ToolExecutionContext, selector: str | None = None
 ) -> ToolResult:
     """Return the page (or a subtree) rendered as Markdown."""
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-    if selector:
-        html = await page.locator(selector).inner_html()
-    else:
-        html = await page.content()
+    backend = await get_browser_backend(exec_context)
+    html = await backend.extract_html(selector)
+    url = backend.current_url
     logger.info(
-        "browser_extract: url=%s selector=%s bytes=%s", page.url, selector, len(html)
+        "browser_extract: url=%s selector=%s bytes=%s", url, selector, len(html)
     )
     markdown = await convert_html_bytes_to_markdown(
-        html.encode("utf-8"), filename=(page.url or "page") + ".html"
+        html.encode("utf-8"), filename=(url or "page") + ".html"
     )
     if markdown is None:
         # ast-grep-ignore: toolresult-text-literal-with-data - error string conveys the same failure mode as the data payload
         return ToolResult(
             text="Failed to convert page to markdown",
-            data={"error": "markdown_conversion_failed", "url": page.url},
+            data={"error": "markdown_conversion_failed", "url": url},
         )
     return ToolResult(
         text=markdown,
-        data={"url": page.url, "markdown": markdown, "selector": selector},
+        data={"url": url, "markdown": markdown, "selector": selector},
     )
 
 
@@ -537,16 +332,16 @@ async def browser_screenshot_tool(
     exec_context: ToolExecutionContext,
 ) -> ToolResult:
     """Capture a PNG screenshot of the current page."""
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-    png = await page.screenshot(type="png")
+    backend = await get_browser_backend(exec_context)
+    png = await backend.screenshot_png()
+    url = backend.current_url
     return ToolResult(
-        data={"url": page.url, "bytes": len(png)},
+        data={"url": url, "bytes": len(png)},
         attachments=[
             ToolAttachment(
                 content=png,
                 mime_type="image/png",
-                description=f"Screenshot of {page.url}",
+                description=f"Screenshot of {url}",
             )
         ],
     )
@@ -565,32 +360,73 @@ async def browser_exec_tool(
     The script runs in the page's V8 context with only same-origin privileges.
     It has no access to the Python process or browser internals.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
+    backend = await get_browser_backend(exec_context)
     logger.info("browser_exec: %d chars", len(code))
     # Clear the ref cache unconditionally — arbitrary JS could have mutated
     # the DOM before throwing (e.g. ``node.remove(); throw new Error()``),
     # so previously-captured refs are unreliable whether or not ``evaluate``
     # succeeds. Doing this up-front keeps the invariant simple: any call to
     # browser_exec means the next click/fill must re-snapshot.
-    session.clear_refs()
+    backend.clear_refs()
     try:
-        raw_result = await page.evaluate(_wrap_exec_code(code))
-    except PlaywrightError as exc:
+        raw_result = await backend.evaluate(code)
+    except BrowserBackendError as exc:
         return ToolResult(
             text=f"JS error: {exc}",
-            data={"error": str(exc), "url": page.url},
+            data={"error": str(exc), "url": backend.current_url},
         )
 
-    with contextlib.suppress(PlaywrightError):
-        await page.wait_for_load_state("domcontentloaded", timeout=2000)
+    await backend.settle(timeout_ms=2000)
 
     # Surface both the result and the (possibly-changed) URL so the LLM can
     # decide whether to re-snapshot. ``raw_result`` is whatever the JS
     # returned — it's genuinely arbitrary JSON, so it's typed as ``object``
     # rather than a specific shape.
-    data: dict[str, object] = {"result": raw_result, "url": page.url}
+    data: dict[str, object] = {"result": raw_result, "url": backend.current_url}
     return ToolResult(data=data)
+
+
+async def browser_request_handoff_tool(
+    exec_context: ToolExecutionContext,
+    reason: str,
+    handoff_note: str = "",
+    expected_origin: str | None = None,
+) -> ToolResult:
+    """Hand the live browser session to a human via the browser-server.
+
+    Use this when a step needs a human: entering payment details, credentials,
+    one-time passcodes, accepting legal consent, or solving a CAPTCHA. The
+    service mints a one-time URL the human opens to take over the *same* browser
+    (via noVNC); the agent loses all observation/control until the human is done.
+    Only available when the optional browser-server integration is configured.
+    """
+    backend = await get_browser_backend(exec_context)
+    logger.info("browser_request_handoff: reason=%s", reason)
+    try:
+        result = await backend.request_handoff(
+            reason=reason,
+            handoff_note=handoff_note,
+            expected_origin=expected_origin,
+            allowed_resume="never",
+        )
+    except HandoffUnavailableError as exc:
+        return ToolResult(
+            text=f"Browser handoff is not available: {exc}",
+            data={"error": "handoff_unavailable", "detail": str(exc)},
+        )
+    except BrowserBackendError as exc:
+        return ToolResult(
+            text=f"Browser handoff failed: {exc}",
+            data={"error": "handoff_failed", "detail": str(exc)},
+        )
+    handoff_url = result.get("handoff_url")
+    return ToolResult(
+        text=(
+            f"Handoff requested ({reason}). Ask the user to open this link to take "
+            f"over the browser: {handoff_url}"
+        ),
+        data=result,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -794,6 +630,47 @@ BROWSER_DOM_TOOLS_DEFINITION: list[ToolDefinition] = [
                     },
                 },
                 "required": ["code"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "browser_request_handoff",
+            "description": (
+                "Hand the live browser session to a human to finish a step the "
+                "agent must not do itself: entering payment details, credentials, "
+                "a one-time passcode, accepting legal consent, or solving a CAPTCHA. "
+                "Returns a one-time link the user opens to take over the same "
+                "browser; the agent loses all access until the human is done. Only "
+                "works when the browser-server integration is configured."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "reason": {
+                        "type": "string",
+                        "enum": [
+                            "payment",
+                            "credentials",
+                            "otp",
+                            "legal_consent",
+                            "captcha",
+                            "cookie_consent",
+                            "other",
+                        ],
+                        "description": "Why the human needs to take over.",
+                    },
+                    "handoff_note": {
+                        "type": "string",
+                        "description": "Short instruction shown to the user on the handoff page.",
+                    },
+                    "expected_origin": {
+                        "type": "string",
+                        "description": "Optional origin (scheme+host) the browser must be on before handing off.",
+                    },
+                },
+                "required": ["reason"],
             },
         },
     },

--- a/src/family_assistant/tools/browser_dom.py
+++ b/src/family_assistant/tools/browser_dom.py
@@ -137,7 +137,7 @@ def _filter_tree(
             continue
         # TypedDicts can't be copy-constructed via dict(td) per pyright; the
         # shape is invariant, so a shallow cast preserves types safely.
-        copy = cast("SnapshotNode", dict(node))
+        copy = cast("SnapshotNode", cast("object", dict(node)))
         if children:
             copy["children"] = _filter_tree(children, query, include_all=node_matches)
             if not copy["children"]:

--- a/src/family_assistant/tools/computer_use.py
+++ b/src/family_assistant/tools/computer_use.py
@@ -1,20 +1,25 @@
-"""Computer Use tools for browser automation using Playwright.
+"""Computer Use tools for browser automation.
 
 This module implements the tools required by the Gemini Computer Use model
-to interact with a web browser using async Playwright.
+to interact with a web browser.  All operations go through
+:class:`~family_assistant.tools.browser_backend.BrowserBackend` so that when a
+remote ``browser-server`` session is active the visual profile shares the
+same live browser tab as the semantic DOM profile.
 
-Session management (``BrowserSession``, ``get_browser_session``,
-``close_browser_session``) lives in :mod:`family_assistant.tools.browser_session`
-so the semantic DOM tools in ``browser_dom.py`` can share the same browser tab.
+When no remote backend is configured the local Playwright session is used,
+preserving the existing behaviour.
+
+``BrowserSession``, ``get_browser_session``, and ``close_browser_session``
+are re-exported for callers that still reference them directly.
 """
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from typing import TYPE_CHECKING
 
+from family_assistant.tools.browser_backend import BrowserBackend, get_browser_backend
 from family_assistant.tools.browser_session import (
     BrowserSession,
     close_browser_session,
@@ -24,8 +29,6 @@ from family_assistant.tools.browser_session import (
 from family_assistant.tools.types import ToolAttachment, ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
-    from rebrowser_playwright.async_api import Page
-
     from family_assistant.tools.types import ToolExecutionContext
 
 logger = logging.getLogger(__name__)
@@ -51,7 +54,7 @@ __all__ = [
 ]
 
 
-async def _take_screenshot_with_url(session: BrowserSession, page: Page) -> ToolResult:
+async def _take_screenshot_with_url(backend: BrowserBackend) -> ToolResult:
     """Take a screenshot and return it as a ToolResult with URL.
 
     The Gemini Computer Use model requires function responses to include
@@ -59,19 +62,19 @@ async def _take_screenshot_with_url(session: BrowserSession, page: Page) -> Tool
 
     Every Computer Use action is assumed to have potentially mutated the
     page (click, type, scroll, navigate, …), so any DOM refs captured by
-    ``browser_dom`` snapshots on the shared session are now stale. We
+    ``browser_dom`` snapshots on the shared session are now stale.  We
     invalidate them here so that a subsequent ``browser_click`` can't
     target a ref that no longer points at the intended element.
     """
-    session.clear_refs()
-    screenshot_bytes = await page.screenshot(type="png")
+    backend.clear_refs()
+    screenshot_bytes = await backend.screenshot_png()
     attachment = ToolAttachment(
         content=screenshot_bytes,
         mime_type="image/png",
         description="Browser screenshot",
     )
     return ToolResult(
-        data={"url": page.url},
+        data={"url": backend.current_url},
         attachments=[attachment],
     )
 
@@ -92,20 +95,12 @@ async def computer_use_click_at(
     Returns:
         A screenshot of the screen after the click.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
-    actual_x = denormalize_coordinate(x, session.screen_width)
-    actual_y = denormalize_coordinate(y, session.screen_height)
-
+    backend = await get_browser_backend(exec_context)
+    actual_x = denormalize_coordinate(x, backend.screen_width)
+    actual_y = denormalize_coordinate(y, backend.screen_height)
     logger.info(f"Clicking at ({actual_x}, {actual_y})")
-    await page.mouse.click(actual_x, actual_y)
-
-    # Wait for potential navigations/renders
-    with contextlib.suppress(Exception):
-        await page.wait_for_load_state(timeout=2000)
-
-    return await _take_screenshot_with_url(session, page)
+    await backend.mouse_click(actual_x, actual_y)
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_type_text_at(
@@ -127,31 +122,17 @@ async def computer_use_type_text_at(
     Returns:
         A screenshot of the screen after typing.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
-    actual_x = denormalize_coordinate(x, session.screen_width)
-    actual_y = denormalize_coordinate(y, session.screen_height)
-
+    backend = await get_browser_backend(exec_context)
+    actual_x = denormalize_coordinate(x, backend.screen_width)
+    actual_y = denormalize_coordinate(y, backend.screen_height)
     logger.info(f"Typing '{text}' at ({actual_x}, {actual_y})")
-
-    # Click to focus
-    await page.mouse.click(actual_x, actual_y)
-
-    # Clear existing text (Ctrl+A + Backspace)
-    await page.keyboard.press("Control+A")
-    await page.keyboard.press("Backspace")
-
-    await page.keyboard.type(text)
-
+    await backend.mouse_click(actual_x, actual_y)
+    await backend.keyboard_press("Control+A")
+    await backend.keyboard_press("Backspace")
+    await backend.keyboard_type(text)
     if press_enter:
-        await page.keyboard.press("Enter")
-
-    # Wait for potential navigations/renders
-    with contextlib.suppress(Exception):
-        await page.wait_for_load_state(timeout=2000)
-
-    return await _take_screenshot_with_url(session, page)
+        await backend.keyboard_press("Enter")
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_scroll_at(
@@ -181,34 +162,24 @@ async def computer_use_scroll_at(
         raise ValueError(
             f"Invalid scroll direction '{direction}'. Must be one of: {valid_directions}"
         )
-
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
-    actual_x = denormalize_coordinate(x, session.screen_width)
-    actual_y = denormalize_coordinate(y, session.screen_height)
-
+    backend = await get_browser_backend(exec_context)
+    actual_x = denormalize_coordinate(x, backend.screen_width)
+    actual_y = denormalize_coordinate(y, backend.screen_height)
     logger.info(f"Scrolling {direction} at ({actual_x}, {actual_y}) by {magnitude}")
-
-    # Calculate delta based on direction
-    delta_x = 0
-    delta_y = 0
-
+    delta_x = 0.0
+    delta_y = 0.0
     if direction == "down":
-        delta_y = magnitude
+        delta_y = float(magnitude)
     elif direction == "up":
-        delta_y = -magnitude
+        delta_y = -float(magnitude)
     elif direction == "right":
-        delta_x = magnitude
+        delta_x = float(magnitude)
     elif direction == "left":
-        delta_x = -magnitude
-
-    await page.mouse.move(actual_x, actual_y)
-    await page.mouse.wheel(delta_x, delta_y)
-
-    await asyncio.sleep(0.5)  # Wait for scroll animation
-
-    return await _take_screenshot_with_url(session, page)
+        delta_x = -float(magnitude)
+    await backend.mouse_move(actual_x, actual_y)
+    await backend.mouse_wheel(delta_x, delta_y)
+    await asyncio.sleep(0.5)
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_open_web_browser(
@@ -222,14 +193,10 @@ async def computer_use_open_web_browser(
     Returns:
         A screenshot of the browser showing Google.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
-    # Navigate to Google as the default starting page
-    # Computer Use API requires a valid HTTP/HTTPS URL
+    backend = await get_browser_backend(exec_context)
     logger.info("Opening web browser (navigating to Google)")
-    await page.goto("https://www.google.com")
-    return await _take_screenshot_with_url(session, page)
+    await backend.goto("https://www.google.com")
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_navigate(
@@ -244,17 +211,12 @@ async def computer_use_navigate(
     Returns:
         A screenshot of the page after navigation.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
+    backend = await get_browser_backend(exec_context)
     logger.info(f"Navigating to {url}")
-
-    # Ensure URL has protocol
     if not url.startswith("http"):
         url = "https://" + url
-
-    await page.goto(url)
-    return await _take_screenshot_with_url(session, page)
+    await backend.goto(url)
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_search(exec_context: ToolExecutionContext) -> ToolResult:
@@ -266,12 +228,10 @@ async def computer_use_search(exec_context: ToolExecutionContext) -> ToolResult:
     Returns:
         A screenshot of the search engine homepage.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
+    backend = await get_browser_backend(exec_context)
     logger.info("Navigating to search engine")
-    await page.goto("https://www.google.com")
-    return await _take_screenshot_with_url(session, page)
+    await backend.goto("https://www.google.com")
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_go_back(exec_context: ToolExecutionContext) -> ToolResult:
@@ -283,12 +243,10 @@ async def computer_use_go_back(exec_context: ToolExecutionContext) -> ToolResult
     Returns:
         A screenshot of the page after navigation.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
+    backend = await get_browser_backend(exec_context)
     logger.info("Going back")
-    await page.go_back()
-    return await _take_screenshot_with_url(session, page)
+    await backend.go_back()
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_go_forward(exec_context: ToolExecutionContext) -> ToolResult:
@@ -300,12 +258,10 @@ async def computer_use_go_forward(exec_context: ToolExecutionContext) -> ToolRes
     Returns:
         A screenshot of the page after navigation.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
+    backend = await get_browser_backend(exec_context)
     logger.info("Going forward")
-    await page.go_forward()
-    return await _take_screenshot_with_url(session, page)
+    await backend.go_forward()
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_key_combination(
@@ -320,12 +276,10 @@ async def computer_use_key_combination(
     Returns:
         A screenshot of the screen after the key press.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
+    backend = await get_browser_backend(exec_context)
     logger.info(f"Pressing keys: {keys}")
-    await page.keyboard.press(keys)
-    return await _take_screenshot_with_url(session, page)
+    await backend.keyboard_press(keys)
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_wait_5_seconds(
@@ -339,12 +293,10 @@ async def computer_use_wait_5_seconds(
     Returns:
         A screenshot of the screen after waiting.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
+    backend = await get_browser_backend(exec_context)
     logger.info("Waiting 5 seconds")
     await asyncio.sleep(5)
-    return await _take_screenshot_with_url(session, page)
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_hover_at(
@@ -360,16 +312,12 @@ async def computer_use_hover_at(
     Returns:
         A screenshot of the screen after hovering.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
-    actual_x = denormalize_coordinate(x, session.screen_width)
-    actual_y = denormalize_coordinate(y, session.screen_height)
-
+    backend = await get_browser_backend(exec_context)
+    actual_x = denormalize_coordinate(x, backend.screen_width)
+    actual_y = denormalize_coordinate(y, backend.screen_height)
     logger.info(f"Hovering at ({actual_x}, {actual_y})")
-    await page.mouse.move(actual_x, actual_y)
-
-    return await _take_screenshot_with_url(session, page)
+    await backend.mouse_move(actual_x, actual_y)
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_drag_and_drop(
@@ -391,24 +339,22 @@ async def computer_use_drag_and_drop(
     Returns:
         A screenshot of the screen after the drag and drop.
     """
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
-    start_x = denormalize_coordinate(x, session.screen_width)
-    start_y = denormalize_coordinate(y, session.screen_height)
-    end_x = denormalize_coordinate(destination_x, session.screen_width)
-    end_y = denormalize_coordinate(destination_y, session.screen_height)
-
+    backend = await get_browser_backend(exec_context)
+    start_x = denormalize_coordinate(x, backend.screen_width)
+    start_y = denormalize_coordinate(y, backend.screen_height)
+    end_x = denormalize_coordinate(destination_x, backend.screen_width)
+    end_y = denormalize_coordinate(destination_y, backend.screen_height)
     logger.info(f"Dragging from ({start_x}, {start_y}) to ({end_x}, {end_y})")
-
-    await page.mouse.move(start_x, start_y)
-    await page.mouse.down()
-    await page.mouse.move(
-        end_x, end_y, steps=10
-    )  # Steps make it more realistic/reliable
-    await page.mouse.up()
-
-    return await _take_screenshot_with_url(session, page)
+    await backend.mouse_move(start_x, start_y)
+    await backend.mouse_down()
+    # Move in steps for realism/reliability
+    step_count = 10
+    for i in range(1, step_count + 1):
+        ix = start_x + (end_x - start_x) * i / step_count
+        iy = start_y + (end_y - start_y) * i / step_count
+        await backend.mouse_move(ix, iy)
+    await backend.mouse_up()
+    return await _take_screenshot_with_url(backend)
 
 
 async def computer_use_scroll_document(
@@ -431,23 +377,17 @@ async def computer_use_scroll_document(
         raise ValueError(
             f"Invalid scroll direction '{direction}'. Must be one of: {valid_directions}"
         )
-
-    session = await get_browser_session(exec_context)
-    page = await session.ensure_page()
-
+    backend = await get_browser_backend(exec_context)
     logger.info(f"Scrolling document {direction}")
-
-    if direction == "down":
-        await page.evaluate("window.scrollBy(0, window.innerHeight)")
-    elif direction == "up":
-        await page.evaluate("window.scrollBy(0, -window.innerHeight)")
-    elif direction == "right":
-        await page.evaluate("window.scrollBy(window.innerWidth, 0)")
-    elif direction == "left":
-        await page.evaluate("window.scrollBy(-window.innerWidth, 0)")
-
+    scroll_js = {
+        "down": "window.scrollBy(0, window.innerHeight)",
+        "up": "window.scrollBy(0, -window.innerHeight)",
+        "right": "window.scrollBy(window.innerWidth, 0)",
+        "left": "window.scrollBy(-window.innerWidth, 0)",
+    }
+    await backend.evaluate(scroll_js[direction])
     await asyncio.sleep(0.5)
-    return await _take_screenshot_with_url(session, page)
+    return await _take_screenshot_with_url(backend)
 
 
 # Tools Definition

--- a/tests/integration/tools/conftest.py
+++ b/tests/integration/tools/conftest.py
@@ -1,0 +1,15 @@
+"""Pytest configuration for browser-server integration tests.
+
+Inserts the sibling browser-server repo into sys.path so that
+``browser_handoff_service`` can be imported from the family-assistant venv.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BROWSER_SERVER_ROOT = Path(__file__).parents[4] / "browser-server"
+if str(_BROWSER_SERVER_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BROWSER_SERVER_ROOT))
+

--- a/tests/integration/tools/conftest.py
+++ b/tests/integration/tools/conftest.py
@@ -1,8 +1,9 @@
 """Pytest configuration for browser-server integration tests.
 
-Inserts the sibling browser-server repo into sys.path so that
+Inserts the sibling browser-server repo into sys.path when present so that
 ``browser_handoff_service`` can be imported from the family-assistant venv.
-If the sibling repo is absent the entire tools integration suite is skipped.
+When the sibling repo is absent the directory is a no-op here; individual
+test modules guard themselves with ``pytest.importorskip``.
 """
 
 from __future__ import annotations
@@ -10,15 +11,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 _BROWSER_SERVER_ROOT = Path(__file__).parents[4] / "browser-server"
 
-if not _BROWSER_SERVER_ROOT.exists():
-    pytest.skip(
-        "browser-server sibling repo not found; skipping browser integration tests",
-        allow_module_level=True,
-    )
-
-if str(_BROWSER_SERVER_ROOT) not in sys.path:
+if _BROWSER_SERVER_ROOT.exists() and str(_BROWSER_SERVER_ROOT) not in sys.path:
     sys.path.insert(0, str(_BROWSER_SERVER_ROOT))
+

--- a/tests/integration/tools/conftest.py
+++ b/tests/integration/tools/conftest.py
@@ -2,6 +2,7 @@
 
 Inserts the sibling browser-server repo into sys.path so that
 ``browser_handoff_service`` can be imported from the family-assistant venv.
+If the sibling repo is absent the entire tools integration suite is skipped.
 """
 
 from __future__ import annotations
@@ -9,7 +10,15 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 _BROWSER_SERVER_ROOT = Path(__file__).parents[4] / "browser-server"
+
+if not _BROWSER_SERVER_ROOT.exists():
+    pytest.skip(
+        "browser-server sibling repo not found; skipping browser integration tests",
+        allow_module_level=True,
+    )
+
 if str(_BROWSER_SERVER_ROOT) not in sys.path:
     sys.path.insert(0, str(_BROWSER_SERVER_ROOT))
-

--- a/tests/integration/tools/test_browser_backend_integration.py
+++ b/tests/integration/tools/test_browser_backend_integration.py
@@ -10,22 +10,23 @@ any imports in this file are resolved.
 
 from __future__ import annotations
 
-import sys
-
 import httpx
 import pytest
-
-# browser_handoff_service is available because conftest.py inserted the sibling
-# browser-server repo into sys.path before this module was imported.
-from browser_handoff_service.main import (
-    app as _browser_server_app,  # type: ignore[import-not-found]  # sibling-repo; added to sys.path in conftest.py
-)
 
 from family_assistant.config_models import BrowserHandoffConfig, RemoteA2AAuthConfig
 from family_assistant.tools.browser_backend import (
     BrowserBackendError,
     RemoteBrowserBackend,
 )
+
+# conftest.py inserts the sibling browser-server repo into sys.path.
+# pytest.importorskip skips this entire module if the import cannot be resolved
+# (e.g. in a checkout without the sibling repo).
+_bhs = pytest.importorskip(
+    "browser_handoff_service.main",
+    reason="browser-server sibling repo not available",
+)
+_browser_server_app = _bhs.app
 
 _SERVICE_TOKEN = "integration-test-token"
 _SERVICE_URL = "http://browser-server.local"
@@ -48,7 +49,9 @@ def _make_backend(*, conversation_id: str = "integ-conv-1") -> RemoteBrowserBack
     cfg = BrowserHandoffConfig(
         enabled=True,
         service_url=_SERVICE_URL,
-        auth=RemoteA2AAuthConfig(type="bearer", token_env="BROWSER_HANDOFF_SERVICE_TOKEN"),
+        auth=RemoteA2AAuthConfig(
+            type="bearer", token_env="BROWSER_HANDOFF_SERVICE_TOKEN"
+        ),
     )
     return RemoteBrowserBackend(
         config=cfg,
@@ -163,7 +166,9 @@ async def test_bearer_token_is_sent_in_every_request() -> None:
     cfg = BrowserHandoffConfig(
         enabled=True,
         service_url=_SERVICE_URL,
-        auth=RemoteA2AAuthConfig(type="bearer", token_env="BROWSER_HANDOFF_SERVICE_TOKEN"),
+        auth=RemoteA2AAuthConfig(
+            type="bearer", token_env="BROWSER_HANDOFF_SERVICE_TOKEN"
+        ),
     )
     backend = RemoteBrowserBackend(
         config=cfg,
@@ -199,7 +204,9 @@ async def test_missing_token_env_raises_browser_backend_error(
     cfg = BrowserHandoffConfig(
         enabled=True,
         service_url=_SERVICE_URL,
-        auth=RemoteA2AAuthConfig(type="bearer", token_env="BROWSER_HANDOFF_SERVICE_TOKEN"),
+        auth=RemoteA2AAuthConfig(
+            type="bearer", token_env="BROWSER_HANDOFF_SERVICE_TOKEN"
+        ),
     )
     backend = RemoteBrowserBackend(
         config=cfg,
@@ -208,10 +215,3 @@ async def test_missing_token_env_raises_browser_backend_error(
     )
     with pytest.raises(BrowserBackendError, match="token env"):
         await backend.goto("https://example.test/")
-
-
-# Guard: if the import above succeeded we know sys.path insertion worked.
-assert "browser_handoff_service" in sys.modules, (
-    "browser_handoff_service not importable — check conftest.py sys.path insertion"
-)
-

--- a/tests/integration/tools/test_browser_backend_integration.py
+++ b/tests/integration/tools/test_browser_backend_integration.py
@@ -1,0 +1,217 @@
+"""Integration test: RemoteBrowserBackend against a real browser-server (fake runtime).
+
+browser-server runs in-process via httpx.ASGITransport with BROWSER_RUNTIME=fake,
+so no Chromium or network is needed.  The test exercises the full HTTP round-trip
+from family-assistant's RemoteBrowserBackend through the browser-server REST API.
+
+The sibling repo is added to sys.path by tests/integration/tools/conftest.py before
+any imports in this file are resolved.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import httpx
+import pytest
+
+# browser_handoff_service is available because conftest.py inserted the sibling
+# browser-server repo into sys.path before this module was imported.
+from browser_handoff_service.main import (
+    app as _browser_server_app,  # type: ignore[import-not-found]  # sibling-repo; added to sys.path in conftest.py
+)
+
+from family_assistant.config_models import BrowserHandoffConfig, RemoteA2AAuthConfig
+from family_assistant.tools.browser_backend import (
+    BrowserBackendError,
+    RemoteBrowserBackend,
+)
+
+_SERVICE_TOKEN = "integration-test-token"
+_SERVICE_URL = "http://browser-server.local"
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BROWSER_RUNTIME", "fake")
+    monkeypatch.setenv("BROWSER_HANDOFF_SERVICE_TOKEN", _SERVICE_TOKEN)
+
+
+def _make_backend(*, conversation_id: str = "integ-conv-1") -> RemoteBrowserBackend:
+    """Return a RemoteBrowserBackend wired to the real browser-server app via ASGITransport."""
+    transport = httpx.ASGITransport(app=_browser_server_app)
+    client = httpx.AsyncClient(
+        transport=transport,
+        base_url=_SERVICE_URL,
+        headers={"Authorization": f"Bearer {_SERVICE_TOKEN}"},
+    )
+    cfg = BrowserHandoffConfig(
+        enabled=True,
+        service_url=_SERVICE_URL,
+        auth=RemoteA2AAuthConfig(type="bearer", token_env="BROWSER_HANDOFF_SERVICE_TOKEN"),
+    )
+    return RemoteBrowserBackend(
+        config=cfg,
+        conversation_id=conversation_id,
+        client=client,
+    )
+
+
+@pytest.mark.integration
+async def test_goto_and_raw_snapshot_return_full_accessibility_tree() -> None:
+    """goto() + raw_snapshot() returns a full accessibility tree, not a stub."""
+    backend = _make_backend(conversation_id="integ-snap")
+    try:
+        await backend.goto("https://example.test/page")
+        snap = await backend.raw_snapshot()
+        # Full tree fields — not the old stub {title, body_text} shape
+        for key in ("url", "title", "forms", "elements", "roots"):
+            assert key in snap, f"missing key {key!r} in snapshot"
+        assert isinstance(snap["roots"], list)
+        assert snap["url"] == "https://example.test/page"
+    finally:
+        await backend.close()
+
+
+@pytest.mark.integration
+async def test_raw_snapshot_is_stable_between_calls() -> None:
+    """Consecutive raw_snapshot() calls return the same element count."""
+    backend = _make_backend(conversation_id="integ-stable")
+    try:
+        await backend.goto("https://example.test/page")
+        snap1 = await backend.raw_snapshot()
+        snap2 = await backend.raw_snapshot()
+        assert snap1.get("elements") == snap2.get("elements")
+    finally:
+        await backend.close()
+
+
+@pytest.mark.integration
+async def test_screenshot_png_returns_valid_png_bytes() -> None:
+    """screenshot_png() returns real PNG bytes, not a redacted stub."""
+    backend = _make_backend(conversation_id="integ-shot")
+    try:
+        await backend.goto("https://example.test/")
+        png_bytes = await backend.screenshot_png()
+        assert isinstance(png_bytes, bytes)
+        assert png_bytes[:8] == b"\x89PNG\r\n\x1a\n", "response is not a valid PNG"
+    finally:
+        await backend.close()
+
+
+@pytest.mark.integration
+async def test_extract_html_returns_string() -> None:
+    """extract_html() returns the page HTML content."""
+    backend = _make_backend(conversation_id="integ-extract")
+    try:
+        await backend.goto("https://example.test/page")
+        html = await backend.extract_html(selector=None)
+        assert isinstance(html, str)
+    finally:
+        await backend.close()
+
+
+@pytest.mark.integration
+async def test_evaluate_returns_serialisable_result() -> None:
+    """evaluate() runs JS in the page V8 context and returns a serialisable result."""
+    backend = _make_backend(conversation_id="integ-eval")
+    try:
+        await backend.goto("https://example.test/page")
+        result = await backend.evaluate("1 + 1")
+        assert result is not None
+    finally:
+        await backend.close()
+
+
+@pytest.mark.integration
+async def test_request_handoff_returns_non_empty_url() -> None:
+    """request_handoff() transitions the session to handoff state and returns a URL."""
+    backend = _make_backend(conversation_id="integ-handoff")
+    try:
+        await backend.goto("https://example.test/checkout")
+        result = await backend.request_handoff(
+            reason="payment",
+            handoff_note="Please complete checkout",
+            expected_origin=None,
+            allowed_resume="never",
+        )
+        assert isinstance(result, dict)
+        # browser-server returns a HandoffResponse with a handoff_url field
+        assert result.get("handoff_url") or result.get("session_id")
+    finally:
+        await backend.close()
+
+
+@pytest.mark.integration
+async def test_bearer_token_is_sent_in_every_request() -> None:
+    """Every outgoing request carries the configured Bearer token."""
+    seen: list[httpx.Request] = []
+
+    class _LoggingTransport(httpx.AsyncBaseTransport):
+        def __init__(self) -> None:
+            self._inner = httpx.ASGITransport(app=_browser_server_app)
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return await self._inner.handle_async_request(request)
+
+    client = httpx.AsyncClient(
+        transport=_LoggingTransport(),
+        base_url=_SERVICE_URL,
+        headers={"Authorization": f"Bearer {_SERVICE_TOKEN}"},
+    )
+    cfg = BrowserHandoffConfig(
+        enabled=True,
+        service_url=_SERVICE_URL,
+        auth=RemoteA2AAuthConfig(type="bearer", token_env="BROWSER_HANDOFF_SERVICE_TOKEN"),
+    )
+    backend = RemoteBrowserBackend(
+        config=cfg,
+        conversation_id="integ-auth-check",
+        client=client,
+    )
+    try:
+        await backend.goto("https://example.test/")
+        await backend.raw_snapshot()
+    finally:
+        await backend.close()
+
+    assert len(seen) >= 2  # at least POST /v1/sessions and POST .../agent-command
+    for req in seen:
+        auth = req.headers.get("authorization", "")
+        assert auth == f"Bearer {_SERVICE_TOKEN}", f"missing/wrong auth on {req.url}"
+
+
+@pytest.mark.integration
+async def test_missing_token_env_raises_browser_backend_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BrowserBackendError is raised immediately when the token env var is not set.
+
+    RemoteBrowserBackend._headers() reads the token from the env var named by
+    auth.token_env.  If that variable is absent it raises BrowserBackendError
+    before making any HTTP request.
+    """
+    monkeypatch.delenv("BROWSER_HANDOFF_SERVICE_TOKEN", raising=False)
+
+    transport = httpx.ASGITransport(app=_browser_server_app)
+    client = httpx.AsyncClient(transport=transport, base_url=_SERVICE_URL)
+    cfg = BrowserHandoffConfig(
+        enabled=True,
+        service_url=_SERVICE_URL,
+        auth=RemoteA2AAuthConfig(type="bearer", token_env="BROWSER_HANDOFF_SERVICE_TOKEN"),
+    )
+    backend = RemoteBrowserBackend(
+        config=cfg,
+        conversation_id="integ-no-token",
+        client=client,
+    )
+    with pytest.raises(BrowserBackendError, match="token env"):
+        await backend.goto("https://example.test/")
+
+
+# Guard: if the import above succeeded we know sys.path insertion worked.
+assert "browser_handoff_service" in sys.modules, (
+    "browser_handoff_service not importable — check conftest.py sys.path insertion"
+)
+

--- a/tests/unit/tools/test_browser_backend.py
+++ b/tests/unit/tools/test_browser_backend.py
@@ -167,7 +167,7 @@ def _exec_context(*, enabled: bool, profile_id: str | None) -> ToolExecutionCont
         processing_profile_id=profile_id,
         conversation_id="conv_select",
     )
-    return cast("ToolExecutionContext", ctx)
+    return cast("ToolExecutionContext", cast("object", ctx))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_browser_backend.py
+++ b/tests/unit/tools/test_browser_backend.py
@@ -1,0 +1,204 @@
+"""Unit tests for the browser backend selection and the remote browser-server client.
+
+The local Playwright backend is exercised by ``tests/functional/tools/test_browser_dom.py``;
+here we cover backend selection (local vs remote) and the ``RemoteBrowserBackend`` HTTP
+mapping against a mocked ``browser-server``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import httpx
+import pytest
+
+from family_assistant.config_models import BrowserHandoffConfig, RemoteA2AAuthConfig
+from family_assistant.tools.browser_backend import (
+    HandoffUnavailableError,
+    LocalPlaywrightBackend,
+    RemoteBrowserBackend,
+    get_browser_backend,
+)
+
+if TYPE_CHECKING:
+    from family_assistant.tools.types import ToolExecutionContext
+
+
+@pytest.fixture(autouse=True)
+def _service_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BROWSER_HANDOFF_SERVICE_TOKEN", "test-token")
+
+
+_PNG_1X1 = base64.b64encode(
+    base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )
+).decode("ascii")
+
+
+def _make_mock_browser_server() -> tuple[httpx.AsyncClient, list[httpx.Request]]:
+    """Return an httpx client wired to a fake browser-server plus a request log."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        path = request.url.path
+        if path == "/v1/sessions":
+            return httpx.Response(
+                200, json={"session_id": "bs_test", "state": "agent_active"}
+            )
+        if path.endswith("/agent-command"):
+            body = json.loads(request.content)
+            ctype = body["type"]
+            result: dict[str, object]
+            if ctype == "navigate":
+                result = {"url": body["args"]["url"], "title": "Fixture"}
+            elif ctype == "snapshot":
+                result = {
+                    "url": "https://example.test/page",
+                    "title": "Fixture",
+                    "forms": 1,
+                    "elements": 1,
+                    "roots": [{"ref": "e1", "role": "heading", "name": "Welcome"}],
+                }
+            elif ctype == "screenshot":
+                result = {"mime_type": "image/png", "image_base64": _PNG_1X1}
+            elif ctype == "extract":
+                result = {
+                    "url": "https://example.test/page",
+                    "html": "<h1>Welcome</h1>",
+                }
+            elif ctype == "exec":
+                result = {"result": "Fixture", "url": "https://example.test/page"}
+            else:
+                result = {
+                    "accepted": True,
+                    "url": "https://example.test/page",
+                    "title": "Fixture",
+                }
+            return httpx.Response(
+                200, json={"command_id": "cmd_1", "ok": True, "result": result}
+            )
+        if path.endswith("/handoff"):
+            return httpx.Response(
+                200,
+                json={
+                    "session_id": "bs_test",
+                    "state": "handoff_requested",
+                    "handoff_url": "https://browser.example/sessions/bs_test?token=abc",
+                    "expires_at": "2026-05-29T00:00:00Z",
+                },
+            )
+        if path.endswith("/close"):
+            return httpx.Response(200, json={"state": "cancelled"})
+        return httpx.Response(404, json={"detail": "not found"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler), timeout=5.0)
+    return client, seen
+
+
+def _config(enabled: bool = True) -> BrowserHandoffConfig:
+    return BrowserHandoffConfig(
+        enabled=enabled,
+        service_url="http://browser-server.test:8000",
+        auth=RemoteA2AAuthConfig(
+            type="bearer", token_env="BROWSER_HANDOFF_SERVICE_TOKEN"
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_backend_snapshot_and_refs() -> None:
+    client, seen = _make_mock_browser_server()
+    backend = RemoteBrowserBackend(_config(), "conv_1", client=client)
+    await backend.goto("https://example.test/page")
+    snapshot = await backend.raw_snapshot()
+    assert snapshot["title"] == "Fixture"
+    assert snapshot["roots"][0]["ref"] == "e1"
+    assert backend.current_url == "https://example.test/page"
+    # A session is created once and reused for subsequent commands.
+    assert sum(1 for r in seen if r.url.path == "/v1/sessions") == 1
+    await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_backend_screenshot_decodes_png() -> None:
+    client, _ = _make_mock_browser_server()
+    backend = RemoteBrowserBackend(_config(), "conv_shot", client=client)
+    png = await backend.screenshot_png()
+    assert png[:8] == b"\x89PNG\r\n\x1a\n"
+    await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_backend_sends_bearer_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BROWSER_HANDOFF_SERVICE_TOKEN", "s3cret")
+    client, seen = _make_mock_browser_server()
+    backend = RemoteBrowserBackend(_config(), "conv_auth", client=client)
+    await backend.goto("https://example.test/page")
+    assert seen[0].headers["authorization"] == "Bearer s3cret"
+    await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_backend_request_handoff_returns_url() -> None:
+    client, _ = _make_mock_browser_server()
+    backend = RemoteBrowserBackend(_config(), "conv_handoff", client=client)
+    result = await backend.request_handoff(
+        reason="payment",
+        handoff_note="pay",
+        expected_origin=None,
+        allowed_resume="never",
+    )
+    assert result["handoff_url"].endswith("token=abc")
+    await backend.close()
+
+
+def _exec_context(*, enabled: bool, profile_id: str | None) -> ToolExecutionContext:
+    app_config = SimpleNamespace(browser_handoff_config=_config(enabled=enabled))
+    service = SimpleNamespace(app_config=app_config)
+    ctx = SimpleNamespace(
+        processing_service=service,
+        processing_profile_id=profile_id,
+        conversation_id="conv_select",
+    )
+    return cast("ToolExecutionContext", ctx)
+
+
+@pytest.mark.asyncio
+async def test_get_browser_backend_uses_remote_for_handoff_profile() -> None:
+    ctx = _exec_context(enabled=True, profile_id="browser_profile")
+    backend = await get_browser_backend(ctx)
+    assert isinstance(backend, RemoteBrowserBackend)
+    await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_get_browser_backend_local_when_disabled() -> None:
+    ctx = _exec_context(enabled=False, profile_id="browser_profile")
+    backend = await get_browser_backend(ctx)
+    assert isinstance(backend, LocalPlaywrightBackend)
+
+
+@pytest.mark.asyncio
+async def test_get_browser_backend_local_for_non_handoff_profile() -> None:
+    ctx = _exec_context(enabled=True, profile_id="default_assistant")
+    backend = await get_browser_backend(ctx)
+    assert isinstance(backend, LocalPlaywrightBackend)
+
+
+@pytest.mark.asyncio
+async def test_local_backend_handoff_is_unavailable() -> None:
+    backend = LocalPlaywrightBackend.__new__(LocalPlaywrightBackend)
+    with pytest.raises(HandoffUnavailableError):
+        await backend.request_handoff(
+            reason="payment",
+            handoff_note="",
+            expected_origin=None,
+            allowed_resume="never",
+        )

--- a/tests/unit/tools/test_browser_dom.py
+++ b/tests/unit/tools/test_browser_dom.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 import pytest
 import toons
 
+from family_assistant.tools.browser_backend import (
+    LocalPlaywrightBackend,
+    _coerce_load_state,  # noqa: PLC2701  # Testing private load-state narrowing helper
+)
 from family_assistant.tools.browser_dom import (
     Snapshot,
     SnapshotNode,
     _any_match,  # noqa: PLC2701  # Testing private query matcher used by renderer
-    _coerce_load_state,  # noqa: PLC2701  # Testing private load-state narrowing helper
     _collect_refs,  # noqa: PLC2701  # Testing private ref-tree walker
     _format_toon,  # noqa: PLC2701  # Testing private TOON renderer
     _resolve_ref,  # noqa: PLC2701  # Testing private ref-cache lookup
@@ -175,16 +178,16 @@ class TestResolveRef:
     """Ref resolution against the session cache."""
 
     def test_returns_selector_when_ref_is_known(self) -> None:
-        session = BrowserSession()
-        session.ref_cache["e7"] = '[data-fa-ref="e7"]'
-        assert _resolve_ref(session, "e7") == '[data-fa-ref="e7"]'
+        backend = LocalPlaywrightBackend(BrowserSession())
+        backend.ref_cache["e7"] = '[data-fa-ref="e7"]'
+        assert _resolve_ref(backend, "e7") == '[data-fa-ref="e7"]'
 
     def test_raises_valueerror_with_known_refs_listed(self) -> None:
-        session = BrowserSession()
-        session.ref_cache["e1"] = '[data-fa-ref="e1"]'
-        session.ref_cache["e2"] = '[data-fa-ref="e2"]'
+        backend = LocalPlaywrightBackend(BrowserSession())
+        backend.ref_cache["e1"] = '[data-fa-ref="e1"]'
+        backend.ref_cache["e2"] = '[data-fa-ref="e2"]'
         with pytest.raises(ValueError, match="Unknown ref 'e99'") as exc:
-            _resolve_ref(session, "e99")
+            _resolve_ref(backend, "e99")
         assert "e1" in str(exc.value)
 
 


### PR DESCRIPTION
## Summary

Implements Milestones 3 & 4 of the browser-server integration design (`docs/design/browser-server-integration.md`): a pluggable `BrowserBackend` protocol that lets **all** browser tools — both DOM navigation and Computer Use (visual) — run against either a local headless Playwright instance (default, unchanged) or the remote `browser-server` service (optional, config-gated).

### What changed

- **`BrowserHandoffConfig`** added to `AppConfig` (off by default). Three env-var overrides: `BROWSER_HANDOFF_ENABLED`, `BROWSER_HANDOFF_URL`, `BROWSER_HANDOFF_TIMEOUT`.
- **`browser_backend.py`** (new): `BrowserBackend` protocol, `LocalPlaywrightBackend` (wraps the existing `BrowserSession`), `RemoteBrowserBackend` (httpx client for browser-server's `/v1/sessions/*` API). Factory `get_browser_backend()` / `close_browser_backend()` select the backend per conversation based on config. The `BrowserBackend` protocol includes both DOM methods (`snapshot`, `screenshot`, `navigate`, `click`, `fill`, `evaluate`, `extract`) and Computer Use methods (`mouse_click`, `mouse_move`, `mouse_down`, `mouse_up`, `mouse_wheel`, `keyboard_type`, `keyboard_press`, `go_back`, `go_forward`, `screen_width`, `screen_height`).
- **`browser_dom.py`** refactored: all tools call `get_browser_backend(exec_context)` instead of `get_browser_session()`.
- **`computer_use.py`** refactored: all 13 Computer Use tools call `get_browser_backend(exec_context)` instead of `get_browser_session()`. Screenshot, mouse, keyboard, scroll, and drag-and-drop all route through the backend abstraction. This means Computer Use tools share the same remote browser session as DOM tools — tab state (URL, cookies, form fills) is shared across profile delegation.
- **`browser_request_handoff`** tool added; available only in `handoff_capable_profiles`.
- **`defaults.yaml`**: `browser_handoff_config` section (all off), both `browser_profile` and `browser_visual_profile` listed in `handoff_capable_profiles`, `browser_profile` prompt updated to mention handoff.
- **`docs/design/browser-server-integration.md`**: full design doc.
- **`docs/user/browser_automation.md`**: "Handing the browser to a human" section.
- **Tests**:
  - `tests/unit/tools/test_browser_backend.py`: unit tests with `httpx.MockTransport`
  - `tests/integration/tools/test_browser_backend_integration.py`: integration tests against a real browser-server in-process (`httpx.ASGITransport`, `BROWSER_RUNTIME=fake`). Covers snapshot shape, PNG bytes, extract/eval/handoff round-trips, bearer auth, missing-token error.

### Design decisions

- **Shared session across profiles**: both `browser_profile` (DOM) and `browser_visual_profile` (Computer Use) resolve to the same `RemoteBrowserBackend` instance keyed by `conversation_id`, so a visual tool delegation picks up exactly where the DOM session left off (same tab, URL, cookies, form state).
- **No NetworkPolicy** added to kube-config — namespaces are not default-deny; adding policies would break existing traffic.
- The `RemoteBrowserBackend` injection seam (`client: httpx.AsyncClient | None = None`) makes both unit and integration tests possible without a real network.

## Test plan

- [ ] `poe test` passes (all existing tests unaffected)
- [ ] `pytest tests/unit/tools/test_browser_backend.py -xq` passes
- [ ] `pytest tests/integration/tools/ -m integration -xq` passes (no Chromium needed)
- [ ] With `browser_handoff_config.enabled: false` (default), browser tools behave identically to before this PR
- [ ] With `browser_handoff_config.enabled: true` and a running browser-server, all DOM and Computer Use tools route to the remote backend sharing the same session

---
_Generated by [Claude Code](https://claude.ai/code/session_017NnPbFYYKhttZ5TZn4deCQ)_