### PR TITLE
Fix macOS test runner environment

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/clean-dist.mjs",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint .",

--- a/frontend/scripts/clean-dist.mjs
+++ b/frontend/scripts/clean-dist.mjs
@@ -1,0 +1,14 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(scriptDir, '../../src/family_assistant/static/dist');
+
+rmSync(distDir, {
+  force: true,
+  maxRetries: 5,
+  recursive: true,
+  retryDelay: 200,
+});
+mkdirSync(distDir, { recursive: true });

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -11,6 +11,16 @@ beforeAll(() => {
   server.listen({
     onUnhandledRequest: 'warn', // Log unhandled requests during development
   });
+
+  // Node's fetch rejects jsdom AbortSignal instances before MSW can handle the request.
+  const mswFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = (input, init) => {
+    if (init?.signal) {
+      const { signal: _signal, ...initWithoutSignal } = init;
+      return mswFetch(input, initWithoutSignal);
+    }
+    return mswFetch(input, init);
+  };
 });
 
 // Reset handlers after each test (RTL auto-cleanup handles component unmount)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -123,8 +123,8 @@ export default defineConfig(({ mode }) => ({
     manifest: true,
     // Output assets to the existing static directory structure
     outDir: path.resolve(__dirname, '../src/family_assistant/static/dist'),
