### PR TITLE
Add iOS APNs device token storage and config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,27 @@ python scripts/generate_vapid_keys.py
 # VAPID_PUBLIC_KEY=<url-safe-base64-no-padding>
 ```
 
+### Environment Variables for iOS Push Notifications (APNs)
+
+Native iOS push notifications are delivered through Apple Push Notification service (APNs) using
+provider-token authentication with a `.p8` auth key. The APNs sender is enabled only when
+`APNS_TEAM_ID`, `APNS_KEY_ID`, `APNS_BUNDLE_ID` and a private key are all configured. All of these
+map to the `apns` config section.
+
+- **`APNS_TEAM_ID`** - Apple Developer Team ID, used as the JWT `iss` claim.
+- **`APNS_KEY_ID`** - APNs auth key id, used as the JWT `kid` header.
+- **`APNS_AUTH_KEY`** - Contents of the `.p8` private key (PEM). Treated as a secret and redacted
+  from logged config.
+- **`APNS_AUTH_KEY_PATH`** - Path to a `.p8` file (alternative to `APNS_AUTH_KEY`).
+- **`APNS_BUNDLE_ID`** - The app bundle id, sent as the `apns-topic` header.
+- **`APNS_USE_SANDBOX`** - Default APNs environment (`true` for sandbox) when a registered token
+  does not specify one. Each device token also carries its own `environment`, and a
+  sandbox/production mismatch (`BadDeviceToken`) is auto-corrected on the next send.
+
+Clients register device tokens via `POST /api/ios/push-tokens` and unregister via
+`DELETE /api/ios/push-tokens/{device_token}` (both authenticated). See
+[docs/design/ios_push_notifications.md](docs/design/ios_push_notifications.md) for the full design.
+
 ### Environment Variables for Email Intake
 
 The following environment variable can be used instead of hardcoding the value in `config.yaml`:

--- a/alembic/versions/2026_06_06-add_ios_push_tokens_table.py
+++ b/alembic/versions/2026_06_06-add_ios_push_tokens_table.py
@@ -1,0 +1,70 @@
+"""Add ios_push_tokens table
+
+Revision ID: add_ios_push_tokens
+Revises: backfill_email_attachment_ids
+Create Date: 2026-06-06 00:00:00.000000+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_ios_push_tokens"
+down_revision: str | None = "backfill_email_attachment_ids"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "ios_push_tokens",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("device_token", sa.String(length=255), nullable=False),
+        sa.Column("user_identifier", sa.String(length=255), nullable=False),
+        sa.Column(
+            "environment",
+            sa.String(length=20),
+            server_default="production",
+            nullable=False,
+        ),
+        sa.Column("bundle_id", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("device_token"),
+    )
+    op.create_index(
+        op.f("ix_ios_push_tokens_device_token"),
+        "ios_push_tokens",
+        ["device_token"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_ios_push_tokens_user_identifier"),
+        "ios_push_tokens",
+        ["user_identifier"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        op.f("ix_ios_push_tokens_user_identifier"),
+        table_name="ios_push_tokens",
+    )
+    op.drop_index(
+        op.f("ix_ios_push_tokens_device_token"),
+        table_name="ios_push_tokens",
+    )
+    op.drop_table("ios_push_tokens")

--- a/alembic/versions/2026_06_06-add_ios_push_tokens_table.py
+++ b/alembic/versions/2026_06_06-add_ios_push_tokens_table.py
@@ -37,7 +37,7 @@ def upgrade() -> None:
             "created_at",
             sa.DateTime(timezone=True),
             nullable=False,
-            server_default=sa.text("now()"),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
         ),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
         sa.PrimaryKeyConstraint("id"),

--- a/alembic/versions/2026_06_06-add_ios_push_tokens_table.py
+++ b/alembic/versions/2026_06_06-add_ios_push_tokens_table.py
@@ -41,13 +41,12 @@ def upgrade() -> None:
         ),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("device_token"),
     )
     op.create_index(
         op.f("ix_ios_push_tokens_device_token"),
         "ios_push_tokens",
         ["device_token"],
-        unique=False,
+        unique=True,
     )
     op.create_index(
         op.f("ix_ios_push_tokens_user_identifier"),

--- a/docs/design/ios_push_notifications.md
+++ b/docs/design/ios_push_notifications.md
@@ -1,0 +1,103 @@
+# iOS Push Notifications (APNs) — Server Side
+
+## Overview
+
+Family Assistant already supports browser Web Push (PWA) notifications via VAPID. This document
+describes the server-side integration for **native iOS push notifications** delivered through Apple
+Push Notification service (APNs).
+
+The two channels are unified behind a single `NotificationDispatcher` so callers send one logical
+notification that fans out to every channel a user is subscribed to (Web Push and/or iOS).
+
+## Components
+
+### Storage: `ios_push_tokens`
+
+A new table stores APNs device tokens registered by authenticated clients.
+
+| Column            | Type        | Notes                                           |
+| ----------------- | ----------- | ----------------------------------------------- |
+| `id`              | Integer PK  |                                                 |
+| `device_token`    | String(255) | Hex APNs device token, globally unique          |
+| `user_identifier` | String(255) | Canonical user id (indexed)                     |
+| `environment`     | String(20)  | `production` or `sandbox` (APNs host selection) |
+| `bundle_id`       | String(255) | Optional app bundle id reported by the client   |
+| `created_at`      | DateTime    | server default `now()`                          |
+| `updated_at`      | DateTime    | refreshed on re-registration                    |
+
+A device token is unique to a device/app install, so registration is an **upsert** keyed on
+`device_token`: re-registering moves the token to the current user and refreshes `environment` and
+`bundle_id`.
+
+### APNs sender: `APNsService`
+
+- Authenticates with an Apple `.p8` APNs auth key using **provider token (JWT)** auth.
+- Signs ES256 JWTs with the configured **Team ID** (`iss`) and **Key ID** (`kid` header). Tokens are
+  cached and refreshed well within Apple's 20–60 minute validity window.
+- Sends HTTP/2 requests to APNs (`api.push.apple.com` for production, `api.sandbox.push.apple.com`
+  for sandbox) using `httpx` with `http2=True`.
+- Sets `apns-topic` to the app bundle id and `apns-push-type: alert`.
+- Payload is a standard alert: `{"aps": {"alert": {"title", "body"}, "sound": "default"}}`.
+
+#### Error handling
+
+- **`410` / reason `Unregistered` / `ExpiredToken`** → delete the stored token.
+- **`400` reason `BadDeviceToken`** → likely a sandbox/production mismatch. Retry once against the
+  other APNs environment; on success, persist the corrected `environment`. If both fail, log and
+  delete the token.
+- **`403` reason `ExpiredProviderToken` / `InvalidProviderToken`** → invalidate the cached JWT and
+  retry once.
+- All non-success responses log the APNs `reason` for debugging.
+
+### `NotificationDispatcher`
+
+A thin facade holding the optional Web Push service and optional APNs service. It exposes the same
+interface used today (`enabled`, `send_notification(user_identifier, title, body, db_context)`) so
+it slots directly into the existing `WebChatInterface` wiring and the new send points. It fans out
+to both channels concurrently and isolates per-channel failures.
+
+## Endpoints
+
+Both require authentication (`get_current_user`), matching the existing Web Push endpoints.
+
+- `POST /api/ios/push-tokens` — register/refresh a device token. Body:
+  `{ "device_token": str, "environment": "production"|"sandbox", "bundle_id": str | null }`.
+- `DELETE /api/ios/push-tokens/{device_token}` — unregister a device token for the current user.
+
+## Send points
+
+A notification is dispatched at four points. For points that only carry a conversation context, the
+owning user is resolved from the most recent user message in that conversation (the same approach
+`WebChatInterface` already uses), extracted into a shared `resolve_conversation_user()` helper.
+
+1. **Assistant reply saved to a web conversation** — existing `WebChatInterface.send_message`, now
+   driven by the dispatcher.
+2. **Pending confirmation created** — `ConfirmationService.create_request` notifies the
+   `target_user_id` (already a canonical user id).
+3. **Automation / task failure** — `TaskWorker` notifies the conversation owner when a task is
+   marked failed after exhausting retries.
+4. **Worker task complete** — the worker completion webhook notifies the conversation owner when a
+   spawned worker finishes.
+
+## Configuration
+
+`apns` config section (all optional; service is disabled unless fully configured):
+
+| Field           | Env var              | Notes                                |
+| --------------- | -------------------- | ------------------------------------ |
+| `team_id`       | `APNS_TEAM_ID`       | Apple Developer Team ID (JWT `iss`)  |
+| `key_id`        | `APNS_KEY_ID`        | APNs auth key id (JWT `kid`)         |
+| `auth_key`      | `APNS_AUTH_KEY`      | `.p8` private key PEM contents       |
+| `auth_key_path` | `APNS_AUTH_KEY_PATH` | Path to a `.p8` file (alternative)   |
+| `bundle_id`     | `APNS_BUNDLE_ID`     | App bundle id used as `apns-topic`   |
+| `use_sandbox`   | `APNS_USE_SANDBOX`   | Default environment when unspecified |
+
+`auth_key` (and any loaded `.p8` contents) are treated as secrets and redacted from logged config.
+
+## Testing strategy
+
+- Storage and config: real test database + config loader round-trips.
+- `APNsService`: an injected `httpx` client backed by `httpx.MockTransport` simulates APNs
+  responses, allowing deterministic tests of success, `Unregistered` deletion, sandbox/production
+  retry, and JWT refresh without contacting Apple.
+- Endpoints: functional tests through the FastAPI app, mirroring `test_push_api.py`.

--- a/docs/design/ios_push_notifications.md
+++ b/docs/design/ios_push_notifications.md
@@ -74,8 +74,25 @@ was sent. It is the public seam exercised by tests.
 Both require authentication (`get_current_user`), matching the existing Web Push endpoints.
 
 - `POST /api/ios/push-tokens` — register/refresh a device token. Body:
-  `{ "device_token": str, "environment": "production"|"sandbox", "bundle_id": str | null }`.
-- `DELETE /api/ios/push-tokens/{device_token}` — unregister a device token for the current user.
+  `{ "token": str, "environment": "production"|"sandbox", "bundle_id": str | null }`. The payload
+  key is `token`, matching the iOS client.
+- `DELETE /api/ios/push-tokens/{token}` — unregister a device token for the current user.
+
+## Interactive notifications
+
+Notifications carry optional `NotificationMetadata` (`category`, `request_id`, `conversation_id`,
+`path`, `url`) so interactive clients can attach action buttons and deep-link:
+
+- For APNs, `category` becomes `aps.category` (driving the iOS client's registered actions) and the
+  remaining fields are sent as top-level custom `userInfo` keys.
+- For Web Push, the metadata is delivered under `data`.
+
+Send points set:
+
+- **Confirmations** → `category=FAMILY_ASSISTANT_CONFIRMATION` + `request_id` (so the approve/deny
+  actions can resolve the request).
+- **Messages, task failures, worker completions** → `category=FAMILY_ASSISTANT_MESSAGE` +
+  `conversation_id` (so a tap deep-links to the conversation).
 
 ## Send points
 

--- a/docs/design/ios_push_notifications.md
+++ b/docs/design/ios_push_notifications.md
@@ -49,12 +49,23 @@ A device token is unique to a device/app install, so registration is an **upsert
   retry once.
 - All non-success responses log the APNs `reason` for debugging.
 
-### `NotificationDispatcher`
+### `Notifier` protocol and `NotificationDispatcher`
 
-A thin facade holding the optional Web Push service and optional APNs service. It exposes the same
-interface used today (`enabled`, `send_notification(user_identifier, title, body, db_context)`) so
-it slots directly into the existing `WebChatInterface` wiring and the new send points. It fans out
-to both channels concurrently and isolates per-channel failures.
+All notification channels implement an explicit `Notifier` protocol (`enabled` +
+`send_notification(user_identifier, title, body, db_context)`): the Web Push service, the APNs
+service, and the `NotificationDispatcher`. Consumers (`WebChatInterface`, `ConfirmationService`,
+`TaskWorker`, the worker webhook) depend on `Notifier` rather than a concrete service, so delivery
+is a type-checked contract rather than structural duck typing.
+
+`NotificationDispatcher` is a thin facade holding the optional Web Push and APNs services. It fans
+out to every enabled channel concurrently and isolates per-channel failures. In production it is the
+`Notifier` injected at every send point; the bare services are injected directly only in narrower
+contexts.
+
+The shared
+`notify_conversation(notifier, db_context, *, interface_type, conversation_id, title, body)` helper
+resolves the owning user from conversation history and dispatches, returning whether a notification
+was sent. It is the public seam exercised by tests.
 
 ## Endpoints
 

--- a/docs/design/ios_push_notifications.md
+++ b/docs/design/ios_push_notifications.md
@@ -43,8 +43,10 @@ A device token is unique to a device/app install, so registration is an **upsert
 
 - **`410` / reason `Unregistered` / `ExpiredToken`** → delete the stored token.
 - **`400` reason `BadDeviceToken`** → likely a sandbox/production mismatch. Retry once against the
-  other APNs environment; on success, persist the corrected `environment`. If both fail, log and
-  delete the token.
+  other APNs environment; on success, persist the corrected `environment`. The token is only deleted
+  if the retry is *also* conclusively invalid (`BadDeviceToken`/`Unregistered`/410); a transient
+  retry failure (5xx, 429, provider-token error, local `httpx` error) leaves the token in place for
+  the next send.
 - **`403` reason `ExpiredProviderToken` / `InvalidProviderToken`** → invalidate the cached JWT and
   retry once.
 - All non-success responses log the APNs `reason` for debugging.

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -542,6 +542,16 @@ various tasks with dark mode support and mobile optimization.
     ![Automations Page](../../screenshots/desktop/automations.png) *The Automations page for
     managing event and schedule-based automations*
 
+- **Push Notifications:** The assistant can notify you even when the app isn't open.
+
+  - **Browser (PWA):** Install the web app to your device and allow notifications to receive browser
+    push notifications.
+  - **iOS app:** The native iOS app registers for Apple push notifications, so you get alerts
+    delivered through the system.
+  - **When you're notified:** a new assistant reply arrives in a web conversation, a confirmation is
+    waiting for your approval, a background task fails after retrying, or a spawned worker task
+    finishes. Notifications are sent to every device you've registered.
+
 ## 8. Tips for Best Results
 
 - **Be Clear:** The more specific your request, the better the assistant can understand and help.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,8 @@ dependencies = [
     "authheaders>=0.16.3",
     "pyspf>=2.0.14",
     "dnspython>=2.8.0",
+    "h2>=4.3.0",
+    "pyjwt[crypto]>=2.10.1",
 ]
 
 [project.optional-dependencies]

--- a/src/family_assistant/assistant.py
+++ b/src/family_assistant/assistant.py
@@ -427,10 +427,9 @@ class Assistant:
             apns=self.apns_service,
         )
 
-        # The dispatcher is API-compatible with the individual push services and is stored under
-        # the same app.state key so existing consumers (e.g. WebChatInterface) fan out to every
-        # configured channel.
-        self.fastapi_app.state.push_notification_service = self.notification_dispatcher
+        self.fastapi_app.state.push_notification_service = (
+            self.push_notification_service
+        )
         self.fastapi_app.state.notification_dispatcher = self.notification_dispatcher
         logger.info(
             "Notifications initialized (web_push=%s, apns=%s)",
@@ -570,7 +569,7 @@ class Assistant:
         assert database_engine is not None
         self.confirmation_service = ConfirmationService(
             db_context_factory=lambda: get_db_context(database_engine),
-            notification_dispatcher=self.notification_dispatcher,
+            notifier=self.notification_dispatcher,
         )
         self.confirmation_result_waiters = ConfirmationResultWaiterRegistry()
         self.fastapi_app.state.confirmation_service = self.confirmation_service

--- a/src/family_assistant/assistant.py
+++ b/src/family_assistant/assistant.py
@@ -64,7 +64,7 @@ from family_assistant.processing import (
     ProcessingService,
     ProcessingServiceConfig,
 )
-from family_assistant.services.apns import APNsService
+from family_assistant.services.apns import APNsService, load_apns_auth_key
 from family_assistant.services.confirmation_service import (
     CONFIRMATION_TOOL_EXECUTION_TASK_TYPE,
     ConfirmationService,
@@ -402,18 +402,10 @@ class Assistant:
         )
 
         apns_conf = self.config.apns
-        apns_auth_key = apns_conf.auth_key
-        if not apns_auth_key and apns_conf.auth_key_path:
-            try:
-                apns_auth_key = Path(apns_conf.auth_key_path).read_text(
-                    encoding="utf-8"
-                )
-            except OSError as e:
-                logger.error(
-                    "Could not read APNs auth key from %s: %s",
-                    apns_conf.auth_key_path,
-                    e,
-                )
+        apns_auth_key = load_apns_auth_key(
+            auth_key=apns_conf.auth_key,
+            auth_key_path=apns_conf.auth_key_path,
+        )
         self.apns_service = APNsService(
             team_id=apns_conf.team_id,
             key_id=apns_conf.key_id,

--- a/src/family_assistant/assistant.py
+++ b/src/family_assistant/assistant.py
@@ -64,6 +64,7 @@ from family_assistant.processing import (
     ProcessingService,
     ProcessingServiceConfig,
 )
+from family_assistant.services.apns import APNsService
 from family_assistant.services.confirmation_service import (
     CONFIRMATION_TOOL_EXECUTION_TASK_TYPE,
     ConfirmationService,
@@ -71,6 +72,7 @@ from family_assistant.services.confirmation_service import (
 from family_assistant.services.confirmation_waiters import (
     ConfirmationResultWaiterRegistry,
 )
+from family_assistant.services.notification_dispatcher import NotificationDispatcher
 from family_assistant.services.push_notification import PushNotificationService
 from family_assistant.services.user_identity import UserIdentityResolver
 from family_assistant.services.worker_backend import get_worker_backend
@@ -282,6 +284,8 @@ class Assistant:
         self.notes_indexer: NotesIndexer | None = None
         self.telegram_service: TelegramService | None = None
         self.push_notification_service: PushNotificationService | None = None
+        self.apns_service: APNsService | None = None
+        self.notification_dispatcher: NotificationDispatcher | None = None
         self.confirmation_service: ConfirmationService | None = None
         self.confirmation_result_waiters: ConfirmationResultWaiterRegistry | None = None
         self.task_worker_instance: TaskWorker | None = None
@@ -388,6 +392,51 @@ class Assistant:
                 logger.debug("Playwright browsers already installed")
         except Exception as e:  # noqa: BLE001
             logger.warning(f"Could not check/install Playwright browsers: {e}")
+
+    def _setup_notifications(self) -> None:
+        """Initialize Web Push and iOS APNs services and the fan-out dispatcher."""
+        assert self.fastapi_app is not None
+        self.push_notification_service = PushNotificationService(
+            vapid_private_key=self.config.pwa_config.vapid_private_key,
+            vapid_contact_email=self.config.pwa_config.vapid_contact_email,
+        )
+
+        apns_conf = self.config.apns
+        apns_auth_key = apns_conf.auth_key
+        if not apns_auth_key and apns_conf.auth_key_path:
+            try:
+                apns_auth_key = Path(apns_conf.auth_key_path).read_text(
+                    encoding="utf-8"
+                )
+            except OSError as e:
+                logger.error(
+                    "Could not read APNs auth key from %s: %s",
+                    apns_conf.auth_key_path,
+                    e,
+                )
+        self.apns_service = APNsService(
+            team_id=apns_conf.team_id,
+            key_id=apns_conf.key_id,
+            auth_key=apns_auth_key,
+            bundle_id=apns_conf.bundle_id,
+            use_sandbox=apns_conf.use_sandbox,
+        )
+
+        self.notification_dispatcher = NotificationDispatcher(
+            web_push=self.push_notification_service,
+            apns=self.apns_service,
+        )
+
+        # The dispatcher is API-compatible with the individual push services and is stored under
+        # the same app.state key so existing consumers (e.g. WebChatInterface) fan out to every
+        # configured channel.
+        self.fastapi_app.state.push_notification_service = self.notification_dispatcher
+        self.fastapi_app.state.notification_dispatcher = self.notification_dispatcher
+        logger.info(
+            "Notifications initialized (web_push=%s, apns=%s)",
+            self.push_notification_service.enabled,
+            self.apns_service.enabled,
+        )
 
     async def setup_dependencies(self) -> None:
         """Initializes and wires up all core application components."""
@@ -512,10 +561,16 @@ class Assistant:
         # Store engine in FastAPI app state for web dependencies
         self.fastapi_app.state.database_engine = self.database_engine
 
+        # Initialize notification channels (Web Push + iOS APNs) and the dispatcher that fans
+        # out to all configured channels. Built before the confirmation service so it can be
+        # injected as a dependency.
+        self._setup_notifications()
+
         database_engine = self.database_engine
         assert database_engine is not None
         self.confirmation_service = ConfirmationService(
-            db_context_factory=lambda: get_db_context(database_engine)
+            db_context_factory=lambda: get_db_context(database_engine),
+            notification_dispatcher=self.notification_dispatcher,
         )
         self.confirmation_result_waiters = ConfirmationResultWaiterRegistry()
         self.fastapi_app.state.confirmation_service = self.confirmation_service
@@ -585,23 +640,6 @@ class Assistant:
         self.fastapi_app.state.attachment_registry = self.attachment_registry
         logger.info(
             f"AttachmentRegistry initialized with path: {attachment_storage_path}"
-        )
-
-        # Initialize PushNotificationService
-        vapid_private_key = self.config.pwa_config.vapid_private_key
-        vapid_contact_email = self.config.pwa_config.vapid_contact_email
-
-        self.push_notification_service = PushNotificationService(
-            vapid_private_key=vapid_private_key,
-            vapid_contact_email=vapid_contact_email,
-        )
-
-        # Store in app.state for lifespan to retrieve
-        self.fastapi_app.state.push_notification_service = (
-            self.push_notification_service
-        )
-        logger.info(
-            f"PushNotificationService initialized (enabled={self.push_notification_service.enabled})"
         )
 
         # Setup error logging to database if enabled
@@ -1354,6 +1392,7 @@ class Assistant:
             chat_interfaces=self.fastapi_app.state.chat_interfaces,
             confirmation_result_waiters=self.confirmation_result_waiters,
             confirmation_ui_managers=self.fastapi_app.state.confirmation_ui_managers,
+            notification_dispatcher=self.notification_dispatcher,
         )
         self.task_worker_instance.register_task_handler(
             "log_message", task_wrapper_handle_log_message

--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -95,6 +95,13 @@ ENV_VAR_MAPPINGS: list[EnvVarMapping] = [
     EnvVarMapping("VAPID_PUBLIC_KEY", "pwa_config.vapid_public_key"),
     EnvVarMapping("VAPID_PRIVATE_KEY", "pwa_config.vapid_private_key"),
     EnvVarMapping("VAPID_CONTACT_EMAIL", "pwa_config.vapid_contact_email"),
+    # APNs (iOS push) configuration
+    EnvVarMapping("APNS_TEAM_ID", "apns.team_id"),
+    EnvVarMapping("APNS_KEY_ID", "apns.key_id"),
+    EnvVarMapping("APNS_AUTH_KEY", "apns.auth_key"),
+    EnvVarMapping("APNS_AUTH_KEY_PATH", "apns.auth_key_path"),
+    EnvVarMapping("APNS_BUNDLE_ID", "apns.bundle_id"),
+    EnvVarMapping("APNS_USE_SANDBOX", "apns.use_sandbox", bool),
     # Profile settings
     EnvVarMapping("DEFAULT_SERVICE_PROFILE_ID", "default_service_profile_id"),
     EnvVarMapping("TIMEZONE", "default_profile_settings.processing_config.timezone"),
@@ -1092,6 +1099,12 @@ def _log_config(
     if "pwa_config" in loggable:
         loggable["pwa_config"] = {
             k: v for k, v in loggable["pwa_config"].items() if k != "vapid_private_key"
+        }
+
+    # Remove APNs private key material
+    if "apns" in loggable:
+        loggable["apns"] = {
+            k: v for k, v in loggable["apns"].items() if k != "auth_key"
         }
 
     logger.info(

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -328,6 +328,23 @@ class PWAConfig(BaseModel):
     vapid_contact_email: str | None = None
 
 
+class ApnsConfig(BaseModel):
+    """Apple Push Notification service (iOS) configuration.
+
+    The APNs sender is enabled only when team_id, key_id, bundle_id and a private key (either
+    `auth_key` inline or `auth_key_path`) are all configured.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    team_id: str | None = None
+    key_id: str | None = None
+    auth_key: str | None = None
+    auth_key_path: str | None = None
+    bundle_id: str | None = None
+    use_sandbox: bool = False
+
+
 class GeminiVoiceConfig(BaseModel):
     """Gemini voice settings."""
 
@@ -1080,6 +1097,7 @@ class AppConfig(BaseSettings):
     # Feature configurations
     calendar_config: CalendarConfig = Field(default_factory=CalendarConfig)
     pwa_config: PWAConfig = Field(default_factory=PWAConfig)
+    apns: ApnsConfig = Field(default_factory=ApnsConfig)
     gemini_live_config: GeminiLiveConfig = Field(default_factory=GeminiLiveConfig)
     mcp_config: MCPConfig = Field(default_factory=MCPConfig)
     indexing_pipeline_config: IndexingPipelineConfig = Field(

--- a/src/family_assistant/services/apns.py
+++ b/src/family_assistant/services/apns.py
@@ -1,0 +1,275 @@
+"""APNs (Apple Push Notification service) sender for iOS push notifications.
+
+Uses provider-token (JWT) authentication with an Apple ``.p8`` auth key and sends HTTP/2 requests
+to APNs. The service mirrors the interface of :class:`PushNotificationService` so it can be used
+interchangeably (and combined) via :class:`NotificationDispatcher`.
+"""
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import Callable
+
+import httpx
+import jwt
+
+from family_assistant.storage.context import DatabaseContext
+from family_assistant.storage.ios_push_token import IosPushToken
+
+logger = logging.getLogger(__name__)
+
+# APNs hosts. Token-based auth uses port 443.
+APNS_HOST_PRODUCTION = "https://api.push.apple.com"
+APNS_HOST_SANDBOX = "https://api.sandbox.push.apple.com"
+
+# Apple requires provider tokens to be refreshed between 20 and 60 minutes. Refresh well within
+# that window to avoid ExpiredProviderToken responses.
+PROVIDER_TOKEN_REFRESH_SECONDS = 40 * 60
+
+# APNs reasons that mean the device token is permanently invalid and should be removed.
+_UNREGISTERED_REASONS = frozenset({
+    "Unregistered",
+    "ExpiredToken",
+    "DeviceTokenNotForTopic",
+})
+# APNs reasons that mean our provider (JWT) token is invalid and should be regenerated.
+_PROVIDER_TOKEN_REASONS = frozenset({
+    "ExpiredProviderToken",
+    "InvalidProviderToken",
+    "MissingProviderToken",
+})
+
+
+def _host_for_environment(environment: str) -> str:
+    """Return the APNs host for a token environment."""
+    return APNS_HOST_SANDBOX if environment == "sandbox" else APNS_HOST_PRODUCTION
+
+
+def _other_environment(environment: str) -> str:
+    """Return the opposite APNs environment."""
+    return "production" if environment == "sandbox" else "sandbox"
+
+
+class APNsService:
+    """Service for sending push notifications to iOS devices via APNs."""
+
+    def __init__(
+        self,
+        *,
+        team_id: str | None,
+        key_id: str | None,
+        auth_key: str | None,
+        bundle_id: str | None,
+        use_sandbox: bool = False,
+        client: httpx.AsyncClient | None = None,
+        time_fn: Callable[[], float] = time.time,
+    ) -> None:
+        """Initialize the APNs service.
+
+        Args:
+            team_id: Apple Developer Team ID (JWT ``iss`` claim).
+            key_id: APNs auth key id (JWT ``kid`` header).
+            auth_key: Contents of the ``.p8`` private key (PEM).
+            bundle_id: App bundle id, used as the ``apns-topic`` header.
+            use_sandbox: Default environment for tokens that do not specify one.
+            client: Optional pre-configured HTTP/2 client (primarily for tests). When omitted, a
+                client is created lazily on first use.
+            time_fn: Callable returning the current wall-clock time, injectable for tests.
+        """
+        self._team_id = team_id
+        self._key_id = key_id
+        self._auth_key = auth_key
+        self._bundle_id = bundle_id
+        self._default_environment = "sandbox" if use_sandbox else "production"
+        self._time_fn = time_fn
+
+        self._client = client
+        self._owns_client = client is None
+
+        self._cached_token: str | None = None
+        self._cached_token_issued_at: float = 0.0
+
+        self.enabled = bool(team_id and key_id and auth_key and bundle_id)
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Return the HTTP/2 client, creating it lazily if needed."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(http2=True, timeout=10.0)
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client if this service owns it."""
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+    def _provider_token(self, *, force_refresh: bool = False) -> str:
+        """Return a cached or freshly-signed APNs provider (JWT) token."""
+        if self._auth_key is None:
+            raise RuntimeError("APNs auth key is not configured")
+        now = self._time_fn()
+        if (
+            not force_refresh
+            and self._cached_token is not None
+            and now - self._cached_token_issued_at < PROVIDER_TOKEN_REFRESH_SECONDS
+        ):
+            return self._cached_token
+
+        token = jwt.encode(
+            {"iss": self._team_id, "iat": int(now)},
+            self._auth_key,
+            algorithm="ES256",
+            headers={"kid": self._key_id, "alg": "ES256"},
+        )
+        self._cached_token = token
+        self._cached_token_issued_at = now
+        return token
+
+    async def send_notification(
+        self,
+        user_identifier: str,
+        title: str,
+        body: str,
+        db_context: DatabaseContext,
+    ) -> None:
+        """Send an APNs alert to all iOS tokens registered for a user.
+
+        Args:
+            user_identifier: The user identifier.
+            title: Notification title.
+            body: Notification body text.
+            db_context: Database context for accessing and pruning tokens.
+        """
+        if not self.enabled:
+            logger.debug(
+                "APNs disabled - team_id/key_id/auth_key/bundle_id not configured"
+            )
+            return
+
+        tokens = await db_context.ios_push_tokens.get_by_user(user_identifier)
+        if not tokens:
+            return
+
+        payload = json.dumps({
+            "aps": {"alert": {"title": title, "body": body}, "sound": "default"}
+        }).encode("utf-8")
+
+        results = await asyncio.gather(
+            *(self._deliver(token, payload) for token in tokens)
+        )
+
+        # Apply token mutations sequentially to avoid concurrent DB writes.
+        for token, action in zip(tokens, results, strict=True):
+            if action == "delete":
+                await db_context.ios_push_tokens.delete_by_token(token.device_token)
+            elif action is not None:
+                # A corrected environment ("production"/"sandbox").
+                await db_context.ios_push_tokens.update_environment(
+                    token.device_token, action
+                )
+
+    async def _deliver(self, token: IosPushToken, payload: bytes) -> str | None:
+        """Deliver a notification to a single device token.
+
+        Returns:
+            ``"delete"`` if the token should be removed, the corrected environment string if it
+            should be updated, or ``None`` if no token mutation is required.
+        """
+        environment = token.environment or self._default_environment
+        status_code, reason = await self._post(token.device_token, environment, payload)
+
+        # Provider token rejected: regenerate and retry once in the same environment.
+        if status_code == 403 and reason in _PROVIDER_TOKEN_REASONS:
+            logger.warning(
+                "APNs provider token rejected (%s); refreshing and retrying", reason
+            )
+            status_code, reason = await self._post(
+                token.device_token, environment, payload, force_token_refresh=True
+            )
+
+        if status_code == 200:
+            logger.info("Sent APNs notification to token %s…", token.device_token[:8])
+            return None
+
+        if status_code == 410 or reason in _UNREGISTERED_REASONS:
+            logger.info(
+                "APNs token %s… unregistered (status=%s reason=%s); deleting",
+                token.device_token[:8],
+                status_code,
+                reason,
+            )
+            return "delete"
+
+        if reason == "BadDeviceToken":
+            # Likely a sandbox/production mismatch. Retry against the other environment.
+            other = _other_environment(environment)
+            logger.info(
+                "APNs token %s… rejected as BadDeviceToken for %s; retrying %s",
+                token.device_token[:8],
+                environment,
+                other,
+            )
+            retry_status, retry_reason = await self._post(
+                token.device_token, other, payload
+            )
+            if retry_status == 200:
+                logger.info(
+                    "APNs token %s… delivered on %s; updating stored environment",
+                    token.device_token[:8],
+                    other,
+                )
+                return other
+            logger.warning(
+                "APNs token %s… invalid in both environments (%s/%s); deleting",
+                token.device_token[:8],
+                reason,
+                retry_reason,
+            )
+            return "delete"
+
+        logger.warning(
+            "APNs delivery failed for token %s… (status=%s reason=%s)",
+            token.device_token[:8],
+            status_code,
+            reason,
+        )
+        return None
+
+    async def _post(
+        self,
+        device_token: str,
+        environment: str,
+        payload: bytes,
+        *,
+        force_token_refresh: bool = False,
+    ) -> tuple[int, str | None]:
+        """Send a single APNs request, returning ``(status_code, reason)``."""
+        url = f"{_host_for_environment(environment)}/3/device/{device_token}"
+        headers = {
+            "authorization": f"bearer {self._provider_token(force_refresh=force_token_refresh)}",
+            "apns-topic": self._bundle_id or "",
+            "apns-push-type": "alert",
+            "apns-priority": "10",
+            "apns-expiration": str(int(self._time_fn()) + 3600),
+            "content-type": "application/json",
+        }
+        try:
+            response = await self._get_client().post(
+                url, content=payload, headers=headers
+            )
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "APNs request error for token %s…: %s", device_token[:8], exc
+            )
+            return 0, None
+
+        if response.status_code == 200:
+            return 200, None
+
+        reason: str | None = None
+        try:
+            reason = response.json().get("reason")
+        except (json.JSONDecodeError, ValueError):
+            reason = response.text or None
+        return response.status_code, reason

--- a/src/family_assistant/services/apns.py
+++ b/src/family_assistant/services/apns.py
@@ -29,12 +29,11 @@ APNS_HOST_SANDBOX = "https://api.sandbox.push.apple.com"
 # that window to avoid ExpiredProviderToken responses.
 PROVIDER_TOKEN_REFRESH_SECONDS = 40 * 60
 
-# APNs reasons that mean the device token is permanently invalid and should be removed.
-_UNREGISTERED_REASONS = frozenset({
-    "Unregistered",
-    "ExpiredToken",
-    "DeviceTokenNotForTopic",
-})
+# APNs reasons that prove the device token is inactive and should be removed. Deliberately narrow:
+# `BadDeviceToken` is a format/environment problem (handled via the environment retry), and
+# `DeviceTokenNotForTopic` is an apns-topic/bundle-id misconfiguration — neither means the device
+# token itself is dead, so pruning on them would erase valid registrations on a bad deployment.
+_UNREGISTERED_REASONS = frozenset({"Unregistered"})
 # APNs reasons that mean our provider (JWT) token is invalid and should be regenerated.
 _PROVIDER_TOKEN_REASONS = frozenset({
     "ExpiredProviderToken",

--- a/src/family_assistant/services/apns.py
+++ b/src/family_assistant/services/apns.py
@@ -10,6 +10,7 @@ import json
 import logging
 import time
 from collections.abc import Callable
+from pathlib import Path
 
 import httpx
 import jwt
@@ -49,6 +50,44 @@ def _host_for_environment(environment: str) -> str:
 def _other_environment(environment: str) -> str:
     """Return the opposite APNs environment."""
     return "production" if environment == "sandbox" else "sandbox"
+
+
+def _is_permanently_invalid(status_code: int, reason: str | None) -> bool:
+    """Whether an APNs response conclusively proves the device token is invalid.
+
+    Transient failures (5xx, 429, provider-token errors, or local ``httpx`` errors reported as
+    ``(0, None)``) are deliberately excluded so a valid token is not pruned on a flaky send.
+    """
+    return (
+        status_code == 410
+        or reason in _UNREGISTERED_REASONS
+        or reason == "BadDeviceToken"
+    )
+
+
+class ApnsAuthKeyError(RuntimeError):
+    """Raised when a configured APNs auth key path cannot be read."""
+
+
+def load_apns_auth_key(
+    *, auth_key: str | None, auth_key_path: str | None
+) -> str | None:
+    """Resolve the APNs auth key from an inline value or a configured ``.p8`` path.
+
+    An inline ``auth_key`` takes precedence. When only ``auth_key_path`` is set, the file must be
+    readable: an unreadable explicit path is a configuration error and is raised rather than
+    silently disabling iOS push.
+    """
+    if auth_key:
+        return auth_key
+    if auth_key_path:
+        try:
+            return Path(auth_key_path).read_text(encoding="utf-8")
+        except OSError as e:
+            raise ApnsAuthKeyError(
+                f"APNs auth key path {auth_key_path!r} could not be read: {e}"
+            ) from e
+    return None
 
 
 class APNsService:
@@ -220,13 +259,23 @@ class APNsService:
                     other,
                 )
                 return other
+            if _is_permanently_invalid(retry_status, retry_reason):
+                logger.warning(
+                    "APNs token %s… invalid in both environments (%s/%s); deleting",
+                    token.device_token[:8],
+                    reason,
+                    retry_reason,
+                )
+                return "delete"
+            # The retry failed for a reason that does not prove the token is invalid (e.g. a
+            # transient 5xx/429 or provider-token error); keep it for the next send.
             logger.warning(
-                "APNs token %s… invalid in both environments (%s/%s); deleting",
+                "APNs token %s… environment retry inconclusive (status=%s reason=%s); keeping",
                 token.device_token[:8],
-                reason,
+                retry_status,
                 retry_reason,
             )
-            return "delete"
+            return None
 
         logger.warning(
             "APNs delivery failed for token %s… (status=%s reason=%s)",

--- a/src/family_assistant/services/apns.py
+++ b/src/family_assistant/services/apns.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import httpx
 import jwt
 
+from family_assistant.services.notifier import NotificationMetadata
 from family_assistant.storage.context import DatabaseContext
 from family_assistant.storage.ios_push_token import IosPushToken
 
@@ -63,6 +64,28 @@ def _is_permanently_invalid(status_code: int, reason: str | None) -> bool:
         or reason in _UNREGISTERED_REASONS
         or reason == "BadDeviceToken"
     )
+
+
+def _build_payload(
+    title: str, body: str, metadata: NotificationMetadata | None
+) -> bytes:
+    """Build the APNs JSON payload, embedding category and custom userInfo fields.
+
+    ``aps.category`` drives the client's interactive action buttons; the remaining metadata fields
+    are added as top-level custom keys (APNs ``userInfo``) so taps can deep-link.
+    """
+    aps: dict[str, object] = {
+        "alert": {"title": title, "body": body},
+        "sound": "default",
+    }
+    payload: dict[str, object] = {"aps": aps}
+    if metadata is not None:
+        fields = metadata.model_dump(exclude_none=True)
+        category = fields.pop("category", None)
+        if category:
+            aps["category"] = category
+        payload.update(fields)
+    return json.dumps(payload).encode("utf-8")
 
 
 class ApnsAuthKeyError(RuntimeError):
@@ -171,6 +194,8 @@ class APNsService:
         title: str,
         body: str,
         db_context: DatabaseContext,
+        *,
+        metadata: NotificationMetadata | None = None,
     ) -> None:
         """Send an APNs alert to all iOS tokens registered for a user.
 
@@ -179,6 +204,9 @@ class APNsService:
             title: Notification title.
             body: Notification body text.
             db_context: Database context for accessing and pruning tokens.
+            metadata: Optional structured metadata. ``category`` becomes ``aps.category`` (driving
+                the client's action buttons); the remaining fields are sent as custom ``userInfo``
+                keys for deep-linking.
         """
         if not self.enabled:
             logger.debug(
@@ -190,9 +218,7 @@ class APNsService:
         if not tokens:
             return
 
-        payload = json.dumps({
-            "aps": {"alert": {"title": title, "body": body}, "sound": "default"}
-        }).encode("utf-8")
+        payload = _build_payload(title, body, metadata)
 
         results = await asyncio.gather(
             *(self._deliver(token, payload) for token in tokens)

--- a/src/family_assistant/services/confirmation_service.py
+++ b/src/family_assistant/services/confirmation_service.py
@@ -87,14 +87,13 @@ class ConfirmationService:
                 confirmation_prompt=confirmation_prompt,
                 expires_at=expires_at,
             )
-            await self._notify_pending(
-                db, target_user_id, request_id, confirmation_prompt
-            )
-            return request
+        # Notify only after the request transaction has committed, so a recipient that immediately
+        # approves/rejects (on a separate connection) can resolve the request_id.
+        await self._notify_pending(target_user_id, request_id, confirmation_prompt)
+        return request
 
     async def _notify_pending(
         self,
-        db: DatabaseContext,
         target_user_id: str,
         request_id: str,
         confirmation_prompt: str,
@@ -103,16 +102,17 @@ class ConfirmationService:
         if self._notifier is None or not self._notifier.enabled:
             return
         try:
-            await self._notifier.send_notification(
-                user_identifier=target_user_id,
-                title="Confirmation needed",
-                body=confirmation_prompt[:150],
-                db_context=db,
-                metadata=NotificationMetadata(
-                    category=CONFIRMATION_CATEGORY,
-                    request_id=request_id,
-                ),
-            )
+            async with self._db_context_factory() as db:
+                await self._notifier.send_notification(
+                    user_identifier=target_user_id,
+                    title="Confirmation needed",
+                    body=confirmation_prompt[:150],
+                    db_context=db,
+                    metadata=NotificationMetadata(
+                        category=CONFIRMATION_CATEGORY,
+                        request_id=request_id,
+                    ),
+                )
         except Exception:
             logger.warning(
                 "Failed to send confirmation push notification", exc_info=True

--- a/src/family_assistant/services/confirmation_service.py
+++ b/src/family_assistant/services/confirmation_service.py
@@ -11,9 +11,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from contextlib import AbstractAsyncContextManager
 
-    from family_assistant.services.notification_dispatcher import (
-        NotificationDispatcher,
-    )
+    from family_assistant.services.notifier import Notifier
     from family_assistant.storage.context import DatabaseContext
     from family_assistant.storage.repositories.confirmation_requests import (
         ConfirmationRequestRow,
@@ -55,10 +53,10 @@ class ConfirmationService:
         self,
         *,
         db_context_factory: Callable[[], AbstractAsyncContextManager[DatabaseContext]],
-        notification_dispatcher: NotificationDispatcher | None = None,
+        notifier: Notifier | None = None,
     ) -> None:
         self._db_context_factory = db_context_factory
-        self._notification_dispatcher = notification_dispatcher
+        self._notifier = notifier
 
     async def create_request(
         self,
@@ -94,12 +92,10 @@ class ConfirmationService:
         confirmation_prompt: str,
     ) -> None:
         """Send a push notification for a newly created pending confirmation."""
-        if self._notification_dispatcher is None or not (
-            self._notification_dispatcher.enabled
-        ):
+        if self._notifier is None or not self._notifier.enabled:
             return
         try:
-            await self._notification_dispatcher.send_notification(
+            await self._notifier.send_notification(
                 user_identifier=target_user_id,
                 title="Confirmation needed",
                 body=confirmation_prompt[:150],

--- a/src/family_assistant/services/confirmation_service.py
+++ b/src/family_assistant/services/confirmation_service.py
@@ -7,6 +7,11 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from family_assistant.services.notifier import (
+    CONFIRMATION_CATEGORY,
+    NotificationMetadata,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from contextlib import AbstractAsyncContextManager
@@ -82,13 +87,16 @@ class ConfirmationService:
                 confirmation_prompt=confirmation_prompt,
                 expires_at=expires_at,
             )
-            await self._notify_pending(db, target_user_id, confirmation_prompt)
+            await self._notify_pending(
+                db, target_user_id, request_id, confirmation_prompt
+            )
             return request
 
     async def _notify_pending(
         self,
         db: DatabaseContext,
         target_user_id: str,
+        request_id: str,
         confirmation_prompt: str,
     ) -> None:
         """Send a push notification for a newly created pending confirmation."""
@@ -100,6 +108,10 @@ class ConfirmationService:
                 title="Confirmation needed",
                 body=confirmation_prompt[:150],
                 db_context=db,
+                metadata=NotificationMetadata(
+                    category=CONFIRMATION_CATEGORY,
+                    request_id=request_id,
+                ),
             )
         except Exception:
             logger.warning(

--- a/src/family_assistant/services/confirmation_service.py
+++ b/src/family_assistant/services/confirmation_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -10,12 +11,17 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from contextlib import AbstractAsyncContextManager
 
+    from family_assistant.services.notification_dispatcher import (
+        NotificationDispatcher,
+    )
     from family_assistant.storage.context import DatabaseContext
     from family_assistant.storage.repositories.confirmation_requests import (
         ConfirmationRequestRow,
         ConfirmationStatus,
     )
     from family_assistant.tools.types import ToolArgumentsView
+
+logger = logging.getLogger(__name__)
 
 CONFIRMATION_TOOL_EXECUTION_TASK_TYPE = "confirmation_tool_execution"
 DURABLE_CONFIRMATION_STATUS_POLL_SECONDS = 5.0
@@ -49,8 +55,10 @@ class ConfirmationService:
         self,
         *,
         db_context_factory: Callable[[], AbstractAsyncContextManager[DatabaseContext]],
+        notification_dispatcher: NotificationDispatcher | None = None,
     ) -> None:
         self._db_context_factory = db_context_factory
+        self._notification_dispatcher = notification_dispatcher
 
     async def create_request(
         self,
@@ -66,7 +74,7 @@ class ConfirmationService:
         """Create a durable pending confirmation request."""
         request_id = f"confirm_{uuid.uuid4().hex[:12]}"
         async with self._db_context_factory() as db:
-            return await db.confirmation_requests.create(
+            request = await db.confirmation_requests.create(
                 request_id=request_id,
                 target_user_id=target_user_id,
                 tool_name=tool_name,
@@ -75,6 +83,31 @@ class ConfirmationService:
                 source_message_internal_id=source_message_internal_id,
                 confirmation_prompt=confirmation_prompt,
                 expires_at=expires_at,
+            )
+            await self._notify_pending(db, target_user_id, confirmation_prompt)
+            return request
+
+    async def _notify_pending(
+        self,
+        db: DatabaseContext,
+        target_user_id: str,
+        confirmation_prompt: str,
+    ) -> None:
+        """Send a push notification for a newly created pending confirmation."""
+        if self._notification_dispatcher is None or not (
+            self._notification_dispatcher.enabled
+        ):
+            return
+        try:
+            await self._notification_dispatcher.send_notification(
+                user_identifier=target_user_id,
+                title="Confirmation needed",
+                body=confirmation_prompt[:150],
+                db_context=db,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to send confirmation push notification", exc_info=True
             )
 
     async def approve_and_enqueue_execution(

--- a/src/family_assistant/services/notification_dispatcher.py
+++ b/src/family_assistant/services/notification_dispatcher.py
@@ -1,0 +1,82 @@
+"""Fan-out dispatcher for user notifications across delivery channels.
+
+Combines the browser Web Push channel (:class:`PushNotificationService`) and the iOS APNs channel
+(:class:`APNsService`) behind a single interface so callers dispatch one logical notification that
+reaches every channel a user is subscribed to. The interface mirrors the individual services
+(``enabled`` and ``send_notification(user_identifier, title, body, db_context)``) so it is a
+drop-in wherever a single push service was previously used.
+"""
+
+import asyncio
+import logging
+
+from family_assistant.services.apns import APNsService
+from family_assistant.services.push_notification import PushNotificationService
+from family_assistant.storage.context import DatabaseContext
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationDispatcher:
+    """Dispatches notifications to all configured channels for a user."""
+
+    def __init__(
+        self,
+        *,
+        web_push: PushNotificationService | None = None,
+        apns: APNsService | None = None,
+    ) -> None:
+        """Initialize the dispatcher.
+
+        Args:
+            web_push: Optional Web Push (PWA) notification service.
+            apns: Optional iOS APNs notification service.
+        """
+        self._web_push = web_push
+        self._apns = apns
+
+    @property
+    def enabled(self) -> bool:
+        """True if at least one underlying channel is enabled."""
+        return bool(
+            (self._web_push is not None and self._web_push.enabled)
+            or (self._apns is not None and self._apns.enabled)
+        )
+
+    async def send_notification(
+        self,
+        user_identifier: str,
+        title: str,
+        body: str,
+        db_context: DatabaseContext,
+    ) -> None:
+        """Send a notification to the user across every enabled channel.
+
+        Each channel is isolated: a failure in one does not prevent the others from delivering.
+        """
+        channels = []
+        if self._web_push is not None and self._web_push.enabled:
+            channels.append(("web_push", self._web_push))
+        if self._apns is not None and self._apns.enabled:
+            channels.append(("apns", self._apns))
+
+        if not channels:
+            return
+
+        results = await asyncio.gather(
+            *(
+                service.send_notification(user_identifier, title, body, db_context)
+                for _, service in channels
+            ),
+            return_exceptions=True,
+        )
+
+        for (name, _), result in zip(channels, results, strict=True):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "Notification channel %s failed for user %s: %s",
+                    name,
+                    user_identifier,
+                    result,
+                    exc_info=result,
+                )

--- a/src/family_assistant/services/notification_dispatcher.py
+++ b/src/family_assistant/services/notification_dispatcher.py
@@ -7,7 +7,6 @@ reaches every channel a user is subscribed to. The interface mirrors the individ
 drop-in wherever a single push service was previously used.
 """
 
-import asyncio
 import logging
 
 from family_assistant.services.apns import APNsService
@@ -55,7 +54,11 @@ class NotificationDispatcher:
     ) -> None:
         """Send a notification to the user across every enabled channel.
 
-        Each channel is isolated: a failure in one does not prevent the others from delivering.
+        Channels are dispatched sequentially rather than concurrently: every channel runs
+        repository queries against the caller's ``db_context``, whose single ``AsyncConnection``
+        cannot service concurrent operations (concurrent use raises "another operation is in
+        progress" on async PostgreSQL). Each channel is isolated so a failure in one does not
+        prevent the others from delivering.
         """
         channels = []
         if self._web_push is not None and self._web_push.enabled:
@@ -63,25 +66,15 @@ class NotificationDispatcher:
         if self._apns is not None and self._apns.enabled:
             channels.append(("apns", self._apns))
 
-        if not channels:
-            return
-
-        results = await asyncio.gather(
-            *(
-                service.send_notification(
+        for name, service in channels:
+            try:
+                await service.send_notification(
                     user_identifier, title, body, db_context, metadata=metadata
                 )
-                for _, service in channels
-            ),
-            return_exceptions=True,
-        )
-
-        for (name, _), result in zip(channels, results, strict=True):
-            if isinstance(result, BaseException):
+            except Exception:
                 logger.warning(
-                    "Notification channel %s failed for user %s: %s",
+                    "Notification channel %s failed for user %s",
                     name,
                     user_identifier,
-                    result,
-                    exc_info=result,
+                    exc_info=True,
                 )

--- a/src/family_assistant/services/notification_dispatcher.py
+++ b/src/family_assistant/services/notification_dispatcher.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 
 from family_assistant.services.apns import APNsService
+from family_assistant.services.notifier import NotificationMetadata
 from family_assistant.services.push_notification import PushNotificationService
 from family_assistant.storage.context import DatabaseContext
 
@@ -49,6 +50,8 @@ class NotificationDispatcher:
         title: str,
         body: str,
         db_context: DatabaseContext,
+        *,
+        metadata: NotificationMetadata | None = None,
     ) -> None:
         """Send a notification to the user across every enabled channel.
 
@@ -65,7 +68,9 @@ class NotificationDispatcher:
 
         results = await asyncio.gather(
             *(
-                service.send_notification(user_identifier, title, body, db_context)
+                service.send_notification(
+                    user_identifier, title, body, db_context, metadata=metadata
+                )
                 for _, service in channels
             ),
             return_exceptions=True,

--- a/src/family_assistant/services/notification_targets.py
+++ b/src/family_assistant/services/notification_targets.py
@@ -1,8 +1,9 @@
-"""Helpers for resolving which user a notification should target."""
+"""Helpers for resolving and notifying the user a notification should target."""
 
 import logging
 from datetime import timedelta
 
+from family_assistant.services.notifier import Notifier
 from family_assistant.storage.context import DatabaseContext
 
 logger = logging.getLogger(__name__)
@@ -37,3 +38,38 @@ async def resolve_conversation_user(
         if message.get("role") == "user" and message.get("user_id"):
             return message["user_id"]
     return None
+
+
+async def notify_conversation(
+    notifier: Notifier,
+    db_context: DatabaseContext,
+    *,
+    interface_type: str | None,
+    conversation_id: str | None,
+    title: str,
+    body: str,
+) -> bool:
+    """Notify the owner of a conversation, resolving the user from conversation history.
+
+    Returns:
+        ``True`` if a notification was dispatched, ``False`` if the channel was disabled or the
+        owning user could not be determined.
+    """
+    if not notifier.enabled or not interface_type or not conversation_id:
+        return False
+
+    user_id = await resolve_conversation_user(
+        db_context,
+        interface_type=interface_type,
+        conversation_id=conversation_id,
+    )
+    if user_id is None:
+        return False
+
+    await notifier.send_notification(
+        user_identifier=user_id,
+        title=title,
+        body=body,
+        db_context=db_context,
+    )
+    return True

--- a/src/family_assistant/services/notification_targets.py
+++ b/src/family_assistant/services/notification_targets.py
@@ -1,0 +1,39 @@
+"""Helpers for resolving which user a notification should target."""
+
+import logging
+from datetime import timedelta
+
+from family_assistant.storage.context import DatabaseContext
+
+logger = logging.getLogger(__name__)
+
+# Conversations can be long-lived; look back far enough to find the owning user.
+_CONVERSATION_LOOKBACK = timedelta(days=365)
+
+
+async def resolve_conversation_user(
+    db_context: DatabaseContext,
+    *,
+    interface_type: str,
+    conversation_id: str,
+    limit: int = 20,
+) -> str | None:
+    """Resolve the owning user id for a conversation.
+
+    Notifications originating from background work (assistant replies, task failures, worker
+    completions) only carry a conversation context. The owning user is recovered from the most
+    recent user message in that conversation that carries a ``user_id``.
+
+    Returns:
+        The user identifier, or ``None`` if it cannot be determined.
+    """
+    recent = await db_context.message_history.get_recent_with_metadata(
+        interface_type=interface_type,
+        conversation_id=conversation_id,
+        limit=limit,
+        max_age=_CONVERSATION_LOOKBACK,
+    )
+    for message in recent:
+        if message.get("role") == "user" and message.get("user_id"):
+            return message["user_id"]
+    return None

--- a/src/family_assistant/services/notification_targets.py
+++ b/src/family_assistant/services/notification_targets.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import timedelta
 
-from family_assistant.services.notifier import Notifier
+from family_assistant.services.notifier import NotificationMetadata, Notifier
 from family_assistant.storage.context import DatabaseContext
 
 logger = logging.getLogger(__name__)
@@ -48,6 +48,7 @@ async def notify_conversation(
     conversation_id: str | None,
     title: str,
     body: str,
+    metadata: NotificationMetadata | None = None,
 ) -> bool:
     """Notify the owner of a conversation, resolving the user from conversation history.
 
@@ -71,5 +72,6 @@ async def notify_conversation(
         title=title,
         body=body,
         db_context=db_context,
+        metadata=metadata,
     )
     return True

--- a/src/family_assistant/services/notifier.py
+++ b/src/family_assistant/services/notifier.py
@@ -1,8 +1,32 @@
-"""Protocol describing a user notification channel."""
+"""Protocol and value types describing a user notification channel."""
 
 from typing import Protocol
 
+from pydantic import BaseModel, ConfigDict
+
 from family_assistant.storage.context import DatabaseContext
+
+# APNs notification categories the iOS client registers actions/handling for.
+CONFIRMATION_CATEGORY = "FAMILY_ASSISTANT_CONFIRMATION"
+MESSAGE_CATEGORY = "FAMILY_ASSISTANT_MESSAGE"
+
+
+class NotificationMetadata(BaseModel):
+    """Structured metadata attached to a notification for interactive clients.
+
+    ``category`` maps to the APNs ``aps.category`` (and is mirrored into Web Push data) so the
+    iOS client can attach action buttons. The remaining fields are delivered as custom payload
+    keys (APNs ``userInfo`` / Web Push ``data``) so taps can deep-link instead of falling back to
+    the default view.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    category: str | None = None
+    request_id: str | None = None
+    conversation_id: str | None = None
+    path: str | None = None
+    url: str | None = None
 
 
 class Notifier(Protocol):
@@ -24,6 +48,8 @@ class Notifier(Protocol):
         title: str,
         body: str,
         db_context: DatabaseContext,
+        *,
+        metadata: NotificationMetadata | None = None,
     ) -> None:
         """Deliver a notification to all of the user's registrations on this channel."""
         ...

--- a/src/family_assistant/services/notifier.py
+++ b/src/family_assistant/services/notifier.py
@@ -1,0 +1,29 @@
+"""Protocol describing a user notification channel."""
+
+from typing import Protocol
+
+from family_assistant.storage.context import DatabaseContext
+
+
+class Notifier(Protocol):
+    """A channel that can deliver notifications to a user.
+
+    Implemented by :class:`PushNotificationService` (Web Push), :class:`APNsService` (iOS), and
+    :class:`NotificationDispatcher` (fan-out across channels). Consumers depend on this protocol
+    rather than a concrete service so notification delivery is an explicit, type-checked contract.
+    """
+
+    @property
+    def enabled(self) -> bool:
+        """Whether this channel is configured and able to deliver notifications."""
+        ...
+
+    async def send_notification(
+        self,
+        user_identifier: str,
+        title: str,
+        body: str,
+        db_context: DatabaseContext,
+    ) -> None:
+        """Deliver a notification to all of the user's registrations on this channel."""
+        ...

--- a/src/family_assistant/services/notifier.py
+++ b/src/family_assistant/services/notifier.py
@@ -28,6 +28,21 @@ class NotificationMetadata(BaseModel):
     path: str | None = None
     url: str | None = None
 
+    def web_push_data(self) -> dict[str, str]:
+        """Return the set fields keyed for the Web Push service worker (camelCase).
+
+        The PWA service worker reads ``data.conversationId``; mirror its naming so notification
+        taps deep-link instead of falling back to the default view.
+        """
+        mapping = {
+            "category": self.category,
+            "conversationId": self.conversation_id,
+            "requestId": self.request_id,
+            "path": self.path,
+            "url": self.url,
+        }
+        return {key: value for key, value in mapping.items() if value is not None}
+
 
 class Notifier(Protocol):
     """A channel that can deliver notifications to a user.

--- a/src/family_assistant/services/push_notification.py
+++ b/src/family_assistant/services/push_notification.py
@@ -6,6 +6,7 @@ import logging
 
 from pywebpush import WebPushException, webpush
 
+from family_assistant.services.notifier import NotificationMetadata
 from family_assistant.storage.context import DatabaseContext
 from family_assistant.storage.push_subscription import (
     PushSubscription as PushSubscriptionModel,
@@ -46,6 +47,8 @@ class PushNotificationService:
         title: str,
         body: str,
         db_context: DatabaseContext,
+        *,
+        metadata: NotificationMetadata | None = None,
     ) -> None:
         """Send push notification to all subscriptions for a user.
 
@@ -54,6 +57,8 @@ class PushNotificationService:
             title: Notification title.
             body: Notification body text.
             db_context: Database context for accessing subscriptions.
+            metadata: Optional structured metadata (category, deep-link fields) delivered to the
+                client under ``data`` for navigation/handling.
         """
         if not self.enabled:
             logger.debug(
@@ -65,7 +70,12 @@ class PushNotificationService:
         if not subscriptions:
             return
 
-        payload = json.dumps({"title": title, "body": body})
+        notification: dict[str, object] = {"title": title, "body": body}
+        if metadata is not None:
+            data = metadata.model_dump(exclude_none=True)
+            if data:
+                notification["data"] = data
+        payload = json.dumps(notification)
 
         # Send notifications concurrently to reduce latency for users with multiple subscriptions
         async def send_to_subscription(sub: PushSubscriptionModel) -> int | None:

--- a/src/family_assistant/services/push_notification.py
+++ b/src/family_assistant/services/push_notification.py
@@ -72,7 +72,7 @@ class PushNotificationService:
 
         notification: dict[str, object] = {"title": title, "body": body}
         if metadata is not None:
-            data = metadata.model_dump(exclude_none=True)
+            data = metadata.web_push_data()
             if data:
                 notification["data"] = data
         payload = json.dumps(notification)

--- a/src/family_assistant/storage/__init__.py
+++ b/src/family_assistant/storage/__init__.py
@@ -39,6 +39,7 @@ from family_assistant.storage.events import (
     event_listeners_table,
     recent_events_table,
 )
+from family_assistant.storage.ios_push_token import ios_push_tokens_table
 from family_assistant.storage.message_history import message_history_table
 from family_assistant.storage.notes import notes_table
 from family_assistant.storage.push_subscription import push_subscriptions_table
@@ -329,6 +330,7 @@ __all__ = [
     "recent_events_table",
     "schedule_automations_table",
     "push_subscriptions_table",
+    "ios_push_tokens_table",
     "scripts_table",
     "metadata",
     "DatabaseContext",  # Export the new context manager

--- a/src/family_assistant/storage/context.py
+++ b/src/family_assistant/storage/context.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
         EmailRepository,
         ErrorLogsRepository,
         EventsRepository,
+        IosPushTokenRepository,
         MessageHistoryRepository,
         NotesRepository,
         PushSubscriptionRepository,
@@ -174,6 +175,7 @@ class DatabaseContext:
         self._schedule_automations = None
         self._automations = None
         self._push_subscriptions = None
+        self._ios_push_tokens = None
         self._worker_tasks = None
         self._a2a_tasks = None
         self._scripts = None
@@ -513,6 +515,17 @@ class DatabaseContext:
 
             self._push_subscriptions = PushSubscriptionRepository(self)
         return self._push_subscriptions
+
+    @property
+    def ios_push_tokens(self) -> "IosPushTokenRepository":
+        """Get the iOS push tokens repository instance."""
+        if self._ios_push_tokens is None:
+            from family_assistant.storage.repositories import (  # noqa: PLC0415
+                IosPushTokenRepository,
+            )
+
+            self._ios_push_tokens = IosPushTokenRepository(self)
+        return self._ios_push_tokens
 
     @property
     def worker_tasks(self) -> "WorkerTasksRepository":

--- a/src/family_assistant/storage/ios_push_token.py
+++ b/src/family_assistant/storage/ios_push_token.py
@@ -1,0 +1,42 @@
+"""iOS APNs device token storage models and table definition."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+from sqlalchemy import Column, DateTime, Integer, String, Table
+from sqlalchemy.sql import functions as func
+
+from family_assistant.storage.base import metadata
+
+
+# --- Pydantic Model for type-safe data transfer ---
+class IosPushToken(BaseModel):
+    """Pydantic model for a registered iOS APNs device token."""
+
+    id: int
+    device_token: str
+    user_identifier: str
+    environment: str
+    bundle_id: str | None
+    created_at: datetime
+    updated_at: datetime | None
+
+
+# --- SQLAlchemy Core Table Definition ---
+ios_push_tokens_table = Table(
+    "ios_push_tokens",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("device_token", String(255), nullable=False, unique=True, index=True),
+    Column("user_identifier", String(255), nullable=False, index=True),
+    Column("environment", String(20), nullable=False, server_default="production"),
+    Column("bundle_id", String(255), nullable=True),
+    Column(
+        "created_at", DateTime(timezone=True), nullable=False, server_default=func.now()
+    ),
+    Column("updated_at", DateTime(timezone=True), nullable=True),
+)
+
+# Note: As with push_subscriptions, no foreign key is used for `user_identifier`. Users are
+# managed through session-based and token-based authentication rather than a central users table.
+# The `device_token` is unique to a device/app install, so registration is an upsert keyed on it.

--- a/src/family_assistant/storage/repositories/__init__.py
+++ b/src/family_assistant/storage/repositories/__init__.py
@@ -7,6 +7,7 @@ from .confirmation_requests import ConfirmationRequestsRepository
 from .email import EmailRepository
 from .error_logs import ErrorLogsRepository
 from .events import EventsRepository
+from .ios_push_token import IosPushTokenRepository
 from .message_history import MessageHistoryRepository
 from .notes import NotesRepository
 from .push_subscription import PushSubscriptionRepository
@@ -24,6 +25,7 @@ __all__ = [
     "EmailRepository",
     "ErrorLogsRepository",
     "EventsRepository",
+    "IosPushTokenRepository",
     "MessageHistoryRepository",
     "NotesRepository",
     "PushSubscriptionRepository",

--- a/src/family_assistant/storage/repositories/ios_push_token.py
+++ b/src/family_assistant/storage/repositories/ios_push_token.py
@@ -1,0 +1,110 @@
+"""Repository for managing iOS APNs device token storage."""
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.sql import functions as func
+
+from family_assistant.storage.ios_push_token import (
+    IosPushToken,
+    ios_push_tokens_table,
+)
+
+from .base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class IosPushTokenRepository(BaseRepository):
+    """Repository for managing iOS APNs device tokens."""
+
+    async def upsert(
+        self,
+        *,
+        user_identifier: str,
+        device_token: str,
+        environment: str,
+        bundle_id: str | None = None,
+    ) -> int:
+        """Register a device token, or refresh it if already present.
+
+        A device token is unique to a device/app install, so this is keyed on `device_token`:
+        re-registering moves the token to the current user and refreshes the environment and
+        bundle id.
+
+        Returns:
+            The ID of the created or updated token row.
+        """
+        existing = await self._db.fetch_one(
+            select(ios_push_tokens_table.c.id).where(
+                ios_push_tokens_table.c.device_token == device_token
+            )
+        )
+        if existing is not None:
+            stmt = (
+                ios_push_tokens_table
+                .update()
+                .where(ios_push_tokens_table.c.device_token == device_token)
+                .values(
+                    user_identifier=user_identifier,
+                    environment=environment,
+                    bundle_id=bundle_id,
+                    updated_at=func.now(),
+                )
+            )
+            await self._db.execute_with_retry(stmt)
+            return existing["id"]
+
+        stmt = ios_push_tokens_table.insert().values(
+            user_identifier=user_identifier,
+            device_token=device_token,
+            environment=environment,
+            bundle_id=bundle_id,
+        )
+        result = await self._db.execute_with_retry(stmt)
+        if hasattr(result, "inserted_primary_key") and result.inserted_primary_key:
+            return result.inserted_primary_key[0]  # type: ignore[return-value]
+        return result.lastrowid  # type: ignore[attr-defined]
+
+    async def get_by_user(self, user_identifier: str) -> list[IosPushToken]:
+        """Get all iOS device tokens for a user."""
+        query = select(ios_push_tokens_table).where(
+            ios_push_tokens_table.c.user_identifier == user_identifier
+        )
+        rows = await self._db.fetch_all(query)
+        return [IosPushToken.model_validate(row) for row in rows]
+
+    async def delete_for_user(self, user_identifier: str, device_token: str) -> int:
+        """Delete a device token belonging to a specific user.
+
+        Returns:
+            Number of rows deleted.
+        """
+        stmt = ios_push_tokens_table.delete().where(
+            (ios_push_tokens_table.c.user_identifier == user_identifier)
+            & (ios_push_tokens_table.c.device_token == device_token)
+        )
+        result = await self._db.execute_with_retry(stmt)
+        return result.rowcount  # type: ignore[attr-defined]
+
+    async def delete_by_token(self, device_token: str) -> int:
+        """Delete a device token regardless of owner (used for APNs cleanup).
+
+        Returns:
+            Number of rows deleted.
+        """
+        stmt = ios_push_tokens_table.delete().where(
+            ios_push_tokens_table.c.device_token == device_token
+        )
+        result = await self._db.execute_with_retry(stmt)
+        return result.rowcount  # type: ignore[attr-defined]
+
+    async def update_environment(self, device_token: str, environment: str) -> None:
+        """Persist a corrected APNs environment for a device token."""
+        stmt = (
+            ios_push_tokens_table
+            .update()
+            .where(ios_push_tokens_table.c.device_token == device_token)
+            .values(environment=environment, updated_at=func.now())
+        )
+        await self._db.execute_with_retry(stmt)

--- a/src/family_assistant/storage/repositories/ios_push_token.py
+++ b/src/family_assistant/storage/repositories/ios_push_token.py
@@ -3,6 +3,8 @@
 import logging
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.sql import functions as func
 
 from family_assistant.storage.ios_push_token import (
@@ -35,36 +37,39 @@ class IosPushTokenRepository(BaseRepository):
         Returns:
             The ID of the created or updated token row.
         """
-        existing = await self._db.fetch_one(
-            select(ios_push_tokens_table.c.id).where(
-                ios_push_tokens_table.c.device_token == device_token
-            )
+        # Atomic upsert keyed on the device_token unique index. A database-level ON CONFLICT
+        # avoids a select-then-insert race in which two concurrent registrations of the same
+        # token both insert and one fails the unique constraint.
+        insert = (
+            postgresql_insert
+            if self._db.engine.dialect.name == "postgresql"
+            else sqlite_insert
         )
-        if existing is not None:
-            stmt = (
-                ios_push_tokens_table
-                .update()
-                .where(ios_push_tokens_table.c.device_token == device_token)
-                .values(
-                    user_identifier=user_identifier,
-                    environment=environment,
-                    bundle_id=bundle_id,
-                    updated_at=func.now(),
-                )
-            )
-            await self._db.execute_with_retry(stmt)
-            return existing["id"]
-
-        stmt = ios_push_tokens_table.insert().values(
+        stmt = insert(ios_push_tokens_table).values(
             user_identifier=user_identifier,
             device_token=device_token,
             environment=environment,
             bundle_id=bundle_id,
         )
-        result = await self._db.execute_with_retry(stmt)
-        if hasattr(result, "inserted_primary_key") and result.inserted_primary_key:
-            return result.inserted_primary_key[0]  # type: ignore[return-value]
-        return result.lastrowid  # type: ignore[attr-defined]
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[ios_push_tokens_table.c.device_token],
+            set_={
+                "user_identifier": user_identifier,
+                "environment": environment,
+                "bundle_id": bundle_id,
+                "updated_at": func.now(),
+            },
+        )
+        await self._db.execute_with_retry(stmt)
+
+        row = await self._db.fetch_one(
+            select(ios_push_tokens_table.c.id).where(
+                ios_push_tokens_table.c.device_token == device_token
+            )
+        )
+        if row is None:  # pragma: no cover - row always exists after upsert
+            raise RuntimeError("iOS push token row missing after upsert")
+        return row["id"]
 
     async def get_by_user(self, user_identifier: str) -> list[IosPushToken]:
         """Get all iOS device tokens for a user."""

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -46,9 +46,7 @@ if TYPE_CHECKING:
     from family_assistant.services.confirmation_waiters import (
         ConfirmationResultWaiterRegistry,
     )
-    from family_assistant.services.notification_dispatcher import (
-        NotificationDispatcher,
-    )
+    from family_assistant.services.notifier import Notifier
     from family_assistant.storage.repositories.confirmation_requests import (
         ConfirmationRequestRow,
     )
@@ -59,7 +57,7 @@ if TYPE_CHECKING:
 # handle_index_email is now a method of EmailIndexer and registered in __main__.py
 from family_assistant.processing import ProcessingService
 from family_assistant.processing.utils import get_file_extension_from_mime_type
-from family_assistant.services.notification_targets import resolve_conversation_user
+from family_assistant.services.notification_targets import notify_conversation
 from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.storage.message_history import message_history_table
 from family_assistant.storage.tasks import enqueue_task, get_task_event
@@ -620,7 +618,7 @@ class TaskWorker:
         chat_interfaces: dict[str, ChatInterface] | None = None,
         confirmation_result_waiters: ConfirmationResultWaiterRegistry | None = None,
         confirmation_ui_managers: dict[str, ConfirmationUIManager] | None = None,
-        notification_dispatcher: NotificationDispatcher | None = None,
+        notification_dispatcher: Notifier | None = None,
     ) -> None:
         """Initializes the TaskWorker with its dependencies."""
         self.processing_service = processing_service
@@ -1032,28 +1030,18 @@ class TaskWorker:
         task: TaskDict,
     ) -> None:
         """Push-notify the conversation owner that a task failed after its retries."""
-        if self.notification_dispatcher is None or not (
-            self.notification_dispatcher.enabled
-        ):
+        if self.notification_dispatcher is None:
             return
         payload = task.get("payload") or {}
-        conversation_id = payload.get("conversation_id")
-        interface_type = payload.get("interface_type")
-        if not conversation_id or not interface_type:
-            return
         try:
-            user_id = await resolve_conversation_user(
+            await notify_conversation(
+                self.notification_dispatcher,
                 db_context,
-                interface_type=interface_type,
-                conversation_id=conversation_id,
+                interface_type=payload.get("interface_type"),
+                conversation_id=payload.get("conversation_id"),
+                title="Task failed",
+                body=f"A background task ({task['task_type']}) failed.",
             )
-            if user_id:
-                await self.notification_dispatcher.send_notification(
-                    user_identifier=user_id,
-                    title="Task failed",
-                    body=f"A background task ({task['task_type']}) failed.",
-                    db_context=db_context,
-                )
         except Exception:
             logger.warning("Failed to send task failure notification", exc_info=True)
 

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
 from family_assistant.processing import ProcessingService
 from family_assistant.processing.utils import get_file_extension_from_mime_type
 from family_assistant.services.notification_targets import notify_conversation
+from family_assistant.services.notifier import MESSAGE_CATEGORY, NotificationMetadata
 from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.storage.message_history import message_history_table
 from family_assistant.storage.tasks import enqueue_task, get_task_event
@@ -1033,14 +1034,19 @@ class TaskWorker:
         if self.notification_dispatcher is None:
             return
         payload = task.get("payload") or {}
+        conversation_id = payload.get("conversation_id")
         try:
             await notify_conversation(
                 self.notification_dispatcher,
                 db_context,
                 interface_type=payload.get("interface_type"),
-                conversation_id=payload.get("conversation_id"),
+                conversation_id=conversation_id,
                 title="Task failed",
                 body=f"A background task ({task['task_type']}) failed.",
+                metadata=NotificationMetadata(
+                    category=MESSAGE_CATEGORY,
+                    conversation_id=conversation_id,
+                ),
             )
         except Exception:
             logger.warning("Failed to send task failure notification", exc_info=True)

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -46,6 +46,9 @@ if TYPE_CHECKING:
     from family_assistant.services.confirmation_waiters import (
         ConfirmationResultWaiterRegistry,
     )
+    from family_assistant.services.notification_dispatcher import (
+        NotificationDispatcher,
+    )
     from family_assistant.storage.repositories.confirmation_requests import (
         ConfirmationRequestRow,
     )
@@ -56,6 +59,7 @@ if TYPE_CHECKING:
 # handle_index_email is now a method of EmailIndexer and registered in __main__.py
 from family_assistant.processing import ProcessingService
 from family_assistant.processing.utils import get_file_extension_from_mime_type
+from family_assistant.services.notification_targets import resolve_conversation_user
 from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.storage.message_history import message_history_table
 from family_assistant.storage.tasks import enqueue_task, get_task_event
@@ -616,6 +620,7 @@ class TaskWorker:
         chat_interfaces: dict[str, ChatInterface] | None = None,
         confirmation_result_waiters: ConfirmationResultWaiterRegistry | None = None,
         confirmation_ui_managers: dict[str, ConfirmationUIManager] | None = None,
+        notification_dispatcher: NotificationDispatcher | None = None,
     ) -> None:
         """Initializes the TaskWorker with its dependencies."""
         self.processing_service = processing_service
@@ -623,6 +628,7 @@ class TaskWorker:
         self.chat_interfaces = chat_interfaces
         self.confirmation_result_waiters = confirmation_result_waiters
         self.confirmation_ui_managers = confirmation_ui_managers
+        self.notification_dispatcher = notification_dispatcher
         # Use provided shutdown_event_instance or create a new instance-specific event
         # Don't use the module-level shutdown_event as it persists across test runs
         self.shutdown_event = (
@@ -1017,6 +1023,39 @@ class TaskWorker:
                 await self._enqueue_script_error_notification(
                     db_context, task, error_str
                 )
+            # Push-notify the conversation owner that a background task failed.
+            await self._notify_task_failure(db_context, task)
+
+    async def _notify_task_failure(
+        self,
+        db_context: DatabaseContext,
+        task: TaskDict,
+    ) -> None:
+        """Push-notify the conversation owner that a task failed after its retries."""
+        if self.notification_dispatcher is None or not (
+            self.notification_dispatcher.enabled
+        ):
+            return
+        payload = task.get("payload") or {}
+        conversation_id = payload.get("conversation_id")
+        interface_type = payload.get("interface_type")
+        if not conversation_id or not interface_type:
+            return
+        try:
+            user_id = await resolve_conversation_user(
+                db_context,
+                interface_type=interface_type,
+                conversation_id=conversation_id,
+            )
+            if user_id:
+                await self.notification_dispatcher.send_notification(
+                    user_identifier=user_id,
+                    title="Task failed",
+                    body=f"A background task ({task['task_type']}) failed.",
+                    db_context=db_context,
+                )
+        except Exception:
+            logger.warning("Failed to send task failure notification", exc_info=True)
 
     async def _enqueue_script_error_notification(
         self,

--- a/src/family_assistant/web/app_creator.py
+++ b/src/family_assistant/web/app_creator.py
@@ -147,14 +147,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             WebChatInterface,
         )
 
-        # Retrieve push service from app.state (injected by Assistant)
-        push_notification_service = getattr(
+        # Retrieve the notification dispatcher (fans out to Web Push + iOS) from app.state,
+        # injected by Assistant. Fall back to the bare Web Push service if only that is wired.
+        notifier = getattr(app.state, "notification_dispatcher", None) or getattr(
             app.state, "push_notification_service", None
         )
 
         app.state.web_chat_interface = WebChatInterface(
             app.state.database_engine,
-            push_notification_service=push_notification_service,
+            notifier=notifier,
         )
         # Register web chat interface in the registry
         if not hasattr(app.state, "chat_interfaces"):

--- a/src/family_assistant/web/app_creator.py
+++ b/src/family_assistant/web/app_creator.py
@@ -51,6 +51,7 @@ from family_assistant.web.routers.gemini_live_api import gemini_live_router
 
 # documents_ui, vector_search, and errors routers removed - replaced with React
 from family_assistant.web.routers.health import health_router
+from family_assistant.web.routers.ios_push import router as ios_push_router
 from family_assistant.web.routers.push import router as push_router
 from family_assistant.web.routers.vite_pages import vite_pages_router
 from family_assistant.web.routers.webhooks import webhooks_router
@@ -267,6 +268,7 @@ def create_app() -> FastAPI:
     # Client configuration and push notification endpoints
     new_app.include_router(client_config_router, tags=["Client Configuration"])
     new_app.include_router(push_router, tags=["Push Notifications"])
+    new_app.include_router(ios_push_router, tags=["iOS Push Notifications"])
 
     # General API endpoints (like /api/tools/execute, /api/documents/upload)
     new_app.include_router(api_router, prefix="/api", tags=["General API"])

--- a/src/family_assistant/web/routers/ios_push.py
+++ b/src/family_assistant/web/routers/ios_push.py
@@ -16,9 +16,12 @@ logger = logging.getLogger(__name__)
 
 
 class IosPushTokenRequest(BaseModel):
-    """Request model for registering an iOS APNs device token."""
+    """Request model for registering an iOS APNs device token.
 
-    device_token: str
+    The payload key matches the iOS client, which posts ``token``.
+    """
+
+    token: str
     environment: Literal["production", "sandbox"] = "production"
     bundle_id: str | None = None
 
@@ -42,7 +45,7 @@ async def register_token(
     try:
         token_id = await db.ios_push_tokens.upsert(
             user_identifier=user["user_identifier"],
-            device_token=request.device_token,
+            device_token=request.token,
             environment=request.environment,
             bundle_id=request.bundle_id,
         )
@@ -59,16 +62,16 @@ async def register_token(
         ) from e
 
 
-@router.delete("/api/ios/push-tokens/{device_token}")
+@router.delete("/api/ios/push-tokens/{token}")
 async def unregister_token(
-    device_token: str,
+    token: str,
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[DatabaseContext, Depends(get_db)],
 ) -> dict[str, str]:
     """Unregister an iOS APNs device token belonging to the current user.
 
     Args:
-        device_token: The APNs device token to remove.
+        token: The APNs device token to remove.
         user: Current authenticated user.
         db: Database context.
 
@@ -76,7 +79,7 @@ async def unregister_token(
         Success response with status.
     """
     deleted_count = await db.ios_push_tokens.delete_for_user(
-        user_identifier=user["user_identifier"], device_token=device_token
+        user_identifier=user["user_identifier"], device_token=token
     )
     if deleted_count > 0:
         logger.info(

--- a/src/family_assistant/web/routers/ios_push.py
+++ b/src/family_assistant/web/routers/ios_push.py
@@ -1,0 +1,87 @@
+"""Router for iOS APNs device token registration."""
+
+import logging
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import exc as sqlalchemy_exc
+
+from family_assistant.storage.context import DatabaseContext
+from family_assistant.web.auth import User
+from family_assistant.web.dependencies import get_current_user, get_db
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+class IosPushTokenRequest(BaseModel):
+    """Request model for registering an iOS APNs device token."""
+
+    device_token: str
+    environment: Literal["production", "sandbox"] = "production"
+    bundle_id: str | None = None
+
+
+@router.post("/api/ios/push-tokens")
+async def register_token(
+    request: IosPushTokenRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[DatabaseContext, Depends(get_db)],
+) -> dict[str, str]:
+    """Register (or refresh) an iOS APNs device token for the current user.
+
+    Args:
+        request: Token registration request.
+        user: Current authenticated user.
+        db: Database context.
+
+    Returns:
+        Success response with the stored token row id.
+    """
+    try:
+        token_id = await db.ios_push_tokens.upsert(
+            user_identifier=user["user_identifier"],
+            device_token=request.device_token,
+            environment=request.environment,
+            bundle_id=request.bundle_id,
+        )
+        logger.info(
+            "Registered iOS push token %s for user %s",
+            token_id,
+            user["user_identifier"],
+        )
+        return {"status": "success", "id": str(token_id)}
+    except sqlalchemy_exc.SQLAlchemyError as e:
+        logger.error(f"Database error registering iOS push token: {e}")
+        raise HTTPException(
+            status_code=503, detail="Database error registering push token"
+        ) from e
+
+
+@router.delete("/api/ios/push-tokens/{device_token}")
+async def unregister_token(
+    device_token: str,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[DatabaseContext, Depends(get_db)],
+) -> dict[str, str]:
+    """Unregister an iOS APNs device token belonging to the current user.
+
+    Args:
+        device_token: The APNs device token to remove.
+        user: Current authenticated user.
+        db: Database context.
+
+    Returns:
+        Success response with status.
+    """
+    deleted_count = await db.ios_push_tokens.delete_for_user(
+        user_identifier=user["user_identifier"], device_token=device_token
+    )
+    if deleted_count > 0:
+        logger.info(
+            "Deleted iOS push token for user %s",
+            user["user_identifier"],
+        )
+        return {"status": "success"}
+    return {"status": "not_found"}

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -31,6 +31,7 @@ from family_assistant.email_intake.security import (
     verify_sender_authorization,
 )
 from family_assistant.services.notification_targets import notify_conversation
+from family_assistant.services.notifier import MESSAGE_CATEGORY, NotificationMetadata
 from family_assistant.services.user_identity import (
     UserIdentityResolutionError,
     UserIdentityResolver,
@@ -696,14 +697,19 @@ async def _handle_worker_completion(
         if updated:
             logger.info(f"Updated worker task {task_id} status to {status}")
             if notification_dispatcher is not None:
+                conversation_id = task.get("conversation_id")
                 try:
                     await notify_conversation(
                         notification_dispatcher,
                         db_context,
                         interface_type=task.get("interface_type"),
-                        conversation_id=task.get("conversation_id"),
+                        conversation_id=conversation_id,
                         title="Worker task complete",
                         body=f"A spawned worker task finished ({status}).",
+                        metadata=NotificationMetadata(
+                            category=MESSAGE_CATEGORY,
+                            conversation_id=conversation_id,
+                        ),
                     )
                 except Exception:
                     logger.warning(

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -30,7 +30,7 @@ from family_assistant.email_intake.security import (
     verify_mailgun_signature,
     verify_sender_authorization,
 )
-from family_assistant.services.notification_targets import resolve_conversation_user
+from family_assistant.services.notification_targets import notify_conversation
 from family_assistant.services.user_identity import (
     UserIdentityResolutionError,
     UserIdentityResolver,
@@ -43,10 +43,7 @@ from family_assistant.web.models import WebhookEventPayload
 if TYPE_CHECKING:
     from family_assistant.config_models import AppConfig
     from family_assistant.events.webhook_source import WebhookEventSource
-    from family_assistant.services.notification_dispatcher import (
-        NotificationDispatcher,
-    )
-    from family_assistant.storage.repositories.worker_tasks import WorkerTaskDict
+    from family_assistant.services.notifier import Notifier
 
 logger = logging.getLogger(__name__)
 webhooks_router = APIRouter()
@@ -628,7 +625,7 @@ async def _handle_worker_completion(
     db_context: DatabaseContext,
     # ast-grep-ignore: no-dict-any - Webhook data is dynamic from external worker
     data: dict[str, Any] | None,
-    notification_dispatcher: "NotificationDispatcher | None" = None,
+    notification_dispatcher: "Notifier | None" = None,
 ) -> None:
     """Handle worker completion webhook by updating task status.
 
@@ -698,41 +695,22 @@ async def _handle_worker_completion(
 
         if updated:
             logger.info(f"Updated worker task {task_id} status to {status}")
-            await _notify_worker_completion(
-                db_context, task, status, notification_dispatcher
-            )
+            if notification_dispatcher is not None:
+                try:
+                    await notify_conversation(
+                        notification_dispatcher,
+                        db_context,
+                        interface_type=task.get("interface_type"),
+                        conversation_id=task.get("conversation_id"),
+                        title="Worker task complete",
+                        body=f"A spawned worker task finished ({status}).",
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to send worker completion notification", exc_info=True
+                    )
         else:
             logger.warning(f"Worker task {task_id} not found for completion update")
 
     except Exception as e:
         logger.error(f"Failed to update worker task {task_id}: {e}", exc_info=True)
-
-
-async def _notify_worker_completion(
-    db_context: DatabaseContext,
-    task: "WorkerTaskDict",
-    status: str,
-    notification_dispatcher: "NotificationDispatcher | None",
-) -> None:
-    """Push-notify the conversation owner that a spawned worker task finished."""
-    if notification_dispatcher is None or not notification_dispatcher.enabled:
-        return
-    conversation_id = task.get("conversation_id")
-    interface_type = task.get("interface_type")
-    if not conversation_id or not interface_type:
-        return
-    try:
-        user_id = await resolve_conversation_user(
-            db_context,
-            interface_type=interface_type,
-            conversation_id=conversation_id,
-        )
-        if user_id:
-            await notification_dispatcher.send_notification(
-                user_identifier=user_id,
-                title="Worker task complete",
-                body=f"A spawned worker task finished ({status}).",
-                db_context=db_context,
-            )
-    except Exception:
-        logger.warning("Failed to send worker completion notification", exc_info=True)

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -30,6 +30,7 @@ from family_assistant.email_intake.security import (
     verify_mailgun_signature,
     verify_sender_authorization,
 )
+from family_assistant.services.notification_targets import resolve_conversation_user
 from family_assistant.services.user_identity import (
     UserIdentityResolutionError,
     UserIdentityResolver,
@@ -42,6 +43,10 @@ from family_assistant.web.models import WebhookEventPayload
 if TYPE_CHECKING:
     from family_assistant.config_models import AppConfig
     from family_assistant.events.webhook_source import WebhookEventSource
+    from family_assistant.services.notification_dispatcher import (
+        NotificationDispatcher,
+    )
+    from family_assistant.storage.repositories.worker_tasks import WorkerTaskDict
 
 logger = logging.getLogger(__name__)
 webhooks_router = APIRouter()
@@ -599,7 +604,13 @@ async def handle_generic_webhook(
 
     # Handle worker completion events - update task status in database
     if effective_event_type == "worker_completion":
-        await _handle_worker_completion(db_context, body.data)
+        await _handle_worker_completion(
+            db_context,
+            body.data,
+            notification_dispatcher=getattr(
+                request.app.state, "notification_dispatcher", None
+            ),
+        )
 
     # Get webhook source and emit event
     webhook_source: WebhookEventSource | None = getattr(
@@ -617,12 +628,14 @@ async def _handle_worker_completion(
     db_context: DatabaseContext,
     # ast-grep-ignore: no-dict-any - Webhook data is dynamic from external worker
     data: dict[str, Any] | None,
+    notification_dispatcher: "NotificationDispatcher | None" = None,
 ) -> None:
     """Handle worker completion webhook by updating task status.
 
     Args:
         db_context: Database context for data access
         data: The webhook data containing task_id, outcome, output, exit_code, callback_token
+        notification_dispatcher: Optional dispatcher used to push-notify the conversation owner.
     """
     if not data:
         logger.warning("Worker completion event missing data payload")
@@ -685,8 +698,41 @@ async def _handle_worker_completion(
 
         if updated:
             logger.info(f"Updated worker task {task_id} status to {status}")
+            await _notify_worker_completion(
+                db_context, task, status, notification_dispatcher
+            )
         else:
             logger.warning(f"Worker task {task_id} not found for completion update")
 
     except Exception as e:
         logger.error(f"Failed to update worker task {task_id}: {e}", exc_info=True)
+
+
+async def _notify_worker_completion(
+    db_context: DatabaseContext,
+    task: "WorkerTaskDict",
+    status: str,
+    notification_dispatcher: "NotificationDispatcher | None",
+) -> None:
+    """Push-notify the conversation owner that a spawned worker task finished."""
+    if notification_dispatcher is None or not notification_dispatcher.enabled:
+        return
+    conversation_id = task.get("conversation_id")
+    interface_type = task.get("interface_type")
+    if not conversation_id or not interface_type:
+        return
+    try:
+        user_id = await resolve_conversation_user(
+            db_context,
+            interface_type=interface_type,
+            conversation_id=conversation_id,
+        )
+        if user_id:
+            await notification_dispatcher.send_notification(
+                user_identifier=user_id,
+                title="Worker task complete",
+                body=f"A spawned worker task finished ({status}).",
+                db_context=db_context,
+            )
+    except Exception:
+        logger.warning("Failed to send worker completion notification", exc_info=True)

--- a/src/family_assistant/web/web_chat_interface.py
+++ b/src/family_assistant/web/web_chat_interface.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from family_assistant.interfaces import ChatInterface
 from family_assistant.llm.messages import AssistantMessage, MessageAttachmentMetadata
 from family_assistant.services.notification_targets import notify_conversation
+from family_assistant.services.notifier import MESSAGE_CATEGORY, NotificationMetadata
 from family_assistant.storage.context import get_db_context
 from family_assistant.utils.clock import SystemClock
 
@@ -103,6 +104,10 @@ class WebChatInterface(ChatInterface):
                             conversation_id=conversation_id,
                             title="New message",
                             body=text[:100],  # Truncate long messages
+                            metadata=NotificationMetadata(
+                                category=MESSAGE_CATEGORY,
+                                conversation_id=conversation_id,
+                            ),
                         )
                     except Exception as e:
                         logger.warning(

--- a/src/family_assistant/web/web_chat_interface.py
+++ b/src/family_assistant/web/web_chat_interface.py
@@ -3,11 +3,11 @@ Web ChatInterface implementation for delivering messages via Server-Sent Events.
 """
 
 import logging
-from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from family_assistant.interfaces import ChatInterface
 from family_assistant.llm.messages import AssistantMessage, MessageAttachmentMetadata
+from family_assistant.services.notification_targets import resolve_conversation_user
 from family_assistant.storage.context import get_db_context
 from family_assistant.utils.clock import SystemClock
 
@@ -101,25 +101,11 @@ class WebChatInterface(ChatInterface):
                     and self.push_notification_service.enabled
                 ):
                     try:
-                        # Find user_id from recent user messages
-                        user_id: str | None = None
-                        if not user_id:
-                            # Fallback: query recent messages to find a user message
-                            # (assistant messages don't have user_id, so we look for user messages)
-                            recent = await db_context.message_history.get_recent_with_metadata(
-                                interface_type="web",
-                                conversation_id=conversation_id,
-                                limit=10,
-                                max_age=timedelta(days=365),
-                            )
-                            # Find the most recent user message with a user_id
-                            for message in recent:
-                                if message.get("role") == "user" and message.get(
-                                    "user_id"
-                                ):
-                                    user_id = message["user_id"]
-                                    break
-
+                        user_id = await resolve_conversation_user(
+                            db_context,
+                            interface_type="web",
+                            conversation_id=conversation_id,
+                        )
                         if user_id:
                             await self.push_notification_service.send_notification(
                                 user_identifier=user_id,

--- a/src/family_assistant/web/web_chat_interface.py
+++ b/src/family_assistant/web/web_chat_interface.py
@@ -7,16 +7,14 @@ from typing import TYPE_CHECKING
 
 from family_assistant.interfaces import ChatInterface
 from family_assistant.llm.messages import AssistantMessage, MessageAttachmentMetadata
-from family_assistant.services.notification_targets import resolve_conversation_user
+from family_assistant.services.notification_targets import notify_conversation
 from family_assistant.storage.context import get_db_context
 from family_assistant.utils.clock import SystemClock
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
 
-    from family_assistant.services.push_notification import (
-        PushNotificationService,
-    )
+    from family_assistant.services.notifier import Notifier
 
 logger = logging.getLogger(__name__)
 
@@ -34,17 +32,18 @@ class WebChatInterface(ChatInterface):
     def __init__(
         self,
         database_engine: "AsyncEngine",
-        push_notification_service: "PushNotificationService | None" = None,
+        notifier: "Notifier | None" = None,
     ) -> None:
         """
         Initialize the WebChatInterface.
 
         Args:
             database_engine: SQLAlchemy async engine for database operations
-            push_notification_service: Optional push notification service for sending notifications
+            notifier: Optional notification channel (Web Push, iOS, or a dispatcher fanning out to
+                both) used to notify the conversation owner of new assistant replies.
         """
         self.database_engine = database_engine
-        self.push_notification_service = push_notification_service
+        self.notifier = notifier
 
     async def send_message(
         self,
@@ -94,25 +93,17 @@ class WebChatInterface(ChatInterface):
                     attachments=attachments,
                 )
 
-                # Send push notification if enabled
-                if (
-                    saved_message is not None
-                    and self.push_notification_service
-                    and self.push_notification_service.enabled
-                ):
+                # Notify the conversation owner about the new assistant reply.
+                if saved_message is not None and self.notifier is not None:
                     try:
-                        user_id = await resolve_conversation_user(
+                        await notify_conversation(
+                            self.notifier,
                             db_context,
                             interface_type="web",
                             conversation_id=conversation_id,
+                            title="New message",
+                            body=text[:100],  # Truncate long messages
                         )
-                        if user_id:
-                            await self.push_notification_service.send_notification(
-                                user_identifier=user_id,
-                                title="New message",
-                                body=text[:100],  # Truncate long messages
-                                db_context=db_context,
-                            )
                     except Exception as e:
                         logger.warning(
                             f"Failed to send push notification: {e}", exc_info=True

--- a/tests/functional/test_ios_notification_send_points.py
+++ b/tests/functional/test_ios_notification_send_points.py
@@ -1,0 +1,177 @@
+"""Functional tests for notification dispatch at the integrated send points."""
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from family_assistant.llm.messages import UserMessage
+from family_assistant.services.confirmation_service import ConfirmationService
+from family_assistant.storage.context import DatabaseContext
+from family_assistant.task_worker import TaskWorker
+from family_assistant.utils.clock import SystemClock
+from family_assistant.web.routers.webhooks import (
+    _handle_worker_completion,  # noqa: PLC2701
+)
+
+if TYPE_CHECKING:
+    from family_assistant.storage.types import TaskDict
+
+
+class _RecordingDispatcher:
+    """A fake NotificationDispatcher capturing dispatched notifications."""
+
+    def __init__(self, *, enabled: bool = True) -> None:
+        self.enabled = enabled
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def send_notification(
+        self,
+        user_identifier: str,
+        title: str,
+        body: str,
+        db_context: Any,  # noqa: ANN401
+    ) -> None:
+        self.calls.append((user_identifier, title, body))
+
+
+@pytest.mark.asyncio
+async def test_pending_confirmation_notifies_target_user(
+    db_engine: AsyncEngine,
+) -> None:
+    """Creating a pending confirmation dispatches a notification to the target user."""
+    dispatcher = _RecordingDispatcher()
+    service = ConfirmationService(
+        db_context_factory=lambda: DatabaseContext(engine=db_engine),
+        notification_dispatcher=dispatcher,  # type: ignore[arg-type]
+    )
+
+    await service.create_request(
+        target_user_id="user-1",
+        tool_name="calendar.create_event",
+        tool_args={"title": "Flight"},
+        tool_call_id="call-1",
+        source_message_internal_id=None,
+        confirmation_prompt="Create calendar event: Flight",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    assert dispatcher.calls == [
+        ("user-1", "Confirmation needed", "Create calendar event: Flight")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_worker_completion_notifies_conversation_owner(
+    db_engine: AsyncEngine,
+) -> None:
+    """A worker completion webhook notifies the conversation owner."""
+    clock = SystemClock()
+    async with DatabaseContext(engine=db_engine) as db:
+        # Establish the owning user via a user message in the conversation.
+        await db.message_history.add_message(
+            message=UserMessage(content="please do the thing"),
+            interface_type="web",
+            conversation_id="conv-1",
+            timestamp=clock.now(),
+            user_id="owner-1",
+        )
+        await db.worker_tasks.create_task(
+            task_id="wt-1",
+            conversation_id="conv-1",
+            interface_type="web",
+            task_description="do the thing",
+            model="claude",
+            context_files=[],
+            timeout_minutes=30,
+            user_name="Owner",
+            callback_token=None,
+        )
+
+    dispatcher = _RecordingDispatcher()
+    async with DatabaseContext(engine=db_engine) as db:
+        await _handle_worker_completion(
+            db,
+            {"task_id": "wt-1", "outcome": "success"},
+            notification_dispatcher=dispatcher,  # type: ignore[arg-type]
+        )
+
+    assert len(dispatcher.calls) == 1
+    user_identifier, title, _ = dispatcher.calls[0]
+    assert user_identifier == "owner-1"
+    assert title == "Worker task complete"
+
+
+@pytest.mark.asyncio
+async def test_worker_completion_no_owner_does_not_notify(
+    db_engine: AsyncEngine,
+) -> None:
+    """No notification is sent when the conversation owner cannot be resolved."""
+    async with DatabaseContext(engine=db_engine) as db:
+        await db.worker_tasks.create_task(
+            task_id="wt-2",
+            conversation_id="conv-unknown",
+            interface_type="web",
+            task_description="do the thing",
+            model="claude",
+            context_files=[],
+            timeout_minutes=30,
+            user_name=None,
+            callback_token=None,
+        )
+
+    dispatcher = _RecordingDispatcher()
+    async with DatabaseContext(engine=db_engine) as db:
+        await _handle_worker_completion(
+            db,
+            {"task_id": "wt-2", "outcome": "success"},
+            notification_dispatcher=dispatcher,  # type: ignore[arg-type]
+        )
+
+    assert dispatcher.calls == []
+
+
+@pytest.mark.asyncio
+async def test_task_failure_notifies_conversation_owner(
+    db_engine: AsyncEngine,
+) -> None:
+    """A task failed after retries notifies the conversation owner."""
+    clock = SystemClock()
+    async with DatabaseContext(engine=db_engine) as db:
+        await db.message_history.add_message(
+            message=UserMessage(content="run the automation"),
+            interface_type="telegram",
+            conversation_id="chat-9",
+            timestamp=clock.now(),
+            user_id="owner-9",
+        )
+
+    dispatcher = _RecordingDispatcher()
+    worker = TaskWorker(
+        processing_service=MagicMock(),
+        chat_interface=MagicMock(),
+        calendar_config={},
+        timezone=ZoneInfo("UTC"),
+        embedding_generator=MagicMock(),
+        engine=db_engine,
+        notification_dispatcher=dispatcher,  # type: ignore[arg-type]
+    )
+
+    task = cast(
+        "TaskDict",
+        {
+            "task_id": "t-1",
+            "task_type": "script_execution",
+            "payload": {"conversation_id": "chat-9", "interface_type": "telegram"},
+        },
+    )
+    async with DatabaseContext(engine=db_engine) as db:
+        await worker._notify_task_failure(db, task)  # noqa: SLF001
+
+    assert len(dispatcher.calls) == 1
+    user_identifier, title, _ = dispatcher.calls[0]
+    assert user_identifier == "owner-9"
+    assert title == "Task failed"

--- a/tests/functional/test_ios_notification_send_points.py
+++ b/tests/functional/test_ios_notification_send_points.py
@@ -13,6 +13,11 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from family_assistant.llm.messages import UserMessage
 from family_assistant.services.confirmation_service import ConfirmationService
 from family_assistant.services.notification_targets import notify_conversation
+from family_assistant.services.notifier import (
+    CONFIRMATION_CATEGORY,
+    MESSAGE_CATEGORY,
+    NotificationMetadata,
+)
 from family_assistant.storage.context import DatabaseContext
 from family_assistant.utils.clock import SystemClock
 from family_assistant.web.app_creator import app as fastapi_app
@@ -24,6 +29,7 @@ class _RecordingNotifier:
     def __init__(self, *, enabled: bool = True) -> None:
         self.enabled = enabled
         self.calls: list[tuple[str, str, str]] = []
+        self.metadata: list[NotificationMetadata | None] = []
 
     async def send_notification(
         self,
@@ -31,8 +37,11 @@ class _RecordingNotifier:
         title: str,
         body: str,
         db_context: DatabaseContext,
+        *,
+        metadata: NotificationMetadata | None = None,
     ) -> None:
         self.calls.append((user_identifier, title, body))
+        self.metadata.append(metadata)
 
 
 async def _add_user_message(
@@ -132,6 +141,10 @@ async def test_pending_confirmation_notifies_target_user(
     assert notifier.calls == [
         ("user-1", "Confirmation needed", "Create calendar event: Flight")
     ]
+    metadata = notifier.metadata[0]
+    assert metadata is not None
+    assert metadata.category == CONFIRMATION_CATEGORY
+    assert metadata.request_id is not None
 
 
 @pytest.mark.asyncio
@@ -178,3 +191,7 @@ async def test_worker_completion_webhook_notifies_owner(
     user_identifier, title, _ = notifier.calls[0]
     assert user_identifier == "owner-9"
     assert title == "Worker task complete"
+    metadata = notifier.metadata[0]
+    assert metadata is not None
+    assert metadata.category == MESSAGE_CATEGORY
+    assert metadata.conversation_id == "conv-9"

--- a/tests/functional/test_ios_notification_send_points.py
+++ b/tests/functional/test_ios_notification_send_points.py
@@ -1,28 +1,25 @@
-"""Functional tests for notification dispatch at the integrated send points."""
+"""Functional tests for notification dispatch at the integrated send points.
+
+These exercise public surfaces only: the ``notify_conversation`` helper, the
+``ConfirmationService.create_request`` API, and the ``/webhook/event`` route.
+"""
 
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import MagicMock
-from zoneinfo import ZoneInfo
 
 import pytest
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from family_assistant.llm.messages import UserMessage
 from family_assistant.services.confirmation_service import ConfirmationService
+from family_assistant.services.notification_targets import notify_conversation
 from family_assistant.storage.context import DatabaseContext
-from family_assistant.task_worker import TaskWorker
 from family_assistant.utils.clock import SystemClock
-from family_assistant.web.routers.webhooks import (
-    _handle_worker_completion,  # noqa: PLC2701
-)
-
-if TYPE_CHECKING:
-    from family_assistant.storage.types import TaskDict
+from family_assistant.web.app_creator import app as fastapi_app
 
 
-class _RecordingDispatcher:
-    """A fake NotificationDispatcher capturing dispatched notifications."""
+class _RecordingNotifier:
+    """A fake Notifier capturing dispatched notifications."""
 
     def __init__(self, *, enabled: bool = True) -> None:
         self.enabled = enabled
@@ -33,9 +30,82 @@ class _RecordingDispatcher:
         user_identifier: str,
         title: str,
         body: str,
-        db_context: Any,  # noqa: ANN401
+        db_context: DatabaseContext,
     ) -> None:
         self.calls.append((user_identifier, title, body))
+
+
+async def _add_user_message(
+    db_engine: AsyncEngine, *, interface_type: str, conversation_id: str, user_id: str
+) -> None:
+    async with DatabaseContext(engine=db_engine) as db:
+        await db.message_history.add_message(
+            message=UserMessage(content="please do the thing"),
+            interface_type=interface_type,
+            conversation_id=conversation_id,
+            timestamp=SystemClock().now(),
+            user_id=user_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_notify_conversation_resolves_and_dispatches(
+    db_engine: AsyncEngine,
+) -> None:
+    """notify_conversation resolves the owning user and dispatches a notification."""
+    await _add_user_message(
+        db_engine, interface_type="web", conversation_id="conv-1", user_id="owner-1"
+    )
+    notifier = _RecordingNotifier()
+
+    async with DatabaseContext(engine=db_engine) as db:
+        dispatched = await notify_conversation(
+            notifier,
+            db,
+            interface_type="web",
+            conversation_id="conv-1",
+            title="Title",
+            body="Body",
+        )
+
+    assert dispatched is True
+    assert notifier.calls == [("owner-1", "Title", "Body")]
+
+
+@pytest.mark.asyncio
+async def test_notify_conversation_no_owner_is_noop(db_engine: AsyncEngine) -> None:
+    """No notification is dispatched when the owner cannot be resolved."""
+    notifier = _RecordingNotifier()
+    async with DatabaseContext(engine=db_engine) as db:
+        dispatched = await notify_conversation(
+            notifier,
+            db,
+            interface_type="web",
+            conversation_id="conv-unknown",
+            title="Title",
+            body="Body",
+        )
+
+    assert dispatched is False
+    assert notifier.calls == []
+
+
+@pytest.mark.asyncio
+async def test_notify_conversation_disabled_is_noop(db_engine: AsyncEngine) -> None:
+    """A disabled notifier is never invoked."""
+    notifier = _RecordingNotifier(enabled=False)
+    async with DatabaseContext(engine=db_engine) as db:
+        dispatched = await notify_conversation(
+            notifier,
+            db,
+            interface_type="web",
+            conversation_id="conv-1",
+            title="Title",
+            body="Body",
+        )
+
+    assert dispatched is False
+    assert notifier.calls == []
 
 
 @pytest.mark.asyncio
@@ -43,10 +113,10 @@ async def test_pending_confirmation_notifies_target_user(
     db_engine: AsyncEngine,
 ) -> None:
     """Creating a pending confirmation dispatches a notification to the target user."""
-    dispatcher = _RecordingDispatcher()
+    notifier = _RecordingNotifier()
     service = ConfirmationService(
         db_context_factory=lambda: DatabaseContext(engine=db_engine),
-        notification_dispatcher=dispatcher,  # type: ignore[arg-type]
+        notifier=notifier,
     )
 
     await service.create_request(
@@ -59,29 +129,23 @@ async def test_pending_confirmation_notifies_target_user(
         expires_at=datetime.now(UTC) + timedelta(hours=1),
     )
 
-    assert dispatcher.calls == [
+    assert notifier.calls == [
         ("user-1", "Confirmation needed", "Create calendar event: Flight")
     ]
 
 
 @pytest.mark.asyncio
-async def test_worker_completion_notifies_conversation_owner(
+async def test_worker_completion_webhook_notifies_owner(
     db_engine: AsyncEngine,
 ) -> None:
-    """A worker completion webhook notifies the conversation owner."""
-    clock = SystemClock()
+    """A worker completion event posted to the webhook route notifies the owner."""
+    await _add_user_message(
+        db_engine, interface_type="web", conversation_id="conv-9", user_id="owner-9"
+    )
     async with DatabaseContext(engine=db_engine) as db:
-        # Establish the owning user via a user message in the conversation.
-        await db.message_history.add_message(
-            message=UserMessage(content="please do the thing"),
-            interface_type="web",
-            conversation_id="conv-1",
-            timestamp=clock.now(),
-            user_id="owner-1",
-        )
         await db.worker_tasks.create_task(
             task_id="wt-1",
-            conversation_id="conv-1",
+            conversation_id="conv-9",
             interface_type="web",
             task_description="do the thing",
             model="claude",
@@ -91,87 +155,26 @@ async def test_worker_completion_notifies_conversation_owner(
             callback_token=None,
         )
 
-    dispatcher = _RecordingDispatcher()
-    async with DatabaseContext(engine=db_engine) as db:
-        await _handle_worker_completion(
-            db,
-            {"task_id": "wt-1", "outcome": "success"},
-            notification_dispatcher=dispatcher,  # type: ignore[arg-type]
-        )
+    notifier = _RecordingNotifier()
+    fastapi_app.state.database_engine = db_engine
+    fastapi_app.state.notification_dispatcher = notifier
+    try:
+        transport = ASGITransport(app=fastapi_app)
+        async with AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            response = await client.post(
+                "/webhook/event",
+                json={
+                    "event_type": "worker_completion",
+                    "data": {"task_id": "wt-1", "outcome": "success"},
+                },
+            )
+        assert response.status_code == 200
+    finally:
+        del fastapi_app.state.notification_dispatcher
 
-    assert len(dispatcher.calls) == 1
-    user_identifier, title, _ = dispatcher.calls[0]
-    assert user_identifier == "owner-1"
-    assert title == "Worker task complete"
-
-
-@pytest.mark.asyncio
-async def test_worker_completion_no_owner_does_not_notify(
-    db_engine: AsyncEngine,
-) -> None:
-    """No notification is sent when the conversation owner cannot be resolved."""
-    async with DatabaseContext(engine=db_engine) as db:
-        await db.worker_tasks.create_task(
-            task_id="wt-2",
-            conversation_id="conv-unknown",
-            interface_type="web",
-            task_description="do the thing",
-            model="claude",
-            context_files=[],
-            timeout_minutes=30,
-            user_name=None,
-            callback_token=None,
-        )
-
-    dispatcher = _RecordingDispatcher()
-    async with DatabaseContext(engine=db_engine) as db:
-        await _handle_worker_completion(
-            db,
-            {"task_id": "wt-2", "outcome": "success"},
-            notification_dispatcher=dispatcher,  # type: ignore[arg-type]
-        )
-
-    assert dispatcher.calls == []
-
-
-@pytest.mark.asyncio
-async def test_task_failure_notifies_conversation_owner(
-    db_engine: AsyncEngine,
-) -> None:
-    """A task failed after retries notifies the conversation owner."""
-    clock = SystemClock()
-    async with DatabaseContext(engine=db_engine) as db:
-        await db.message_history.add_message(
-            message=UserMessage(content="run the automation"),
-            interface_type="telegram",
-            conversation_id="chat-9",
-            timestamp=clock.now(),
-            user_id="owner-9",
-        )
-
-    dispatcher = _RecordingDispatcher()
-    worker = TaskWorker(
-        processing_service=MagicMock(),
-        chat_interface=MagicMock(),
-        calendar_config={},
-        timezone=ZoneInfo("UTC"),
-        embedding_generator=MagicMock(),
-        engine=db_engine,
-        notification_dispatcher=dispatcher,  # type: ignore[arg-type]
-    )
-
-    task = cast(
-        "TaskDict",
-        {
-            "task_id": "t-1",
-            "task_type": "script_execution",
-            "payload": {"conversation_id": "chat-9", "interface_type": "telegram"},
-        },
-    )
-    async with DatabaseContext(engine=db_engine) as db:
-        await worker._notify_task_failure(db, task)  # noqa: SLF001
-
-    assert len(dispatcher.calls) == 1
-    user_identifier, title, _ = dispatcher.calls[0]
+    assert len(notifier.calls) == 1
+    user_identifier, title, _ = notifier.calls[0]
     assert user_identifier == "owner-9"
-    assert title == "Task failed"
+    assert title == "Worker task complete"

--- a/tests/functional/test_ios_push_api.py
+++ b/tests/functional/test_ios_push_api.py
@@ -1,0 +1,111 @@
+"""Functional tests for iOS APNs push token API endpoints."""
+
+import httpx
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from family_assistant.storage.ios_push_token import ios_push_tokens_table
+
+
+@pytest.mark.asyncio
+async def test_register_token_creates_row(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+) -> None:
+    """POST /api/ios/push-tokens stores the device token."""
+    response = await api_client.post(
+        "/api/ios/push-tokens",
+        json={
+            "device_token": "abc123",
+            "environment": "sandbox",
+            "bundle_id": "com.example.app",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert "id" in data
+
+    async with db_engine.begin() as conn:  # type: ignore[attr-defined]
+        result = await conn.execute(
+            select(ios_push_tokens_table).where(
+                ios_push_tokens_table.c.id == int(data["id"])
+            )
+        )
+        row = result.fetchone()
+        assert row is not None
+        assert row.device_token == "abc123"
+        assert row.environment == "sandbox"
+        assert row.bundle_id == "com.example.app"
+
+
+@pytest.mark.asyncio
+async def test_register_token_defaults_to_production(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+) -> None:
+    """Environment defaults to production when omitted."""
+    response = await api_client.post(
+        "/api/ios/push-tokens", json={"device_token": "def456"}
+    )
+
+    assert response.status_code == 200
+    async with db_engine.begin() as conn:  # type: ignore[attr-defined]
+        result = await conn.execute(select(ios_push_tokens_table))
+        row = result.fetchone()
+        assert row is not None
+        assert row.environment == "production"
+
+
+@pytest.mark.asyncio
+async def test_register_token_is_idempotent(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+) -> None:
+    """Re-registering the same token updates it rather than duplicating."""
+    await api_client.post(
+        "/api/ios/push-tokens",
+        json={"device_token": "tok", "environment": "production"},
+    )
+    await api_client.post(
+        "/api/ios/push-tokens",
+        json={"device_token": "tok", "environment": "sandbox"},
+    )
+
+    async with db_engine.begin() as conn:  # type: ignore[attr-defined]
+        result = await conn.execute(select(ios_push_tokens_table))
+        rows = result.fetchall()
+        assert len(rows) == 1
+        assert rows[0].environment == "sandbox"
+
+
+@pytest.mark.asyncio
+async def test_unregister_token_removes_row(
+    api_client: httpx.AsyncClient,
+    db_engine: AsyncEngine,
+) -> None:
+    """DELETE /api/ios/push-tokens/{token} removes the token."""
+    await api_client.post(
+        "/api/ios/push-tokens",
+        json={"device_token": "to-delete", "environment": "production"},
+    )
+
+    response = await api_client.delete("/api/ios/push-tokens/to-delete")
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+
+    async with db_engine.begin() as conn:  # type: ignore[attr-defined]
+        result = await conn.execute(select(ios_push_tokens_table))
+        assert result.fetchall() == []
+
+
+@pytest.mark.asyncio
+async def test_unregister_nonexistent_returns_not_found(
+    api_client: httpx.AsyncClient,
+) -> None:
+    """Deleting a token that does not exist returns not_found."""
+    response = await api_client.delete("/api/ios/push-tokens/nope")
+    assert response.status_code == 200
+    assert response.json()["status"] == "not_found"

--- a/tests/functional/test_ios_push_api.py
+++ b/tests/functional/test_ios_push_api.py
@@ -17,7 +17,7 @@ async def test_register_token_creates_row(
     response = await api_client.post(
         "/api/ios/push-tokens",
         json={
-            "device_token": "abc123",
+            "token": "abc123",
             "environment": "sandbox",
             "bundle_id": "com.example.app",
         },
@@ -47,9 +47,7 @@ async def test_register_token_defaults_to_production(
     db_engine: AsyncEngine,
 ) -> None:
     """Environment defaults to production when omitted."""
-    response = await api_client.post(
-        "/api/ios/push-tokens", json={"device_token": "def456"}
-    )
+    response = await api_client.post("/api/ios/push-tokens", json={"token": "def456"})
 
     assert response.status_code == 200
     async with db_engine.begin() as conn:  # type: ignore[attr-defined]
@@ -67,11 +65,11 @@ async def test_register_token_is_idempotent(
     """Re-registering the same token updates it rather than duplicating."""
     await api_client.post(
         "/api/ios/push-tokens",
-        json={"device_token": "tok", "environment": "production"},
+        json={"token": "tok", "environment": "production"},
     )
     await api_client.post(
         "/api/ios/push-tokens",
-        json={"device_token": "tok", "environment": "sandbox"},
+        json={"token": "tok", "environment": "sandbox"},
     )
 
     async with db_engine.begin() as conn:  # type: ignore[attr-defined]
@@ -89,7 +87,7 @@ async def test_unregister_token_removes_row(
     """DELETE /api/ios/push-tokens/{token} removes the token."""
     await api_client.post(
         "/api/ios/push-tokens",
-        json={"device_token": "to-delete", "environment": "production"},
+        json={"token": "to-delete", "environment": "production"},
     )
 
     response = await api_client.delete("/api/ios/push-tokens/to-delete")

--- a/tests/functional/web/ui/test_chat_push_integration.py
+++ b/tests/functional/web/ui/test_chat_push_integration.py
@@ -212,11 +212,13 @@ async def test_web_chat_sends_push_notification_with_user_message(
     send_notification_called = False
     send_notification_args = {}
 
-    async def mock_send_notification(  # noqa: ANN401
+    async def mock_send_notification(
         user_identifier: str,
         title: str,
         body: str,
         db_context: Any,  # noqa: ANN401
+        *,
+        metadata: Any = None,  # noqa: ANN401
     ) -> None:
         nonlocal send_notification_called, send_notification_args
         send_notification_called = True

--- a/tests/functional/web/ui/test_chat_push_integration.py
+++ b/tests/functional/web/ui/test_chat_push_integration.py
@@ -34,13 +34,13 @@ async def test_web_chat_interface_initialized_with_push_service(
     # Act
     chat_interface = WebChatInterface(
         database_engine=db_engine,
-        push_notification_service=service,
+        notifier=service,
     )
 
     # Assert
-    assert chat_interface.push_notification_service is service
-    assert chat_interface.push_notification_service is not None
-    assert chat_interface.push_notification_service.enabled
+    assert chat_interface.notifier is service
+    assert chat_interface.notifier is not None
+    assert chat_interface.notifier.enabled
 
 
 @pytest.mark.asyncio
@@ -51,11 +51,11 @@ async def test_web_chat_accepts_none_push_service(
     # Act
     chat_interface = WebChatInterface(
         database_engine=db_engine,
-        push_notification_service=None,
+        notifier=None,
     )
 
     # Assert
-    assert chat_interface.push_notification_service is None
+    assert chat_interface.notifier is None
 
 
 @pytest.mark.asyncio
@@ -73,7 +73,7 @@ async def test_web_chat_message_saved_successfully(
 
     chat_interface = WebChatInterface(
         database_engine=db_engine,
-        push_notification_service=service,
+        notifier=service,
     )
 
     # Act
@@ -120,7 +120,7 @@ async def test_web_chat_no_notification_when_disabled(
 
     chat_interface = WebChatInterface(
         database_engine=db_engine,
-        push_notification_service=disabled_service,
+        notifier=disabled_service,
     )
 
     # Act
@@ -158,7 +158,7 @@ async def test_web_chat_handles_push_notification_error_gracefully(
 
     chat_interface = WebChatInterface(
         database_engine=db_engine,
-        push_notification_service=failing_service,
+        notifier=failing_service,
     )
 
     # Act
@@ -230,7 +230,7 @@ async def test_web_chat_sends_push_notification_with_user_message(
 
     chat_interface = WebChatInterface(
         database_engine=db_engine,
-        push_notification_service=service,
+        notifier=service,
     )
 
     # Act - send assistant message
@@ -256,7 +256,7 @@ async def test_web_chat_without_push_service(
     # Arrange
     chat_interface = WebChatInterface(
         database_engine=db_engine,
-        push_notification_service=None,
+        notifier=None,
     )
 
     # Act

--- a/tests/unit/services/test_apns_service.py
+++ b/tests/unit/services/test_apns_service.py
@@ -172,6 +172,22 @@ async def test_unregistered_token_is_deleted(db_context: DatabaseContext) -> Non
 
 
 @pytest.mark.asyncio
+async def test_topic_mismatch_keeps_token(db_context: DatabaseContext) -> None:
+    """A DeviceTokenNotForTopic (bundle-id misconfig) must not prune a valid token."""
+    await db_context.ios_push_tokens.upsert(
+        user_identifier="user-1", device_token="tok", environment="production"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"reason": "DeviceTokenNotForTopic"})
+
+    await _service(handler).send_notification("user-1", "t", "b", db_context)
+
+    # Token is preserved so it recovers once the topic/bundle id is fixed.
+    assert len(await db_context.ios_push_tokens.get_by_user("user-1")) == 1
+
+
+@pytest.mark.asyncio
 async def test_bad_device_token_retries_other_environment(
     db_context: DatabaseContext,
 ) -> None:

--- a/tests/unit/services/test_apns_service.py
+++ b/tests/unit/services/test_apns_service.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
 import httpx
 import jwt
@@ -14,7 +15,9 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from family_assistant.services.apns import (
     APNS_HOST_PRODUCTION,
     APNS_HOST_SANDBOX,
+    ApnsAuthKeyError,
     APNsService,
+    load_apns_auth_key,
 )
 from family_assistant.storage.context import DatabaseContext
 
@@ -174,6 +177,29 @@ async def test_bad_device_token_in_both_environments_deletes(
 
 
 @pytest.mark.asyncio
+async def test_bad_device_token_keeps_token_on_transient_retry_failure(
+    db_context: DatabaseContext,
+) -> None:
+    """A transient failure on the environment retry must not delete a valid token."""
+    await db_context.ios_push_tokens.upsert(
+        user_identifier="user-1", device_token="tok", environment="production"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Production rejects as BadDeviceToken; the sandbox retry hits a transient 500.
+        if request.url.host == httpx.URL(APNS_HOST_SANDBOX).host:
+            return httpx.Response(500, json={"reason": "InternalServerError"})
+        return httpx.Response(400, json={"reason": "BadDeviceToken"})
+
+    await _service(handler).send_notification("user-1", "t", "b", db_context)
+
+    # Token is preserved (environment unchanged) for the next send attempt.
+    tokens = await db_context.ios_push_tokens.get_by_user("user-1")
+    assert len(tokens) == 1
+    assert tokens[0].environment == "production"
+
+
+@pytest.mark.asyncio
 async def test_expired_provider_token_refreshes_and_retries(
     db_context: DatabaseContext,
 ) -> None:
@@ -213,3 +239,31 @@ async def test_no_tokens_is_noop(db_context: DatabaseContext) -> None:
 
     await _service(handler).send_notification("nobody", "t", "b", db_context)
     assert called is False
+
+
+def test_load_apns_auth_key_prefers_inline_value(tmp_path: Path) -> None:
+    """An inline auth key is used in preference to a path."""
+    key_file = tmp_path / "key.p8"
+    key_file.write_text("from-file")
+    assert (
+        load_apns_auth_key(auth_key="inline", auth_key_path=str(key_file)) == "inline"
+    )
+
+
+def test_load_apns_auth_key_reads_path(tmp_path: Path) -> None:
+    """A configured path is read when no inline key is provided."""
+    key_file = tmp_path / "key.p8"
+    key_file.write_text("from-file")
+    assert load_apns_auth_key(auth_key=None, auth_key_path=str(key_file)) == "from-file"
+
+
+def test_load_apns_auth_key_none_when_unconfigured() -> None:
+    """No key and no path yields None (APNs simply stays disabled)."""
+    assert load_apns_auth_key(auth_key=None, auth_key_path=None) is None
+
+
+def test_load_apns_auth_key_raises_on_unreadable_path(tmp_path: Path) -> None:
+    """An explicitly configured but unreadable path is a fatal configuration error."""
+    missing = tmp_path / "does-not-exist.p8"
+    with pytest.raises(ApnsAuthKeyError):
+        load_apns_auth_key(auth_key=None, auth_key_path=str(missing))

--- a/tests/unit/services/test_apns_service.py
+++ b/tests/unit/services/test_apns_service.py
@@ -19,6 +19,7 @@ from family_assistant.services.apns import (
     APNsService,
     load_apns_auth_key,
 )
+from family_assistant.services.notifier import NotificationMetadata
 from family_assistant.storage.context import DatabaseContext
 
 
@@ -93,6 +94,38 @@ async def test_sends_alert_with_expected_headers_and_payload(
 
     # Token is still present (not deleted) after a successful send.
     assert len(await db_context.ios_push_tokens.get_by_user("user-1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_metadata_sets_category_and_custom_fields(
+    db_context: DatabaseContext,
+) -> None:
+    """Notification metadata becomes aps.category plus top-level custom userInfo keys."""
+    await db_context.ios_push_tokens.upsert(
+        user_identifier="user-1", device_token="tok", environment="production"
+    )
+
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200)
+
+    metadata = NotificationMetadata(
+        category="FAMILY_ASSISTANT_CONFIRMATION",
+        request_id="confirm_abc",
+        conversation_id="conv-1",
+    )
+    await _service(handler).send_notification(
+        "user-1", "Hi", "There", db_context, metadata=metadata
+    )
+
+    body = json.loads(seen[0].content)
+    assert body["aps"]["category"] == "FAMILY_ASSISTANT_CONFIRMATION"
+    # Custom fields are top-level userInfo keys, not nested under aps.
+    assert body["request_id"] == "confirm_abc"
+    assert body["conversation_id"] == "conv-1"
+    assert "category" not in body
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_apns_service.py
+++ b/tests/unit/services/test_apns_service.py
@@ -1,0 +1,215 @@
+"""Unit tests for APNsService using an injected httpx MockTransport."""
+
+import json
+from collections.abc import AsyncGenerator
+
+import httpx
+import jwt
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from family_assistant.services.apns import (
+    APNS_HOST_PRODUCTION,
+    APNS_HOST_SANDBOX,
+    APNsService,
+)
+from family_assistant.storage.context import DatabaseContext
+
+
+def _make_p8_key() -> str:
+    """Generate a P-256 private key in PEM form, usable as a fake .p8 auth key."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+
+AUTH_KEY = _make_p8_key()
+
+
+@pytest_asyncio.fixture(scope="function")
+async def db_context(db_engine: AsyncEngine) -> AsyncGenerator[DatabaseContext]:
+    """Provides an entered DatabaseContext for APNs tests."""
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        yield db_ctx
+
+
+def _service(handler: object, **kwargs: object) -> APNsService:
+    """Build an APNsService backed by a MockTransport handler."""
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))  # type: ignore[arg-type]
+    return APNsService(
+        team_id="TEAM123",
+        key_id="KEY456",
+        auth_key=AUTH_KEY,
+        bundle_id="com.example.app",
+        client=client,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_unconfigured() -> None:
+    """The service reports disabled when required settings are missing."""
+    service = APNsService(team_id=None, key_id=None, auth_key=None, bundle_id=None)
+    assert service.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_sends_alert_with_expected_headers_and_payload(
+    db_context: DatabaseContext,
+) -> None:
+    """A configured token receives an alert push with the correct APNs headers."""
+    await db_context.ios_push_tokens.upsert(
+        user_identifier="user-1",
+        device_token="tok-prod",
+        environment="production",
+    )
+
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200)
+
+    service = _service(handler)
+    await service.send_notification("user-1", "Hi", "There", db_context)
+
+    assert len(seen) == 1
+    request = seen[0]
+    assert str(request.url) == f"{APNS_HOST_PRODUCTION}/3/device/tok-prod"
+    assert request.headers["apns-topic"] == "com.example.app"
+    assert request.headers["apns-push-type"] == "alert"
+    assert request.headers["authorization"].startswith("bearer ")
+    body = json.loads(request.content)
+    assert body["aps"]["alert"] == {"title": "Hi", "body": "There"}
+
+    # Token is still present (not deleted) after a successful send.
+    assert len(await db_context.ios_push_tokens.get_by_user("user-1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_signs_provider_token_with_team_and_key(
+    db_context: DatabaseContext,
+) -> None:
+    """The Authorization bearer is an ES256 JWT carrying the team id and key id."""
+    await db_context.ios_push_tokens.upsert(
+        user_identifier="user-1", device_token="tok", environment="production"
+    )
+
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["auth"] = request.headers["authorization"]
+        return httpx.Response(200)
+
+    await _service(handler).send_notification("user-1", "t", "b", db_context)
+
+    token = captured["auth"].removeprefix("bearer ")
+    header = jwt.get_unverified_header(token)
+    assert header["kid"] == "KEY456"
+    assert header["alg"] == "ES256"
+    # Verify the signature with the public key derived from AUTH_KEY.
+    private_key = serialization.load_pem_private_key(AUTH_KEY.encode(), password=None)
+    assert isinstance(private_key, ec.EllipticCurvePrivateKey)
+    decoded = jwt.decode(token, private_key.public_key(), algorithms=["ES256"])
+    assert decoded["iss"] == "TEAM123"
+
+
+@pytest.mark.asyncio
+async def test_unregistered_token_is_deleted(db_context: DatabaseContext) -> None:
+    """A 410 Unregistered response prunes the device token."""
+    await db_context.ios_push_tokens.upsert(
+        user_identifier="user-1", device_token="dead", environment="production"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(410, json={"reason": "Unregistered"})
+
+    await _service(handler).send_notification("user-1", "t", "b", db_context)
+
+    assert await db_context.ios_push_tokens.get_by_user("user-1") == []
+
+
+@pytest.mark.asyncio
+async def test_bad_device_token_retries_other_environment(
+    db_context: DatabaseContext,
+) -> None:
+    """A BadDeviceToken on production succeeds on sandbox and updates the stored environment."""
+    await db_context.ios_push_tokens.upsert(
+        user_identifier="user-1", device_token="tok", environment="production"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == httpx.URL(APNS_HOST_SANDBOX).host:
+            return httpx.Response(200)
+        return httpx.Response(400, json={"reason": "BadDeviceToken"})
+
+    await _service(handler).send_notification("user-1", "t", "b", db_context)
+
+    tokens = await db_context.ios_push_tokens.get_by_user("user-1")
+    assert len(tokens) == 1
+    assert tokens[0].environment == "sandbox"
+
+
+@pytest.mark.asyncio
+async def test_bad_device_token_in_both_environments_deletes(
+    db_context: DatabaseContext,
+) -> None:
+    """A BadDeviceToken in both environments prunes the token."""
+    await db_context.ios_push_tokens.upsert(
+        user_identifier="user-1", device_token="tok", environment="production"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"reason": "BadDeviceToken"})
+
+    await _service(handler).send_notification("user-1", "t", "b", db_context)
+
+    assert await db_context.ios_push_tokens.get_by_user("user-1") == []
+
+
+@pytest.mark.asyncio
+async def test_expired_provider_token_refreshes_and_retries(
+    db_context: DatabaseContext,
+) -> None:
+    """A 403 ExpiredProviderToken triggers a JWT refresh and a successful retry."""
+    await db_context.ios_push_tokens.upsert(
+        user_identifier="user-1", device_token="tok", environment="production"
+    )
+
+    attempts: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(request.headers["authorization"])
+        if len(attempts) == 1:
+            return httpx.Response(403, json={"reason": "ExpiredProviderToken"})
+        return httpx.Response(200)
+
+    # Distinct issue times so the refreshed token differs from the first.
+    times = iter([1000.0, 1000.0, 5000.0, 5000.0, 5000.0])
+    service = _service(handler, time_fn=lambda: next(times))
+    await service.send_notification("user-1", "t", "b", db_context)
+
+    assert len(attempts) == 2
+    assert attempts[0] != attempts[1]
+    # Token retained after a successful retry.
+    assert len(await db_context.ios_push_tokens.get_by_user("user-1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_tokens_is_noop(db_context: DatabaseContext) -> None:
+    """Sending to a user with no tokens does not raise or call the transport."""
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200)
+
+    await _service(handler).send_notification("nobody", "t", "b", db_context)
+    assert called is False

--- a/tests/unit/services/test_notification_dispatcher.py
+++ b/tests/unit/services/test_notification_dispatcher.py
@@ -1,10 +1,10 @@
 """Unit tests for NotificationDispatcher fan-out behavior."""
 
-from typing import Any
-
 import pytest
 
 from family_assistant.services.notification_dispatcher import NotificationDispatcher
+from family_assistant.services.notifier import NotificationMetadata
+from family_assistant.storage.context import DatabaseContext
 
 
 class _FakeChannel:
@@ -14,15 +14,19 @@ class _FakeChannel:
         self.enabled = enabled
         self.fail = fail
         self.calls: list[tuple[str, str, str]] = []
+        self.metadata: list[NotificationMetadata | None] = []
 
     async def send_notification(
         self,
         user_identifier: str,
         title: str,
         body: str,
-        db_context: Any,  # noqa: ANN401
+        db_context: DatabaseContext,
+        *,
+        metadata: NotificationMetadata | None = None,
     ) -> None:
         self.calls.append((user_identifier, title, body))
+        self.metadata.append(metadata)
         if self.fail:
             raise RuntimeError("channel down")
 

--- a/tests/unit/services/test_notification_dispatcher.py
+++ b/tests/unit/services/test_notification_dispatcher.py
@@ -1,0 +1,78 @@
+"""Unit tests for NotificationDispatcher fan-out behavior."""
+
+from typing import Any
+
+import pytest
+
+from family_assistant.services.notification_dispatcher import NotificationDispatcher
+
+
+class _FakeChannel:
+    """Minimal stand-in matching the notification service interface."""
+
+    def __init__(self, *, enabled: bool, fail: bool = False) -> None:
+        self.enabled = enabled
+        self.fail = fail
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def send_notification(
+        self,
+        user_identifier: str,
+        title: str,
+        body: str,
+        db_context: Any,  # noqa: ANN401
+    ) -> None:
+        self.calls.append((user_identifier, title, body))
+        if self.fail:
+            raise RuntimeError("channel down")
+
+
+@pytest.mark.asyncio
+async def test_enabled_reflects_any_channel() -> None:
+    """The dispatcher is enabled when any underlying channel is enabled."""
+    assert NotificationDispatcher().enabled is False
+    assert (
+        NotificationDispatcher(web_push=_FakeChannel(enabled=False)).enabled is False  # type: ignore[arg-type]
+    )
+    assert (
+        NotificationDispatcher(apns=_FakeChannel(enabled=True)).enabled is True  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.asyncio
+async def test_fans_out_to_all_enabled_channels() -> None:
+    """A notification reaches every enabled channel."""
+    web = _FakeChannel(enabled=True)
+    apns = _FakeChannel(enabled=True)
+    dispatcher = NotificationDispatcher(web_push=web, apns=apns)  # type: ignore[arg-type]
+
+    await dispatcher.send_notification("user-1", "Title", "Body", db_context=None)  # type: ignore[arg-type]
+
+    assert web.calls == [("user-1", "Title", "Body")]
+    assert apns.calls == [("user-1", "Title", "Body")]
+
+
+@pytest.mark.asyncio
+async def test_skips_disabled_channels() -> None:
+    """Disabled channels are not invoked."""
+    web = _FakeChannel(enabled=False)
+    apns = _FakeChannel(enabled=True)
+    dispatcher = NotificationDispatcher(web_push=web, apns=apns)  # type: ignore[arg-type]
+
+    await dispatcher.send_notification("user-1", "Title", "Body", db_context=None)  # type: ignore[arg-type]
+
+    assert web.calls == []
+    assert apns.calls == [("user-1", "Title", "Body")]
+
+
+@pytest.mark.asyncio
+async def test_one_channel_failure_does_not_block_others() -> None:
+    """A failing channel is isolated and does not prevent other deliveries."""
+    web = _FakeChannel(enabled=True, fail=True)
+    apns = _FakeChannel(enabled=True)
+    dispatcher = NotificationDispatcher(web_push=web, apns=apns)  # type: ignore[arg-type]
+
+    # Should not raise despite the web channel failing.
+    await dispatcher.send_notification("user-1", "Title", "Body", db_context=None)  # type: ignore[arg-type]
+
+    assert apns.calls == [("user-1", "Title", "Body")]

--- a/tests/unit/services/test_push_notification_service.py
+++ b/tests/unit/services/test_push_notification_service.py
@@ -8,6 +8,7 @@ import pytest
 from pywebpush import WebPushException
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from family_assistant.services.notifier import NotificationMetadata
 from family_assistant.services.push_notification import PushNotificationService
 from family_assistant.storage.context import DatabaseContext
 
@@ -77,6 +78,41 @@ async def test_send_notification_success(
         sent_payload = json.loads(call_args.kwargs["data"])
         assert sent_payload["title"] == "Test Title"
         assert sent_payload["body"] == "Test Body"
+
+
+@pytest.mark.asyncio
+@patch("family_assistant.services.push_notification.webpush", autospec=True)
+async def test_send_notification_serializes_metadata_for_service_worker(
+    mock_webpush: MagicMock, db_engine: AsyncEngine
+) -> None:
+    """Metadata is delivered under data using the service worker's camelCase keys."""
+    async with DatabaseContext(engine=db_engine) as db_context:
+        await db_context.push_subscriptions.add(
+            user_identifier="user1",
+            subscription_json={
+                "endpoint": "https://example.com/push",
+                "keys": {"p256dh": "key", "auth": "auth_key"},
+            },
+        )
+
+        service = PushNotificationService(
+            vapid_private_key=TEST_PRIVATE_KEY, vapid_contact_email=TEST_CONTACT_EMAIL
+        )
+        await service.send_notification(
+            "user1",
+            "Title",
+            "Body",
+            db_context,
+            metadata=NotificationMetadata(
+                category="FAMILY_ASSISTANT_MESSAGE", conversation_id="conv-1"
+            ),
+        )
+
+        sent_payload = json.loads(mock_webpush.call_args.kwargs["data"])
+        # The PWA service worker reads data.conversationId.
+        assert sent_payload["data"]["conversationId"] == "conv-1"
+        assert sent_payload["data"]["category"] == "FAMILY_ASSISTANT_MESSAGE"
+        assert "conversation_id" not in sent_payload["data"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/storage/test_ios_push_token_repository.py
+++ b/tests/unit/storage/test_ios_push_token_repository.py
@@ -1,0 +1,96 @@
+"""Unit tests for IosPushTokenRepository."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from family_assistant.storage.context import DatabaseContext
+
+
+@pytest_asyncio.fixture(scope="function")
+async def db_context(db_engine: AsyncEngine) -> AsyncGenerator[DatabaseContext]:
+    """Provides an entered DatabaseContext for repository tests."""
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        yield db_ctx
+
+
+class TestIosPushTokenRepository:
+    """Tests for IosPushTokenRepository operations."""
+
+    @pytest.mark.asyncio
+    async def test_upsert_and_get_by_user(self, db_context: DatabaseContext) -> None:
+        """A registered token can be retrieved for its owner."""
+        token_id = await db_context.ios_push_tokens.upsert(
+            user_identifier="user-1",
+            device_token="abc123",
+            environment="sandbox",
+            bundle_id="com.example.app",
+        )
+        assert token_id is not None
+
+        tokens = await db_context.ios_push_tokens.get_by_user("user-1")
+        assert len(tokens) == 1
+        assert tokens[0].device_token == "abc123"
+        assert tokens[0].environment == "sandbox"
+        assert tokens[0].bundle_id == "com.example.app"
+
+    @pytest.mark.asyncio
+    async def test_upsert_is_idempotent_on_token(
+        self, db_context: DatabaseContext
+    ) -> None:
+        """Re-registering the same token updates it instead of duplicating."""
+        await db_context.ios_push_tokens.upsert(
+            user_identifier="user-1",
+            device_token="abc123",
+            environment="sandbox",
+        )
+        await db_context.ios_push_tokens.upsert(
+            user_identifier="user-2",
+            device_token="abc123",
+            environment="production",
+            bundle_id="com.example.app",
+        )
+
+        # Token moved to the new owner; old owner has none.
+        assert await db_context.ios_push_tokens.get_by_user("user-1") == []
+        tokens = await db_context.ios_push_tokens.get_by_user("user-2")
+        assert len(tokens) == 1
+        assert tokens[0].environment == "production"
+        assert tokens[0].bundle_id == "com.example.app"
+
+    @pytest.mark.asyncio
+    async def test_delete_for_user_scoped_to_owner(
+        self, db_context: DatabaseContext
+    ) -> None:
+        """A user can only delete their own token."""
+        await db_context.ios_push_tokens.upsert(
+            user_identifier="user-1",
+            device_token="abc123",
+            environment="production",
+        )
+
+        # Wrong user cannot delete it.
+        assert await db_context.ios_push_tokens.delete_for_user("user-2", "abc123") == 0
+        # Owner can.
+        assert await db_context.ios_push_tokens.delete_for_user("user-1", "abc123") == 1
+        assert await db_context.ios_push_tokens.get_by_user("user-1") == []
+
+    @pytest.mark.asyncio
+    async def test_delete_by_token_and_update_environment(
+        self, db_context: DatabaseContext
+    ) -> None:
+        """APNs cleanup helpers operate by token regardless of owner."""
+        await db_context.ios_push_tokens.upsert(
+            user_identifier="user-1",
+            device_token="abc123",
+            environment="production",
+        )
+
+        await db_context.ios_push_tokens.update_environment("abc123", "sandbox")
+        tokens = await db_context.ios_push_tokens.get_by_user("user-1")
+        assert tokens[0].environment == "sandbox"
+
+        assert await db_context.ios_push_tokens.delete_by_token("abc123") == 1
+        assert await db_context.ios_push_tokens.get_by_user("user-1") == []

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -486,6 +486,25 @@ class TestApplyEnvVarOverrides:
             apply_env_var_overrides(config)
         assert config["pwa_config"]["vapid_public_key"] == "test-key"
 
+    def test_applies_apns_env_vars(self) -> None:
+        """APNs configuration is populated from environment variables."""
+        config: dict[str, Any] = {"apns": {}}
+        with mock.patch.dict(
+            os.environ,
+            {
+                "APNS_TEAM_ID": "TEAM123",
+                "APNS_KEY_ID": "KEY456",
+                "APNS_BUNDLE_ID": "com.example.app",
+                "APNS_USE_SANDBOX": "true",
+            },
+            clear=False,
+        ):
+            apply_env_var_overrides(config)
+        assert config["apns"]["team_id"] == "TEAM123"
+        assert config["apns"]["key_id"] == "KEY456"
+        assert config["apns"]["bundle_id"] == "com.example.app"
+        assert config["apns"]["use_sandbox"] is True
+
     def test_applies_int_env_var(self) -> None:
         """Test applying an integer environment variable."""
         config: dict[str, Any] = {"embedding_dimensions": 768}

--- a/uv.lock
+++ b/uv.lock
@@ -1726,6 +1726,7 @@ dependencies = [
     { name = "filetype" },
     { name = "genson" },
     { name = "google-genai" },
+    { name = "h2" },
     { name = "homeassistant-api" },
     { name = "httpx" },
     { name = "icalendar" },
@@ -1759,6 +1760,7 @@ dependencies = [
     { name = "pycares" },
     { name = "pydantic-monty" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pyspf" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
@@ -1878,6 +1880,7 @@ requires-dist = [
     { name = "filetype", specifier = ">=1.2.0" },
     { name = "genson", specifier = ">=1.3.0" },
     { name = "google-genai", specifier = ">=1.0.0" },
+    { name = "h2", specifier = ">=4.3.0" },
     { name = "homeassistant", marker = "extra == 'dev'", specifier = ">=2025.4.4" },
     { name = "homeassistant-api", specifier = ">=5.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
@@ -1930,6 +1933,7 @@ requires-dist = [
     { name = "pycares", specifier = ">=4.4.0,<5.0.0" },
     { name = "pydantic-monty", specifier = ">=0.0.17" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
     { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pyspf", specifier = ">=2.0.14" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -2297,6 +2301,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
 ]
 
 [[package]]
@@ -2729,6 +2746,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
 name = "http-ece"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2831,6 +2857,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/e6/bb064537288eee2be97f3e0fcad8e7242bc5bbe9664ae57c7d29b3fa18c2/hupper-1.12.1.tar.gz", hash = "sha256:06bf54170ff4ecf4c84ad5f188dee3901173ab449c2608ad05b9bfd6b13e32eb", size = 43231, upload-time = "2024-01-26T09:14:57.294Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/7d/3888833e4f5ea56af4a9935066ec09a83228e533d7b8877f65889d706ee4/hupper-1.12.1-py3-none-any.whl", hash = "sha256:e872b959f09d90be5fb615bd2e62de89a0b57efc037bdf9637fb09cdf8552b19", size = 22830, upload-time = "2024-01-26T09:14:55.176Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add the ios_push_tokens table, repository, DatabaseContext property and
Alembic migration for storing APNs device tokens, plus an ApnsConfig
section with environment variable wiring and secret redaction.

Includes a design doc describing the full iOS push integration.