### PR TITLE
[codex] Add Kata Podman worker profile

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1496,6 +1496,7 @@ ai_worker_config:
     runtime_class: "gvisor"
     job_ttl_seconds: 3600
     enable_rootless_podman: false
+    enable_kata_podman: false
   docker:
     image: "ghcr.io/werdnum/ai-coding-base:latest"
     network: "bridge"

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -803,6 +803,7 @@ class KubernetesBackendConfig(BaseModel):
     run_as_group: int | None = 1000
     fs_group: int | None = 1000
     enable_rootless_podman: bool = False
+    enable_kata_podman: bool = False
 
     # Additional volumes and volume mounts to attach to worker pods
     extra_volumes: list[k8s_models.Volume] | None = None

--- a/src/family_assistant/services/backends/kubernetes.py
+++ b/src/family_assistant/services/backends/kubernetes.py
@@ -23,6 +23,7 @@ from kubernetes_asyncio.client import (
     CoreV1Api,
     V1Capabilities,
     V1Container,
+    V1EmptyDirVolumeSource,
     V1EnvFromSource,
     V1EnvVar,
     V1Job,
@@ -53,6 +54,21 @@ logger = logging.getLogger(__name__)
 
 # Default max turns for the AI agent
 DEFAULT_MAX_TURNS = 50
+
+KATA_PODMAN_CAPABILITIES = [
+    "CHOWN",
+    "DAC_OVERRIDE",
+    "FOWNER",
+    "FSETID",
+    "SETGID",
+    "SETUID",
+    "SETFCAP",
+    "SETPCAP",
+    "MKNOD",
+    "SYS_ADMIN",
+    "SYS_CHROOT",
+    "NET_RAW",
+]
 
 
 @dataclass
@@ -206,6 +222,17 @@ class KubernetesBackend:
 
     def _worker_container_security_context(self) -> V1SecurityContext:
         """Build the worker container security context."""
+        if self._config.enable_kata_podman:
+            return V1SecurityContext(
+                allow_privilege_escalation=True,
+                capabilities=V1Capabilities(
+                    add=KATA_PODMAN_CAPABILITIES,
+                    drop=["ALL"],
+                ),
+                read_only_root_filesystem=False,
+                seccomp_profile=V1SeccompProfile(type="Unconfined"),
+            )
+
         if self._config.enable_rootless_podman:
             return V1SecurityContext(
                 allow_privilege_escalation=True,
@@ -221,6 +248,23 @@ class KubernetesBackend:
             allow_privilege_escalation=False,
             capabilities=V1Capabilities(drop=["ALL"]),
             read_only_root_filesystem=False,
+        )
+
+    def _worker_pod_security_context(self) -> V1PodSecurityContext:
+        """Build the worker pod security context."""
+        if self._config.enable_kata_podman:
+            return V1PodSecurityContext(
+                run_as_non_root=False,
+                run_as_user=0,
+                run_as_group=0,
+                fs_group=self._config.fs_group,
+            )
+
+        return V1PodSecurityContext(
+            run_as_non_root=self._config.run_as_user is not None,
+            run_as_user=self._config.run_as_user,
+            run_as_group=self._config.run_as_group,
+            fs_group=self._config.fs_group,
         )
 
     async def _ensure_config_loaded(self) -> None:
@@ -370,6 +414,28 @@ class KubernetesBackend:
             )
         ]
 
