### PR TITLE
ci: run iOS unit tests on macOS when ios/ changes

### DIFF
--- a/.github/workflows/ci-with-devcontainer.yml
+++ b/.github/workflows/ci-with-devcontainer.yml
@@ -55,6 +55,7 @@ jobs:
             has_code_changes:
               - '!docs/**'
               - '!*.md'
+              - '!ios/**'
               - '!.claude/**'
               - '!.serena/**'
               - '!.ast-grep/**'

--- a/.github/workflows/ci-with-devcontainer.yml
+++ b/.github/workflows/ci-with-devcontainer.yml
@@ -31,7 +31,7 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      has_code_changes: ${{ steps.filter.outputs.has_code_changes }}
+      has_code_changes: ${{ steps.code_changes.outputs.has_code_changes }}
       ast_grep_changes: ${{ steps.filter.outputs.ast_grep_changes }}
       frontend_source: ${{ steps.filter.outputs.frontend_source }}
       frontend_tests: ${{ steps.filter.outputs.frontend_tests }}
@@ -46,12 +46,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Detect changed paths
+      - name: Detect code changes
         uses: dorny/paths-filter@v4
-        id: filter
+        id: code_changes
         with:
+          # A file counts as a code change only when it falls outside *every*
+          # exclusion below. This requires predicate-quantifier: every -- with
+          # the default 'some', an all-negated list matches as soon as a file
+          # fails any single negation (e.g. an ios/ file still matches
+          # '!docs/**'), so the exclusions would never gate anything.
+          predicate-quantifier: every
           filters: |
-            # Detect if there are any code changes (anything NOT in the docs-only list)
             has_code_changes:
               - '!docs/**'
               - '!*.md'
@@ -61,6 +66,7 @@ jobs:
               - '!.ast-grep/**'
               - '!.github/workflows/gemini-*.yml'
               - '!.github/workflows/build-containers.yml'
+              - '!.github/workflows/ios-tests.yml'
               - '!.github/dependabot.yml'
               - '!.devcontainer/claude-wrapper.sh'
               - '!.devcontainer/throttle_backspaces.py'
@@ -78,6 +84,11 @@ jobs:
               - '!.mcp.json'
               - '!mcp_config.dev.json'
               - '!.build'
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
             ast_grep_changes:
               - '.ast-grep/**'
             frontend_source:

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -17,10 +17,10 @@ permissions:
   contents: read
 jobs:
   test:
-    # Pinned to macos-15 (Apple Silicon, Xcode 16.x) for a reproducible
-    # toolchain + simulator set. macos-latest is a moving target that has
-    # already advanced to macOS 26 / Xcode 26.x. Bump deliberately when ready.
-    runs-on: macos-15
+    # macos-26 (Apple Silicon, Xcode 26.x) is the current GA image. The exact
+    # simulator lineup changes with each Xcode release, so the simulator is
+    # resolved dynamically below rather than hardcoded to a device name.
+    runs-on: macos-26
     timeout-minutes: 30
     defaults:
       run:
@@ -32,13 +32,33 @@ jobs:
         run: |
           xcodebuild -version
           xcrun simctl list devices available
+      - name: Select iOS simulator
+        id: sim
+        run: |
+          UDID=$(xcrun simctl list devices available --json | python3 -c "
+          import json, sys
+          devices = json.load(sys.stdin)['devices']
+          candidates = [
+              device
+              for runtime, devs in devices.items()
+              if 'iOS' in runtime
+              for device in devs
+              if device.get('isAvailable') and device['name'].startswith('iPhone')
+          ]
+          print(candidates[0]['udid'] if candidates else '')
+          ")
+          if [ -z "$UDID" ]; then
+            echo "No available iPhone simulator found" >&2
+            exit 1
+          fi
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
       - name: Run unit tests
         run: |
           set -o pipefail
           xcodebuild test \
             -project FamilyAssistant.xcodeproj \
             -scheme FamilyAssistant \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO
       - name: Upload test results

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -1,0 +1,51 @@
+name: iOS Tests
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-tests.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ios/**'
+      - '.github/workflows/ios-tests.yml'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  test:
+    # Pinned to macos-15 (Apple Silicon, Xcode 16.x) for a reproducible
+    # toolchain + simulator set. macos-latest is a moving target that has
+    # already advanced to macOS 26 / Xcode 26.x. Bump deliberately when ready.
+    runs-on: macos-15
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ios/FamilyAssistant
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Show toolchain
+        run: |
+          xcodebuild -version
+          xcrun simctl list devices available
+      - name: Run unit tests
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project FamilyAssistant.xcodeproj \
+            -scheme FamilyAssistant \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -resultBundlePath TestResults.xcresult \
+            CODE_SIGNING_ALLOWED=NO
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: ios-test-results-${{ github.run_id }}
+          path: ios/FamilyAssistant/TestResults.xcresult
+          retention-days: 7
+          if-no-files-found: ignore

--- a/ios/FamilyAssistant/README.md
+++ b/ios/FamilyAssistant/README.md
@@ -186,14 +186,15 @@ xcodebuild -project FamilyAssistant.xcodeproj \
 
 The `iOS Tests` GitHub Actions workflow (`.github/workflows/ios-tests.yml`) runs the
 `FamilyAssistantTests` unit tests on every push and pull request that touches `ios/**`. It builds
-the `FamilyAssistant` scheme on a `macos-15` runner (Apple Silicon, Xcode 16.x) against an iOS
-Simulator with code signing disabled:
+the `FamilyAssistant` scheme on a `macos-26` runner (Apple Silicon, Xcode 26.x) against an iOS
+Simulator with code signing disabled. The workflow resolves an available iPhone simulator
+dynamically (the device lineup changes between Xcode releases), so the effective command is roughly:
 
 ```bash
 xcodebuild test \
   -project FamilyAssistant.xcodeproj \
   -scheme FamilyAssistant \
-  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  -destination "platform=iOS Simulator,id=<resolved-iphone-simulator-udid>" \
   CODE_SIGNING_ALLOWED=NO
 ```
 

--- a/ios/FamilyAssistant/README.md
+++ b/ios/FamilyAssistant/README.md
@@ -182,6 +182,24 @@ xcodebuild -project FamilyAssistant.xcodeproj \
 # build/Debug-iphonesimulator/FamilyAssistant.app
 ```
 
+## Continuous Integration
+
+The `iOS Tests` GitHub Actions workflow (`.github/workflows/ios-tests.yml`) runs the
+`FamilyAssistantTests` unit tests on every push and pull request that touches `ios/**`. It builds
+the `FamilyAssistant` scheme on a `macos-15` runner (Apple Silicon, Xcode 16.x) against an iOS
+Simulator with code signing disabled:
+
+```bash
+xcodebuild test \
+  -project FamilyAssistant.xcodeproj \
+  -scheme FamilyAssistant \
+  -destination 'platform=iOS Simulator,name=iPhone 16' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Changes outside `ios/**` do not trigger this workflow, and iOS-only changes are excluded from the
+Linux devcontainer CI so the two suites stay independent.
+
 ## Local Development
 
 To test against a local server over HTTP, the app's Info.plist includes


### PR DESCRIPTION
Add a dedicated 'iOS Tests' GitHub Actions workflow that builds the
FamilyAssistant scheme and runs the FamilyAssistantTests XCTest suite on a
macos-15 runner, triggered only on push/PR that touch ios/**. Exclude ios/**
from the Linux devcontainer CI's change detection so the two suites stay
independent, and document the workflow in the iOS README.