### PR TITLE
Stabilize frontend chat tests

### DIFF
--- a/frontend/src/chat/ToolGroup.tsx
+++ b/frontend/src/chat/ToolGroup.tsx
@@ -31,9 +31,11 @@ const DEFAULT_TOOL_GROUP_STATE: ToolGroupState = {
 
 // Hook to safely access message state with fallback
 function useSafeToolGroupState(startIndex: number, endIndex: number): ToolGroupState {
+  let serializedState: string | null = null;
+
   try {
-    const serializedState = useAuiState((s) => {
-      const parts = s.message.parts;
+    serializedState = useAuiState((state) => {
+      const parts = state.message.parts;
       const toolNames: string[] = [];
       const toolCallIds: string[] = [];
       let hasUnfinishedTool = false;
@@ -52,12 +54,21 @@ function useSafeToolGroupState(startIndex: number, endIndex: number): ToolGroupS
 
       return JSON.stringify({ toolNames, toolCallIds, hasUnfinishedTool });
     });
-
-    return useMemo(() => JSON.parse(serializedState) as ToolGroupState, [serializedState]);
   } catch {
-    // Fallback when message context is not available (e.g., in tests)
-    return DEFAULT_TOOL_GROUP_STATE;
+    serializedState = null;
   }
+
+  return useMemo(() => {
+    if (!serializedState) {
+      return DEFAULT_TOOL_GROUP_STATE;
+    }
+
+    try {
+      return JSON.parse(serializedState) as ToolGroupState;
+    } catch {
+      return DEFAULT_TOOL_GROUP_STATE;
+    }
+  }, [serializedState]);
 }
 
 const ToolGroup: React.FC<ToolGroupProps> = ({ startIndex, endIndex, children }) => {

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import './mocks/localStorageMock';
 import { afterEach, afterAll, beforeAll } from 'vitest';
 import { setupServer } from 'msw/node';
 import { handlers } from './mocks/handlers';
@@ -6,11 +7,24 @@ import { handlers } from './mocks/handlers';
 // Set up MSW server
 export const server = setupServer(...handlers);
 
+let originalFetch;
+
 // Start server before all tests
 beforeAll(() => {
   server.listen({
     onUnhandledRequest: 'warn', // Log unhandled requests during development
   });
+
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = (input, init) => {
+    if (init && 'signal' in init) {
+      const sanitizedInit = { ...init };
+      delete sanitizedInit.signal;
+      return originalFetch(input, sanitizedInit);
+    }
+
+    return originalFetch(input, init);
+  };
 });
 
 // Reset handlers after each test (RTL auto-cleanup handles component unmount)
@@ -20,6 +34,7 @@ afterEach(() => {
 
 // Stop server after all tests
 afterAll(() => {
+  globalThis.fetch = originalFetch;
   server.close();
 });
 

--- a/tests/functional/web/pages/chat_page.py
+++ b/tests/functional/web/pages/chat_page.py
@@ -100,6 +100,10 @@ class ChatPage(BasePage):
         # Use locator API to avoid stale element references
         chat_input = self.page.locator(self.CHAT_INPUT)
         await chat_input.wait_for(state="visible", timeout=10000)
+        await expect(chat_input).to_be_enabled(timeout=10000)
+
+        send_button = self.page.locator(self.SEND_BUTTON)
+        await expect(send_button).to_be_enabled(timeout=10000)
 
         # Focus the input
         await chat_input.click()

--- a/tests/unit/test_app_config_storage_path.py
+++ b/tests/unit/test_app_config_storage_path.py
@@ -110,4 +110,5 @@ def test_relative_path_without_yaml_context_falls_back_to_cwd() -> None:
     with tempfile.TemporaryDirectory() as fallback_cwd, _cwd(Path(fallback_cwd)):
         cfg = AppConfig(attachment_storage_path="./relative-fallback")
 
-    assert cfg.attachment_storage_path == str(Path(fallback_cwd) / "relative-fallback")
+    expected = (Path(fallback_cwd) / "relative-fallback").resolve()
+    assert Path(cfg.attachment_storage_path) == expected


### PR DESCRIPTION
## Summary

- Restore `ToolGroup` to the assistant-ui store shape used by the upstream message grouping primitive while preserving the isolated-test fallback.
- Make the frontend test setup install the localStorage mock before MSW and sanitize jsdom `RequestInit.signal` before requests reach the Node/MSW fetch layer.
- Tighten chat Playwright sends by waiting for the composer and send button to be enabled before typing.
- Compare resolved paths in the macOS `/var` vs `/private/var` storage-path regression assertion.

## Validation

- `npm run test --prefix frontend -- --run src/chat/__tests__/ToolGroup.test.tsx src/chat/__tests__/StreamingAndToolCall.test.tsx` passed.
- Focused pytest reruns around the UI chat cases still hit the existing flaky retry/failure path before this was published at your request.

This is separate from the native iOS notification client PR so that the iOS review stays focused.