### PR TITLE
Polish native iOS chat composer and live-updates indicator

### DIFF
--- a/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViewModel.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViewModel.swift
@@ -18,6 +18,7 @@ final class ChatViewModel {
     var isLoadingProfiles = false
     var isStreaming = false
     var errorMessage: String?
+    var liveUpdatesConnected = true
     var mobileShowsConversationList = false
 
     var canSendDraft: Bool {
@@ -401,6 +402,11 @@ final class ChatViewModel {
         }
     }
 
+    func reconnectLiveUpdates() async {
+        liveUpdatesConnected = true
+        startLiveEvents()
+    }
+
     private func startLiveEvents() {
         liveEventsTask?.cancel()
         guard let conversationID else {
@@ -420,15 +426,20 @@ final class ChatViewModel {
                             await loadMessages(conversationID: conversationID)
                             await refreshConversations()
                         }
-                    case .connected, .heartbeat:
+                    case .connected:
+                        liveUpdatesConnected = true
+                    case .heartbeat:
                         break
                     default:
                         break
                     }
                 }
+                if !Task.isCancelled {
+                    liveUpdatesConnected = false
+                }
             } catch {
                 if !Task.isCancelled {
-                    errorMessage = "Live updates disconnected. Pull to refresh."
+                    liveUpdatesConnected = false
                 }
             }
         }

--- a/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViews.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViews.swift
@@ -66,6 +66,11 @@ struct ChatRootView: View {
                 .navigationTitle("Chat")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
+                    if !viewModel.liveUpdatesConnected {
+                        ToolbarItem(placement: .topBarLeading) {
+                            LiveUpdatesIndicator(viewModel: viewModel)
+                        }
+                    }
                     ToolbarItem(placement: .topBarTrailing) {
                         ProfilePickerView(viewModel: viewModel)
                     }
@@ -286,26 +291,32 @@ private struct ChatComposerView: View {
     @State private var selectedPhotoItem: PhotosPickerItem?
     @State private var importsFiles = false
 
+    private var sendButtonEnabled: Bool {
+        viewModel.isStreaming || viewModel.canSendDraft
+    }
+
     var body: some View {
         VStack(spacing: 8) {
             if !viewModel.draftAttachments.isEmpty {
                 DraftAttachmentStrip(viewModel: viewModel)
             }
-            HStack(alignment: .bottom, spacing: 8) {
+            HStack(alignment: .bottom, spacing: 4) {
                 PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
                     Image(systemName: "photo")
-                        .frame(width: 36, height: 36)
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 32, height: 36)
                 }
-                .buttonStyle(.bordered)
                 .accessibilityLabel("Add Photo")
 
                 Button {
                     importsFiles = true
                 } label: {
                     Image(systemName: "paperclip")
-                        .frame(width: 36, height: 36)
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 32, height: 36)
                 }
-                .buttonStyle(.bordered)
                 .accessibilityLabel("Add File")
 
                 TextField(
@@ -316,8 +327,10 @@ private struct ChatComposerView: View {
                     ),
                     axis: .vertical
                 )
-                    .textFieldStyle(.roundedBorder)
+                    .textFieldStyle(.plain)
                     .lineLimit(1...6)
+                    .frame(minHeight: 36)
+                    .padding(.horizontal, 4)
                     .accessibilityIdentifier("chat-composer")
 
                 Button {
@@ -328,14 +341,25 @@ private struct ChatComposerView: View {
                     }
                 } label: {
                     Image(systemName: viewModel.isStreaming ? "stop.fill" : "arrow.up")
-                        .frame(width: 36, height: 36)
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 30, height: 30)
+                        .background(sendButtonEnabled ? Color.accentColor : Color.secondary.opacity(0.4))
+                        .clipShape(Circle())
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.plain)
                 .disabled(!viewModel.isStreaming && !viewModel.canSendDraft)
+                .padding(.vertical, 3)
                 .accessibilityIdentifier(viewModel.isStreaming ? "chat-stop-button" : "chat-send-button")
             }
+            .padding(.horizontal, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .fill(Color(.secondarySystemBackground))
+            )
         }
-        .padding()
+        .padding(.horizontal)
+        .padding(.vertical, 6)
         .background(.bar)
         .onChange(of: selectedPhotoItem) { _, item in
             guard let item else { return }
@@ -450,6 +474,21 @@ private struct DraftAttachmentStrip: View {
         case .file:
             "paperclip"
         }
+    }
+}
+
+private struct LiveUpdatesIndicator: View {
+    var viewModel: ChatViewModel
+
+    var body: some View {
+        Button {
+            Task { await viewModel.reconnectLiveUpdates() }
+        } label: {
+            Image(systemName: "wifi.slash")
+                .foregroundStyle(.orange)
+        }
+        .accessibilityLabel("Live updates disconnected. Tap to reconnect.")
+        .accessibilityIdentifier("chat-live-updates-disconnected")
     }
 }
 

