### PR TITLE
Add Streamable HTTP transport support for remote MCP servers

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -124,6 +124,10 @@
 
 # --- MCP (Model Context Protocol) Servers ---
 # Configure external MCP servers. These override the defaults in defaults.yaml.
+# Supported transports: "stdio" (default, local process), "sse" (remote
+# Server-Sent Events), and "streamable_http" (remote Streamable HTTP; aliases
+# "streamablehttp"/"http"). Remote transports accept an optional Bearer `token`
+# (use "$ENV_VAR" to read it from the environment).
 # mcp_config:
 #   mcpServers:
 #     custom_server:
@@ -131,3 +135,11 @@
 #       args: ["path/to/server.py"]
 #       env:
 #         API_KEY: "$CUSTOM_API_KEY"
+#     remote_sse_server:
+#       transport: "sse"
+#       url: "https://example.com/sse"
+#       token: "$MY_MCP_TOKEN"
+#     remote_http_server:
+#       transport: "streamable_http"
+#       url: "https://example.com/mcp"
+#       token: "$MY_MCP_TOKEN"

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -181,6 +181,25 @@ indexing_pipeline_config:
 # --- MCP (Model Context Protocol) Servers ---
 # Configuration for external MCP servers that provide additional tools.
 # Operator-specific servers (e.g. Home Assistant) should be added in config.yaml.
