### PR TITLE
Recover the browser backend from expired sessions automatically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -451,5 +451,5 @@ explicit = true
 [tool.uv.sources]
 torch = { index = "torch-cpu" }
 telegram-bot-api-mock = { git = "https://github.com/werdnum/telegram-bot-api-mock" }
-browser-handoff-service = { git = "https://github.com/werdnum/browser-server.git" }
+browser-handoff-service = { git = "https://github.com/werdnum/browser-server.git", branch = "claude/browser-server-lease-expiry-uu3AY" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -451,5 +451,5 @@ explicit = true
 [tool.uv.sources]
 torch = { index = "torch-cpu" }
 telegram-bot-api-mock = { git = "https://github.com/werdnum/telegram-bot-api-mock" }
-browser-handoff-service = { git = "https://github.com/werdnum/browser-server.git", branch = "claude/browser-server-lease-expiry-uu3AY" }
+browser-handoff-service = { git = "https://github.com/werdnum/browser-server.git" }
 

--- a/src/family_assistant/tools/browser_backend.py
+++ b/src/family_assistant/tools/browser_backend.py
@@ -536,6 +536,18 @@ class RemoteBrowserBackend:
         detail = payload.get("detail")
         return isinstance(detail, str) and "unknown session" in detail.lower()
 
+    def _is_session_gone_response(self, resp: httpx.Response) -> bool:
+        """True when the cached session can no longer be used and must be replaced.
+
+        Covers two server signals: 404 ``unknown session`` (the server forgot the
+        session, e.g. after eviction or a restart) and 410 ``Gone`` (the session
+        existed but expired or reached a terminal state). Both mean "start a new
+        session"; a 403 deliberately does *not* match, because that signals the
+        agent does not own the lease (e.g. a human handoff is in progress) and must
+        not be papered over by silently opening a fresh session.
+        """
+        return resp.status_code == 410 or self._is_unknown_session_response(resp)
+
     def _session_lost_error(self, action: str, session_id: str) -> BrowserBackendError:
         self._clear_remote_session(session_id)
         return BrowserBackendError(
@@ -554,7 +566,7 @@ class RemoteBrowserBackend:
             headers=self._headers(),
             json={"type": command_type, "args": args or {}},
         )
-        if self._is_unknown_session_response(resp):
+        if self._is_session_gone_response(resp):
             if command_type != "navigate":
                 raise self._session_lost_error(f"command {command_type}", session_id)
             self._clear_remote_session(session_id)
@@ -686,7 +698,7 @@ class RemoteBrowserBackend:
             headers=self._headers(),
             json=payload,
         )
-        if self._is_unknown_session_response(resp):
+        if self._is_session_gone_response(resp):
             raise self._session_lost_error("handoff", session_id)
         self._raise_for_status(resp, "handoff")
         return resp.json()

--- a/tests/integration/tools/test_browser_backend_integration.py
+++ b/tests/integration/tools/test_browser_backend_integration.py
@@ -7,12 +7,14 @@ network service is needed while still exercising the browser-server REST API.
 
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import httpx
 import pytest
 from browser_handoff_service.main import app as browser_server_app
 from browser_handoff_service.main import registry as browser_server_registry
+from browser_handoff_service.models import TERMINAL_STATES, now_utc
 
 from family_assistant.config_models import BrowserHandoffConfig, RemoteA2AAuthConfig
 from family_assistant.tools.browser_backend import (
@@ -251,6 +253,76 @@ async def test_unknown_session_handoff_fails_instead_of_handing_off_fresh_sessio
             for session in browser_server_registry.list_sessions()
             if session.conversation_id == conversation_id
         ] == []