--- a/ios/build-and-install.sh
+++ b/ios/build-and-install.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Build the FamilyAssistant iOS app and install it on a connected iPhone.
+#
+# Usage:
+#   ./ios/build-and-install.sh                # auto-pick the first connected device
+#   ./ios/build-and-install.sh <device-udid>  # target a specific device
+#   ./ios/build-and-install.sh --list         # list connected devices and exit
+#
+# Environment overrides:
+#   CONFIGURATION  Debug|Release (default: Debug)
+#   SCHEME         Xcode scheme (default: FamilyAssistant)
+#
+# Requires Xcode 15.4+ and a device that has been paired and trusted in Xcode.
+# Code signing uses the team configured in the .xcodeproj (automatic signing).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR/FamilyAssistant"
+PROJECT="$PROJECT_DIR/FamilyAssistant.xcodeproj"
+SCHEME="${SCHEME:-FamilyAssistant}"
+CONFIGURATION="${CONFIGURATION:-Debug}"
+DERIVED_DATA="$PROJECT_DIR/build/DerivedDataPhone"
+
+if [[ ! -d "$PROJECT" ]]; then
+    echo "ERROR: cannot find Xcode project at $PROJECT" >&2
+    exit 1
+fi
+
+list_devices() {
+    # devicectl prints JSON; pull the connected iOS devices out of it.
+    local tmp
+    tmp="$(mktemp -t fa-devices.XXXXXX.json)"
+    trap 'rm -f "$tmp"' RETURN
+    xcrun devicectl list devices --quiet --json-output "$tmp" >/dev/null
+    /usr/bin/python3 - "$tmp" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+devices = data.get("result", {}).get("devices", [])
+for d in devices:
+    props = d.get("deviceProperties", {})
+    hw = d.get("hardwareProperties", {})
+    conn = d.get("connectionProperties", {})
+    platform = (hw.get("platform") or "").lower()
+    if "ios" not in platform and "iphone" not in platform and "ipad" not in platform:
+        continue
+    if conn.get("tunnelState") in ("unavailable",):
+        continue
+    name = props.get("name", "unknown")
+    udid = d.get("identifier", "")
+    os_ver = props.get("osVersionNumber", "?")
+    paired = conn.get("pairingState", "?")
+    print(f"{udid}\t{name}\tiOS {os_ver}\t{paired}")
+PY
+}
+
+if [[ "${1:-}" == "--list" ]]; then
+    echo "Connected iOS devices:"
+    list_devices | column -t -s $'\t' || true
+    exit 0
+fi
+
+DEVICE_UDID="${1:-}"
+if [[ -z "$DEVICE_UDID" ]]; then
+    echo "Discovering connected iOS device..."
+    DEVICE_LINE="$(list_devices | head -n 1)"
+    if [[ -z "$DEVICE_LINE" ]]; then
+        echo "ERROR: no connected iOS device found. Plug in your iPhone, unlock it," >&2
+        echo "       trust this Mac, and verify with: $0 --list" >&2
+        exit 1
+    fi
+    DEVICE_UDID="$(echo "$DEVICE_LINE" | cut -f1)"
+    DEVICE_NAME="$(echo "$DEVICE_LINE" | cut -f2)"
+    echo "Using device: $DEVICE_NAME ($DEVICE_UDID)"
+fi
+
+echo "Building $SCHEME ($CONFIGURATION) for device $DEVICE_UDID..."
+xcodebuild \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -configuration "$CONFIGURATION" \
+    -destination "id=$DEVICE_UDID" \
+    -derivedDataPath "$DERIVED_DATA" \
+    -allowProvisioningUpdates \
+    build
+
+APP_PATH="$DERIVED_DATA/Build/Products/${CONFIGURATION}-iphoneos/${SCHEME}.app"
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "ERROR: build succeeded but app bundle not found at $APP_PATH" >&2
+    exit 1
+fi
+
+echo "Installing $APP_PATH to $DEVICE_UDID..."
+xcrun devicectl device install app --device "$DEVICE_UDID" "$APP_PATH"
+
+echo
+echo "Done. The app is installed on the device."
+echo "Launch it from the Home Screen, or run:"
+echo "  xcrun devicectl device process launch --device $DEVICE_UDID dev.andrewgarrett.assistant"


### PR DESCRIPTION
Follow-up to #876.

## Summary
- New `ios/build-and-install.sh` script to build and push the FamilyAssistant app to a connected iPhone in one command (auto-discovers the device via `devicectl`).
- Redesign the native chat composer as a single rounded "input bar" filling the bottom tray: plain icon buttons for the photo/file pickers, borderless `TextField`, circular send button that turns accent-colored when enabled. Outer tray padding tightened so the composer hugs the bottom edge.
- Replace the modal "Live updates disconnected. Pull to refresh." alert with a dedicated `liveUpdatesConnected` state and a subtle `wifi.slash` indicator in the chat toolbar. Tapping it reconnects the SSE stream.

## Test plan
- [x] Build and install on a physical device via the new script
- [x] Composer renders as one cohesive bubble; send button activates with text/attachments
- [ ] Verify SSE drop shows the `wifi.slash` icon (not a modal) and that tapping reconnects
- [ ] Verify the existing `chat-send-button` / `chat-stop-button` / `chat-composer` accessibility identifiers still pass UI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)