### PR TITLE
Fix adaptive pytest with compact quiet flags

### DIFF
--- a/scripts/run_pytest_adaptive.py
+++ b/scripts/run_pytest_adaptive.py
@@ -52,6 +52,14 @@ def _sanitize_pytest_args(args: list[str]) -> list[str]:
             skip_next = False
             continue
 
+        if arg.startswith("-") and not arg.startswith("--") and len(arg) > 2:
+            compact_flags = arg[1:]
+            if set(compact_flags) <= {"q", "x"}:
+                compact_flags = compact_flags.replace("q", "")
+                if not compact_flags:
+                    continue
+                arg = f"-{compact_flags}"
+
         if arg in {
             "--disable-warnings",
             "--json-report",

--- a/tests/unit/test_run_pytest_adaptive.py
+++ b/tests/unit/test_run_pytest_adaptive.py
@@ -1,0 +1,31 @@
+"""Tests for the adaptive pytest runner."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _load_runner_module() -> ModuleType:
+    script_path = Path(__file__).parents[2] / "scripts" / "run_pytest_adaptive.py"
+    spec = importlib.util.spec_from_file_location("run_pytest_adaptive", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {script_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sanitize_pytest_args_strips_quiet_from_compact_fail_fast() -> None:
+    runner = _load_runner_module()
+
+    assert runner._sanitize_pytest_args(["--db", "postgres", "-xq"]) == [
+        "--db",
+        "postgres",
+        "-x",
+    ]


### PR DESCRIPTION
## Summary
- Normalize compact `-xq` pytest flags in the adaptive runner by stripping the quiet flag while preserving fail-fast.
- Add regression coverage for the sanitizer path used by `poe test-postgres`.

## Why
`poe test-postgres` invokes `scripts/run-tests.sh --skip-lint --db postgres -xq`. The adaptive runner collected with the compact `-xq` flag still present, which caused `pytest --collect-only` to emit only per-file counts. The runner scraped stdout for nodeids and treated that as zero collected tests.

## Verification
- `.venv/bin/pytest tests/unit/test_run_pytest_adaptive.py --db sqlite -q`
- `PYTEST_ADAPTIVE_BATCH_SIZE=10 PYTEST_ADAPTIVE_JOBS=2 .venv/bin/python scripts/run_pytest_adaptive.py --db postgres -xq tests/unit/test_app_config_storage_path.py`
- `.venv/bin/poe test-postgres`
- `scripts/format-and-lint.sh`