+#
+# Three transports are supported:
+#   - stdio (default): spawn a local process via `command`/`args`/`env`.
+#   - sse: connect to a remote Server-Sent Events endpoint via `url`.
+#   - streamable_http: connect to a remote Streamable HTTP endpoint via `url`
+#     (aliases: "streamablehttp", "http").
+# Remote transports (sse, streamable_http) accept an optional `token` for a
+# Bearer Authorization header. Use "$ENV_VAR" to read the token from the
+# environment, e.g. token: "$MY_MCP_TOKEN".
+#
+# Example remote servers:
+#   remote_sse:
+#     transport: "sse"
+#     url: "https://example.com/sse"
+#     token: "$MY_MCP_TOKEN"
+#   remote_http:
+#     transport: "streamable_http"
+#     url: "https://example.com/mcp"
+#     token: "$MY_MCP_TOKEN"
 mcp_config:
   mcpServers:
     time:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,10 @@ dependencies = [
     # HTML templating
     "python-multipart",
     # Required by FastAPI for form data
-    "mcp>=1.6.0",
-    # Model Context Protocol SDK
+    "mcp>=1.8.0",
+    # Model Context Protocol SDK. Floor is 1.8.0: the Streamable HTTP client
+    # transport (mcp.client.streamable_http) was introduced in that release and
+    # is imported unconditionally by family_assistant.tools.mcp.
     "caldav>=1.2.0",
     # CalDAV client library
     "vobject>=0.9.6",

--- a/src/family_assistant/tools/mcp.py
+++ b/src/family_assistant/tools/mcp.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from mcp import ClientSession
 from mcp import ClientSession, StdioServerParameters, stdio_client
 from mcp.client.sse import sse_client  # Assuming sse_client is in mcp.client.sse
+from mcp.client.streamable_http import streamablehttp_client
 from mcp.types import TextContent  # Import TextContent from mcp.types
 
 from family_assistant.tools.metadata import (
@@ -38,6 +39,15 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Transport type aliases for the Streamable HTTP transport. The MCP spec calls
+# this "Streamable HTTP"; we accept several spellings so operators can use
+# whichever they're familiar with (Claude Code uses "http").
+MCP_STREAMABLE_HTTP_TRANSPORTS = frozenset({
+    "streamable_http",
+    "streamablehttp",
+    "http",
+})
 
 # MCP Server Status Constants
 MCP_SERVER_STATUS_PENDING = "pending"
@@ -334,9 +344,16 @@ class MCPToolsProvider:
 
                 self._connection_contexts[server_id] = exit_stack
 
-            elif transport_type == "sse":
+            elif (
+                transport_type == "sse"
+                or transport_type in MCP_STREAMABLE_HTTP_TRANSPORTS
+            ):
+                is_streamable_http = transport_type in MCP_STREAMABLE_HTTP_TRANSPORTS
+                transport_label = "streamable_http" if is_streamable_http else "sse"
                 if not url:
-                    logger.error(f"MCP server '{server_id}' (sse): 'url' is missing.")
+                    logger.error(
+                        f"MCP server '{server_id}' ({transport_label}): 'url' is missing."
+                    )
                     self._server_statuses[server_id] = MCP_SERVER_STATUS_FAILED
                     with contextlib.suppress(Exception):
                         await exit_stack.aclose()
@@ -347,17 +364,30 @@ class MCPToolsProvider:
                 if resolved_token_sse:
                     headers["Authorization"] = f"Bearer {resolved_token_sse}"
                     logger.debug(
-                        f"Using Authorization header for SSE server '{server_id}'."
+                        f"Using Authorization header for {transport_label} server '{server_id}'."
                     )
                 else:
                     logger.warning(
-                        f"No token resolved for SSE server '{server_id}'. Connecting without Authorization header."
+                        f"No token resolved for {transport_label} server '{server_id}'. "
+                        "Connecting without Authorization header."
                     )
                     # Add other potential header mappings here if needed
 
-                read_stream, write_stream = await exit_stack.enter_async_context(
-                    sse_client(url=url, headers=headers)
-                )
+                if is_streamable_http:
+                    # streamablehttp_client yields a 3-tuple; the third element is a
+                    # callback for retrieving the negotiated session id, which we
+                    # don't need here.
+                    (
+                        read_stream,
+                        write_stream,
+                        _get_session_id,
+                    ) = await exit_stack.enter_async_context(
+                        streamablehttp_client(url=url, headers=headers)
+                    )
+                else:
+                    read_stream, write_stream = await exit_stack.enter_async_context(
+                        sse_client(url=url, headers=headers)
+                    )
 
                 session = await exit_stack.enter_async_context(
                     ClientSession(read_stream, write_stream)

--- a/src/family_assistant/tools/types.py
+++ b/src/family_assistant/tools/types.py
@@ -56,6 +56,19 @@ class MCPServerSSEConfig(TypedDict):
     tool_metadata: NotRequired[dict[str, list[str]]]
 
 
+class MCPServerStreamableHTTPConfig(TypedDict):
+    """Configuration for a Streamable HTTP-based MCP server.
+
+    The ``transport`` field accepts ``"streamable_http"`` (canonical) as well as
+    the ``"streamablehttp"`` and ``"http"`` aliases.
+    """
+
+    transport: Literal["streamable_http", "streamablehttp", "http"]
+    url: str
+    token: NotRequired[str | None]
+    tool_metadata: NotRequired[dict[str, list[str]]]
+
+
 class MCPServerGenericConfig(TypedDict, total=False):
     """Generic configuration for MCP servers, used when transport is not explicitly specified."""
 
@@ -69,7 +82,12 @@ class MCPServerGenericConfig(TypedDict, total=False):
 
 
 # Use a Union to represent the allowed MCP server configurations.
-MCPServerConfig = MCPServerStdIOConfig | MCPServerSSEConfig | MCPServerGenericConfig
+MCPServerConfig = (
+    MCPServerStdIOConfig
+    | MCPServerSSEConfig
+    | MCPServerStreamableHTTPConfig
+    | MCPServerGenericConfig
+)
 
 
 # Tool Definition Types

--- a/tests/functional/integration/test_mcp_integration.py
+++ b/tests/functional/integration/test_mcp_integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os  # Added os import
@@ -40,6 +41,7 @@ from family_assistant.tools import (
     LocalToolsProvider,
     MCPToolsProvider,
 )
+from family_assistant.tools.types import ToolExecutionContext
 from tests.helpers import find_free_port, require_executable, wait_for_server
 from tests.mocks.mock_llm import (
     LLMOutput,  # Use LLMOutput from mocks for rules
@@ -68,16 +70,18 @@ MCP_TIME_TOOL_NAME = (
 )
 
 
-# --- Fixture to manage mcp-proxy subprocess for SSE tests ---
-@pytest_asyncio.fixture(scope="function")  # Use pytest_asyncio.fixture
-async def mcp_proxy_server() -> AsyncGenerator[str]:
-    """
-    Starts mcp-proxy listening for SSE and forwarding to mcp-server-time via stdio.
-    Yields the SSE URL.
+# --- Fixtures to manage mcp-proxy subprocess for remote-transport tests ---
+@contextlib.asynccontextmanager
+async def _run_mcp_proxy() -> AsyncGenerator[str]:
+    """Start mcp-proxy forwarding to mcp-server-time and yield its base URL.
+
+    mcp-proxy exposes both an SSE endpoint (``/sse``) and a Streamable HTTP
+    endpoint (``/mcp/``) on the same port, so the caller can derive whichever
+    endpoint URL it needs from the yielded base URL.
     """
     host = "127.0.0.1"
     port = find_free_port()
-    sse_url = f"http://{host}:{port}/sse"
+    base_url = f"http://{host}:{port}"
     mcp_proxy_command = require_executable("mcp-proxy")
     mcp_server_time_command = require_executable("mcp-server-time")
     command = [
@@ -98,7 +102,7 @@ async def mcp_proxy_server() -> AsyncGenerator[str]:
 
     # Wait for the server to be ready
     try:
-        await wait_for_server(sse_url, timeout=30.0)
+        await wait_for_server(f"{base_url}/sse", timeout=30.0)
     except RuntimeError as e:
         # If server didn't start, capture any stderr output
         stderr_output = ""
@@ -116,39 +120,61 @@ async def mcp_proxy_server() -> AsyncGenerator[str]:
             f"Failed to start MCP proxy: {e}\nstderr: {stderr_output}"
         ) from e
 
-    yield sse_url  # Provide the SSE URL to the test
+    try:
+        yield base_url  # Provide the base URL to the caller
+    finally:
+        logger.info("Stopping MCP proxy server...")
+        if process.returncode is None:  # Check if process is still running
+            try:
+                # Terminate the process group first
+                # Ensure process.pid is available; it should be after creation
+                if process.pid is not None:
+                    os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+                # Also send SIGINT to the main process, as mcp-proxy might trap it
+                process.send_signal(signal.SIGINT)
+                await asyncio.wait_for(process.wait(), timeout=5)
+            except (ProcessLookupError, PermissionError) as e:
+                logger.warning(
+                    f"Error sending SIGTERM/SIGINT to process group or process: {e}"
+                )
+            except TimeoutError:
+                logger.warning(
+                    "MCP proxy did not terminate after SIGINT/SIGTERM, sending SIGKILL."
+                )
+                if process.returncode is None:  # Check again before kill
+                    try:
+                        process.kill()
+                        await asyncio.wait_for(process.wait(), timeout=5)
+                    except TimeoutError:
+                        logger.error("MCP proxy did not terminate after SIGKILL.")
+                    except Exception as e:
+                        logger.error(f"Error during SIGKILL: {e}")
+        else:
+            logger.info(
+                f"MCP proxy server already terminated with code {process.returncode}."
+            )
+        logger.info("MCP proxy server stopped.")
 
-    logger.info("Stopping MCP proxy server...")
-    if process.returncode is None:  # Check if process is still running
-        try:
-            # Terminate the process group first
-            # Ensure process.pid is available; it should be after creation
-            if process.pid is not None:
-                os.killpg(os.getpgid(process.pid), signal.SIGTERM)
-            # Also send SIGINT to the main process, as mcp-proxy might trap it
-            process.send_signal(signal.SIGINT)
-            await asyncio.wait_for(process.wait(), timeout=5)
-        except (ProcessLookupError, PermissionError) as e:
-            logger.warning(
-                f"Error sending SIGTERM/SIGINT to process group or process: {e}"
-            )
-        except TimeoutError:
-            logger.warning(
-                "MCP proxy did not terminate after SIGINT/SIGTERM, sending SIGKILL."
-            )
-            if process.returncode is None:  # Check again before kill
-                try:
-                    process.kill()
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except TimeoutError:
-                    logger.error("MCP proxy did not terminate after SIGKILL.")
-                except Exception as e:
-                    logger.error(f"Error during SIGKILL: {e}")
-    else:
-        logger.info(
-            f"MCP proxy server already terminated with code {process.returncode}."
-        )
-    logger.info("MCP proxy server stopped.")
+
+@pytest_asyncio.fixture(scope="function")  # Use pytest_asyncio.fixture
+async def mcp_proxy_server() -> AsyncGenerator[str]:
+    """
+    Starts mcp-proxy listening for SSE and forwarding to mcp-server-time via stdio.
+    Yields the SSE URL.
+    """
+    async with _run_mcp_proxy() as base_url:
+        yield f"{base_url}/sse"  # Provide the SSE URL to the test
+
+
+@pytest_asyncio.fixture(scope="function")  # Use pytest_asyncio.fixture
+async def mcp_proxy_streamable_http_server() -> AsyncGenerator[str]:
+    """
+    Starts mcp-proxy listening for Streamable HTTP and forwarding to
+    mcp-server-time via stdio. Yields the Streamable HTTP URL.
+    """
+    async with _run_mcp_proxy() as base_url:
+        # mcp-proxy serves the Streamable HTTP endpoint at /mcp/ (trailing slash).
+        yield f"{base_url}/mcp/"  # Provide the Streamable HTTP URL to the test
 
 
 @pytest.mark.asyncio
@@ -549,3 +575,72 @@ async def test_mcp_time_conversion_sse(
         f"Verified MCP tool '{MCP_TIME_TOOL_NAME}' was called via SSE and final response contained expected fragment."
     )
     await processing_service.tools_provider.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["streamable_http", "streamablehttp", "http"])
+async def test_mcp_time_conversion_streamable_http(
+    mcp_proxy_streamable_http_server: str, transport: str
+) -> None:
+    """
+    Tests connecting to an MCP server over the Streamable HTTP transport and
+    executing a tool end-to-end via mcp-proxy (which forwards to
+    mcp-server-time over stdio).
+
+    Parametrized over all accepted spellings of the transport name
+    ("streamable_http", "streamablehttp", "http") to confirm each alias
+    resolves to the Streamable HTTP transport.
+    """
+    mcp_config: dict[str, MCPServerConfig] = {
+        "time_http": {
+            "transport": transport,
+            "url": mcp_proxy_streamable_http_server,
+        }
+    }
+    mcp_provider = MCPToolsProvider(mcp_server_configs=mcp_config)
+    await mcp_provider.initialize()
+
+    try:
+        # The Streamable HTTP server should advertise the convert_time tool.
+        definitions = await mcp_provider.get_tool_definitions()
+        tool_names = [d.get("function", {}).get("name") for d in definitions]
+        assert MCP_TIME_TOOL_NAME in tool_names, (
+            f"Expected tool '{MCP_TIME_TOOL_NAME}' to be discovered over "
+            f"Streamable HTTP (transport={transport}). Found: {tool_names}"
+        )
+
+        context = ToolExecutionContext(
+            interface_type="test",
+            conversation_id=str(TEST_CHAT_ID),
+            user_name=TEST_USER_NAME,
+            turn_id="turn-http",
+            db_context=MagicMock(),
+            processing_service=None,
+            clock=None,
+            home_assistant_client=None,
+            event_sources=None,
+            attachment_registry=None,
+            camera_backend=None,
+            timezone=ZoneInfo("UTC"),
+        )
+        result = await mcp_provider.execute_tool(
+            MCP_TIME_TOOL_NAME,
+            {
+                "time": SOURCE_TIME,
+                "source_timezone": SOURCE_TZ,
+                "target_timezone": TARGET_TZ,
+            },
+            context,
+        )
+
+        assert EXPECTED_CONVERTED_TIME_FRAGMENT in result, (
+            f"Streamable HTTP tool result did not contain the expected converted "
+            f"time. Got: '{result}' Expected fragment: "
+            f"'{EXPECTED_CONVERTED_TIME_FRAGMENT}'"
+        )
+        logger.info(
+            f"Verified MCP tool '{MCP_TIME_TOOL_NAME}' executed via Streamable HTTP "
+            f"transport (transport={transport})."
+        )
+    finally:
+        await mcp_provider.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1899,7 +1899,7 @@ requires-dist = [
     { name = "markdown-it-py", specifier = ">=3.0.0" },
     { name = "markdownify", specifier = ">=1.1.0" },
     { name = "markitdown", extras = ["all"], specifier = ">=0.1.1" },
-    { name = "mcp", specifier = ">=1.6.0" },
+    { name = "mcp", specifier = ">=1.8.0" },
     { name = "mcp-proxy", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "mcp-server-time", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "mdformat", marker = "extra == 'dev'", specifier = ">=0.7.17" },


### PR DESCRIPTION
## Summary
This PR adds support for the Streamable HTTP transport to the MCP (Model Context Protocol) integration, enabling connections to remote MCP servers via HTTP endpoints in addition to the existing SSE (Server-Sent Events) transport.

## Key Changes

- **New transport type**: Added `MCPServerStreamableHTTPConfig` TypedDict in `types.py` to define configuration for Streamable HTTP-based MCP servers, with support for three transport name aliases (`"streamable_http"`, `"streamablehttp"`, `"http"`)

- **MCP client integration**: Updated `mcp.py` to:
  - Import `streamablehttp_client` from the MCP library
  - Define `MCP_STREAMABLE_HTTP_TRANSPORTS` frozenset for transport name aliases
  - Extend connection logic to handle Streamable HTTP transport alongside SSE, properly unpacking the 3-tuple response from `streamablehttp_client`

- **Configuration documentation**: Enhanced `defaults.yaml` and `config.yaml.example` with:
  - Clear explanation of the three supported transports (stdio, sse, streamable_http)
  - Documentation of the optional Bearer token support for remote transports
  - Example configurations for both SSE and Streamable HTTP remote servers

- **Test coverage**: Added comprehensive test in `test_mcp_integration.py`:
  - Refactored `mcp_proxy_server` fixture to use a new `_run_mcp_proxy()` async context manager that yields a base URL
  - Created new `mcp_proxy_streamable_http_server` fixture for Streamable HTTP endpoint testing
  - Added `test_mcp_time_conversion_streamable_http()` parametrized test covering all three transport name aliases to verify end-to-end tool execution over Streamable HTTP

## Implementation Details

- The Streamable HTTP client returns a 3-tuple `(read_stream, write_stream, get_session_id)`, whereas SSE returns a 2-tuple. The implementation correctly handles both cases.
- Transport name aliases allow operators to use whichever spelling they're familiar with (e.g., Claude Code uses `"http"`).
- Remote transports (both SSE and Streamable HTTP) support optional Bearer token authentication via environment variable substitution.
- The refactored fixture infrastructure allows both SSE and Streamable HTTP endpoints to be served from the same mcp-proxy instance on different paths (`/sse` and `/mcp/`).

https://claude.ai/code/session_01Mt9Hg75RfzteX8E5WNNSeR