+        if self._config.enable_kata_podman:
+            volume_mounts.extend([
+                V1VolumeMount(
+                    name="podman-varlib",
+                    mount_path="/var/lib/containers",
+                ),
+                V1VolumeMount(
+                    name="podman-run",
+                    mount_path="/run/containers",
+                ),
+            ])
+            volumes.extend([
+                V1Volume(
+                    name="podman-varlib",
+                    empty_dir=V1EmptyDirVolumeSource(),
+                ),
+                V1Volume(
+                    name="podman-run",
+                    empty_dir=V1EmptyDirVolumeSource(),
+                ),
+            ])
+
         if model == "claude" and self._config.claude_config_volume:
             vol = self._config.claude_config_volume
             volume_mounts.append(
@@ -442,12 +508,7 @@ class KubernetesBackend:
                         restart_policy="Never",
                         service_account_name=self.service_account,
                         runtime_class_name=self.runtime_class,
-                        security_context=V1PodSecurityContext(
-                            run_as_non_root=self._config.run_as_user is not None,
-                            run_as_user=self._config.run_as_user,
-                            run_as_group=self._config.run_as_group,
-                            fs_group=self._config.fs_group,
-                        ),
+                        security_context=self._worker_pod_security_context(),
                         containers=[
                             V1Container(
                                 name="worker",

--- a/tests/unit/services/backends/test_kubernetes_backend.py
+++ b/tests/unit/services/backends/test_kubernetes_backend.py
@@ -10,6 +10,7 @@ import pytest
 
 from family_assistant.config_models import KubernetesBackendConfig
 from family_assistant.services.backends.kubernetes import (
+    KATA_PODMAN_CAPABILITIES,
     KubernetesBackend,
     KubernetesTask,
 )
@@ -303,6 +304,51 @@ class TestKubernetesBackendBuildJobManifest:
         assert container_security.capabilities.add == ["SETUID", "SETGID"]
         assert container_security.capabilities.drop == ["ALL"]
         assert container_security.seccomp_profile.type == "Unconfined"
+
+    def test_build_manifest_kata_podman_profile(self) -> None:
+        """Test Kata Podman support is explicitly opt-in."""
+        config = KubernetesBackendConfig(
+            namespace="test-namespace",
+            ai_coder_image="test-image:latest",
+            service_account="test-sa",
+            enable_kata_podman=True,
+            run_as_user=1001,
+            run_as_group=1001,
+            fs_group=1001,
+        )
+        custom_backend = KubernetesBackend(config=config)
+        custom_backend._config_loaded = True
+
+        manifest = custom_backend._build_job_manifest(
+            job_name="ai-worker-task-123",
+            task_id="task-123",
+            prompt_path="tasks/task-123/prompt.md",
+            output_dir="tasks/task-123/output",
+            webhook_url="http://localhost:8000/webhook/event",
+            model="claude",
+            timeout_minutes=30,
+        )
+
+        pod_spec = manifest.spec.template.spec
+        pod_security = pod_spec.security_context
+        assert pod_security.run_as_non_root is False
+        assert pod_security.run_as_user == 0
+        assert pod_security.run_as_group == 0
+        assert pod_security.fs_group == 1001
+
+        container_security = pod_spec.containers[0].security_context
+        assert container_security.allow_privilege_escalation is True
+        assert container_security.capabilities.add == KATA_PODMAN_CAPABILITIES
+        assert container_security.capabilities.drop == ["ALL"]
+        assert container_security.seccomp_profile.type == "Unconfined"
+
+        volume_mounts = {v.name: v for v in pod_spec.containers[0].volume_mounts}
+        assert volume_mounts["podman-varlib"].mount_path == "/var/lib/containers"
+        assert volume_mounts["podman-run"].mount_path == "/run/containers"
+
+        volumes = {v.name: v for v in pod_spec.volumes}
+        assert volumes["podman-varlib"].empty_dir is not None
+        assert volumes["podman-run"].empty_dir is not None
 
     def test_build_manifest_custom_uid_gid(self) -> None:
         """Test job manifest uses custom uid/gid from config."""


### PR DESCRIPTION
## Summary

- add an opt-in `enable_kata_podman` worker profile for ai-worker jobs
- run the worker pod as root inside the Kata VM only when that profile is enabled
- add the Podman storage mounts and security context needed for `podman run` and `podman build`
- keep the default worker profile and existing `enable_rootless_podman` behavior unchanged

## Validation

- `git diff --check`
- `uvx ruff check --preview --ignore=E501 src/family_assistant/config_models.py src/family_assistant/services/backends/kubernetes.py tests/unit/services/backends/test_kubernetes_backend.py`
- `uvx ruff format --check --preview src/family_assistant/config_models.py src/family_assistant/services/backends/kubernetes.py tests/unit/services/backends/test_kubernetes_backend.py`
- `python3 -m py_compile src/family_assistant/config_models.py src/family_assistant/services/backends/kubernetes.py tests/unit/services/backends/test_kubernetes_backend.py`

`uv run pytest tests/unit/services/backends/test_kubernetes_backend.py` could not run locally because the checkout venv does not have `pytest`; `uvx pytest tests/unit/services/backends/test_kubernetes_backend.py` then failed at test collection because `tests/conftest.py` imports missing `caldav`.

A live ml-bot smoke Job using the equivalent Kata Podman profile completed successfully with plain `podman run`, `podman build`, and running the locally built image.