+    finally:
+        await backend.close()
+
+
+async def _expire_session(session_id: str) -> None:
+    """Drive a live session to the EXPIRED terminal state, as the reaper would."""
+    browser_server_registry.sessions[session_id].idle_expires_at = (
+        now_utc() - timedelta(seconds=1)
+    )
+    await browser_server_registry.reap_expired()
+
+
+def _live_session_id_for_conversation(conversation_id: str) -> str:
+    """The single non-terminal session for a conversation.
+
+    Unlike server eviction, an expired session lingers in the registry in the
+    EXPIRED terminal state, so a recovered conversation has both the dead and the
+    fresh session; the recovered backend points at the live one.
+    """
+    matches = [
+        session.session_id
+        for session in browser_server_registry.list_sessions()
+        if session.conversation_id == conversation_id
+        and session.state not in TERMINAL_STATES
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+@pytest.mark.integration
+async def test_expired_session_recreates_session_and_retries_navigation() -> None:
+    """An expired (terminal) session is recovered transparently on browser_open."""
+    conversation_id = "integ-expired-nav"
+    backend = _make_backend(conversation_id=conversation_id)
+    try:
+        await backend.goto("https://example.test/before-expiry")
+        stale_session_id = _live_session_id_for_conversation(conversation_id)
+        await _expire_session(stale_session_id)
+
+        await backend.goto("https://example.test/after-expiry")
+
+        recovered_session_id = _live_session_id_for_conversation(conversation_id)
+        assert recovered_session_id != stale_session_id
+        assert backend.current_url == "https://example.test/after-expiry"
+    finally:
+        await backend.close()
+
+
+@pytest.mark.integration
+async def test_expired_session_command_prompts_browser_open() -> None:
+    """A non-navigation command on an expired session fails clearly and clears it.
+
+    The agent should be told to start over with browser_open rather than be
+    wedged on a dead session (the bug that previously needed a pod restart).
+    """
+    conversation_id = "integ-expired-cmd"
+    backend = _make_backend(conversation_id=conversation_id)
+    try:
+        await backend.goto("https://example.test/checkout")
+        stale_session_id = _live_session_id_for_conversation(conversation_id)
+        await _expire_session(stale_session_id)
+
+        with pytest.raises(BrowserBackendError, match="browser_open"):
+            await backend.raw_snapshot()
+
+        # The dead session is cleared, so a fresh browser_open succeeds without
+        # any manual lease release or pod restart.
+        await backend.goto("https://example.test/restarted")
+        recovered_session_id = _live_session_id_for_conversation(conversation_id)
+        assert recovered_session_id != stale_session_id
     finally:
         await backend.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -1160,7 +1160,7 @@ wheels = [
 [[package]]
 name = "browser-handoff-service"
 version = "0.1.0"
-source = { git = "https://github.com/werdnum/browser-server.git?branch=claude%2Fbrowser-server-lease-expiry-uu3AY#2c12868b3b4188f80e5b279497c820bb8ef7b7e7" }
+source = { git = "https://github.com/werdnum/browser-server.git#668d2157954028b91ba4701b473a2aa22501c864" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
@@ -1868,7 +1868,7 @@ requires-dist = [
     { name = "backoff", specifier = ">=2.2.1" },
     { name = "basedpyright", marker = "extra == 'dev'" },
     { name = "bcrypt", specifier = ">=4.0.0,<5.0.0" },
-    { name = "browser-handoff-service", marker = "extra == 'dev'", git = "https://github.com/werdnum/browser-server.git?branch=claude%2Fbrowser-server-lease-expiry-uu3AY" },
+    { name = "browser-handoff-service", marker = "extra == 'dev'", git = "https://github.com/werdnum/browser-server.git" },
     { name = "caldav", specifier = ">=1.2.0" },
     { name = "cloudcoil-models-kubernetes", specifier = ">=1.32" },
     { name = "dkimpy", specifier = ">=1.1.8" },

--- a/uv.lock
+++ b/uv.lock
@@ -1160,7 +1160,7 @@ wheels = [
 [[package]]
 name = "browser-handoff-service"
 version = "0.1.0"
-source = { git = "https://github.com/werdnum/browser-server.git#09bef388d8563e3267b1d32e823e53ca52d2d54e" }
+source = { git = "https://github.com/werdnum/browser-server.git?branch=claude%2Fbrowser-server-lease-expiry-uu3AY#2c12868b3b4188f80e5b279497c820bb8ef7b7e7" }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
@@ -1868,7 +1868,7 @@ requires-dist = [
     { name = "backoff", specifier = ">=2.2.1" },
     { name = "basedpyright", marker = "extra == 'dev'" },
     { name = "bcrypt", specifier = ">=4.0.0,<5.0.0" },
-    { name = "browser-handoff-service", marker = "extra == 'dev'", git = "https://github.com/werdnum/browser-server.git" },
+    { name = "browser-handoff-service", marker = "extra == 'dev'", git = "https://github.com/werdnum/browser-server.git?branch=claude%2Fbrowser-server-lease-expiry-uu3AY" },
     { name = "caldav", specifier = ">=1.2.0" },
     { name = "cloudcoil-models-kubernetes", specifier = ">=1.32" },
     { name = "dkimpy", specifier = ">=1.1.8" },


### PR DESCRIPTION
## Problem

When a browser-server session hit its idle/absolute expiry, the server reaped it into the `EXPIRED` terminal state and answered agent-commands with 403. The remote backend (`RemoteBrowserBackend`) caches one session id per conversation and only recognised `404 "unknown session"` as a lost session, so it stayed wedged on the dead session id — returning 403 on every call until the process restarted. This is the failure that looked like a "stale lease" needing a manual pod restart.

## Fix

browser-server now reports an expired/terminal session as **410 Gone**, distinct from the **403** it still returns when a human owns the lease (werdnum/browser-server#20, merged).

- Add `_is_session_gone_response`, which matches 410 **and** the existing 404 unknown-session signal.
- `_command` and `request_handoff` use it: `browser_open`/navigate transparently starts a fresh session; other commands clear the dead session and tell the agent to start over with `browser_open`.
- A **403 is deliberately not recovered from**, so an in-progress human handoff is never silently replaced by a fresh agent session.

## Tests

Added two integration tests against the real browser-server ASGI app:
- `test_expired_session_recreates_session_and_retries_navigation` — `browser_open` after expiry transparently recovers.
- `test_expired_session_command_prompts_browser_open` — a non-navigation command on an expired session fails clearly, clears the dead session, and a subsequent `browser_open` succeeds.

All 43 browser tests pass; ruff/format/basedpyright/pylint/ast-grep conformance all green.

## Dependency

The `browser-handoff-service` dev dependency is locked to the browser-server `main` commit that contains the 410 fix (werdnum/browser-server#20 is merged), so the integration tests exercise the 410 path end-to-end. No further coordination needed — this PR is safe to merge on its own.

https://claude.ai/code/session_01PtRVcqJeTVUXgs5ZDVYMog