-    // Empty the output directory on each build
-    emptyOutDir: true,
+    // The npm prebuild script cleans this directory with retries for macOS shared volumes.
+    emptyOutDir: false,
     // Increase chunk size warning limit since we're code splitting
     chunkSizeWarningLimit: 600,
     rollupOptions: {

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -12,6 +12,8 @@ SUMMARY_FILE=".poe-test-summary.txt"
 # Track all background processes for cleanup
 BACKGROUND_PIDS=()
 CLEANUP_RUNNING=0
+LOCK_DIR_ACQUIRED=0
+LOCK_DIR=""
 
 # Cleanup function - kills all background processes
 cleanup() {
@@ -23,23 +25,32 @@ cleanup() {
     fi
     CLEANUP_RUNNING=1
 
-    # If we have background processes, clean them up
-    if [ ${#BACKGROUND_PIDS[@]} -gt 0 ]; then
+    if [ "$LOCK_DIR_ACQUIRED" -eq 1 ] && [ -n "$LOCK_DIR" ]; then
+        rm -rf "$LOCK_DIR"
+    fi
+
+    # If we have live background processes, clean them up
+    local live_pids=()
+    for pid in "${BACKGROUND_PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            live_pids+=("$pid")
+        fi
+    done
+
+    if [ ${#live_pids[@]} -gt 0 ]; then
         echo ""
         echo "${YELLOW}⚠️  Interrupted - cleaning up background processes...${NC}" >&2
 
         # Send SIGTERM to all background processes
-        for pid in "${BACKGROUND_PIDS[@]}"; do
-            if kill -0 "$pid" 2>/dev/null; then
-                kill "$pid" 2>/dev/null || true
-            fi
+        for pid in "${live_pids[@]}"; do
+            kill "$pid" 2>/dev/null || true
         done
 
         # Wait up to 3 seconds for graceful shutdown
         local wait_count=0
         while [ "$wait_count" -lt 30 ]; do
             local any_alive=0
-            for pid in "${BACKGROUND_PIDS[@]}"; do
+            for pid in "${live_pids[@]}"; do
                 if kill -0 "$pid" 2>/dev/null; then
                     # Check if process is a zombie
                     local state
@@ -60,7 +71,7 @@ cleanup() {
         done
 
         # Force kill any remaining processes
-        for pid in "${BACKGROUND_PIDS[@]}"; do
+        for pid in "${live_pids[@]}"; do
             if kill -0 "$pid" 2>/dev/null; then
                 echo "${YELLOW}  Force killing process $pid${NC}" >&2
                 kill -9 "$pid" 2>/dev/null || true
@@ -218,10 +229,30 @@ echo "${GREEN}✓ Dependencies are up to date${NC}"
 
 # Acquire exclusive lock to prevent concurrent test runs
 LOCK_FILE="$HOME/.poe-test.lock"
-exec 200>"$LOCK_FILE"
+LOCK_DIR="$LOCK_FILE.dir"
 
 echo "${BLUE}Acquiring test lock...${NC}"
-if ! flock --exclusive --timeout 300 200; then
+if command -v flock >/dev/null 2>&1; then
+    exec 200>"$LOCK_FILE"
+    lock_acquired=0
+    if flock --exclusive --timeout 300 200; then
+        lock_acquired=1
+    fi
+else
+    lock_acquired=0
+    lock_wait_start=$(date +%s)
+    while [ $(( $(date +%s) - lock_wait_start )) -lt 300 ]; do
+        if mkdir "$LOCK_DIR" 2>/dev/null; then
+            LOCK_DIR_ACQUIRED=1
+            printf '%s\n' "$$" > "$LOCK_DIR/pid"
+            lock_acquired=1
+            break
+        fi
+        sleep 1
+    done
+fi
+
+if [ "$lock_acquired" -ne 1 ]; then
     echo "${RED}❌ Error: Could not acquire lock after waiting 5 minutes.${NC}" >&2
     echo "${YELLOW}Tests are currently running in another process.${NC}" >&2
     echo "${YELLOW}  Lock file: $LOCK_FILE${NC}" >&2
@@ -233,6 +264,12 @@ if ! flock --exclusive --timeout 300 200; then
             echo "${YELLOW}  Process holding lock: PID $LOCK_HOLDER${NC}" >&2
             ps -p "$LOCK_HOLDER" -o pid,cmd 2>/dev/null | grep -v "PID CMD" | sed "s/^/${YELLOW}    /" | sed "s/$/${NC}/" >&2
         fi
+    fi
+
+    if [ -f "$LOCK_DIR/pid" ]; then
+        LOCK_HOLDER=$(cat "$LOCK_DIR/pid")
+        echo "${YELLOW}  Process holding fallback lock: PID $LOCK_HOLDER${NC}" >&2
+        ps -p "$LOCK_HOLDER" -o pid,cmd 2>/dev/null | grep -v "PID CMD" | sed "s/^/${YELLOW}    /" | sed "s/$/${NC}/" >&2
     fi
 
     echo "" >&2

--- a/scripts/run_pytest_adaptive.py
+++ b/scripts/run_pytest_adaptive.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -271,9 +272,12 @@ def main() -> int:
         shard_reports_dir.mkdir()
         env["PYTEST_ADAPTIVE_SHARD_REPORT_DIR"] = str(shard_reports_dir)
 
-    limit_command = (
-        f"{sys.executable} {(_repo_root() / 'scripts' / 'cgroup_memory_gate.py')} "
-        f"{mem_threshold}"
+    limit_command = " ".join(
+        [
+            shlex.quote(sys.executable),
+            shlex.quote(str(_repo_root() / "scripts" / "cgroup_memory_gate.py")),
+            shlex.quote(mem_threshold),
+        ]
     )
     shard_runner = _repo_root() / "scripts" / "run_pytest_shard.py"
     command = [
@@ -296,8 +300,8 @@ def main() -> int:
         "--results",
         str(results_dir),
         "--line-buffer",
-        sys.executable,
-        str(shard_runner),
+        shlex.quote(sys.executable),
+        shlex.quote(str(shard_runner)),
         "::::",
         str(nodeids_file),
     ]

--- a/tests/unit/test_app_config_storage_path.py
+++ b/tests/unit/test_app_config_storage_path.py
@@ -109,5 +109,6 @@ def test_relative_path_without_yaml_context_falls_back_to_cwd() -> None:
     """
     with tempfile.TemporaryDirectory() as fallback_cwd, _cwd(Path(fallback_cwd)):
         cfg = AppConfig(attachment_storage_path="./relative-fallback")
+        expected = (Path(fallback_cwd) / "relative-fallback").resolve()
 
-    assert cfg.attachment_storage_path == str(Path(fallback_cwd) / "relative-fallback")
+    assert Path(cfg.attachment_storage_path) == expected


### PR DESCRIPTION
## Summary
- Add macOS-compatible test locking/cleanup behavior in `run-tests.sh`.
- Quote adaptive GNU Parallel shard commands so workspaces with spaces in their path run correctly.
- Make frontend test/build setup robust on macOS by cleaning the dist directory before Vite builds and stripping jsdom `AbortSignal` values before MSW's test fetch handler.
- Normalize a storage-path regression assertion for macOS `/var` vs `/private/var` path aliases.

## Verification
- `scripts/format-and-lint.sh`
- `.venv/bin/pytest tests/unit/test_app_config_storage_path.py --db sqlite -q`
- `.venv/bin/pytest tests/functional/tools/test_browser_dom.py --db sqlite -q`
- `npm run test --prefix frontend -- --run`
- `.venv/bin/poe test` (SQLite-only; PostgreSQL not detected locally)