### PR TITLE
Continue chat processing in background after client disconnect

### DIFF
--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -563,6 +563,11 @@ various tasks with dark mode support and mobile optimization.
   - **When you're notified:** a new assistant reply arrives in a web conversation, a confirmation is
     waiting for your approval, a background task fails after retrying, or a spawned worker task
     finishes. Notifications are sent to every device you've registered.
+  - **Closing the app mid-reply:** If you send a message and then close or background the app (web
+    or iOS) before the assistant finishes, processing keeps running on the server. When it
+    completes, the reply is delivered as a push notification — tap it to jump back to the
+    conversation. (You'll only get this push if the connection actually dropped; while you're
+    watching the response stream live, no extra notification is sent.)
 
 ## 8. Tips for Best Results
 

--- a/src/family_assistant/web/app_creator.py
+++ b/src/family_assistant/web/app_creator.py
@@ -200,6 +200,11 @@ def create_app() -> FastAPI:
     new_app.state.server_url = SERVER_URL
     new_app.state.docs_user_dir = docs_user_dir
 
+    # Tracks chat-processing tasks detached from disconnected streaming requests
+    # so they keep running (and deliver a push notification) instead of being
+    # cancelled. See chat_api._get_background_chat_tasks.
+    new_app.state.background_chat_tasks = set()
+
     # Initialize tool_definitions for development mode
     # This will be populated by Assistant.setup_dependencies() in production
     # For development, we load them directly here

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -1070,6 +1070,13 @@ async def api_chat_send_message_stream(
         # SSE stream.
         client_disconnected = asyncio.Event()
 
+        # Set when the consumer (this generator) has stopped consuming events,
+        # whether because the stream was fully delivered, the client
+        # disconnected, or an error occurred. process_stream waits on this before
+        # making its final push-notification decision so the decision reflects
+        # the true delivery outcome rather than racing the disconnect signal.
+        consumer_finished = asyncio.Event()
+
         # Create confirmation callback that queues events
         async def web_confirmation_callback(
             interface_type: str,
@@ -1348,17 +1355,26 @@ async def api_chat_send_message_stream(
                             final_reply_parts.clear()
                         elif event.type == "error":
                             logger.error(f"Stream event error: {event.error}")
-                        # Add events to queue
-                        await confirmation_queue.put({
-                            "type": "stream_event",
-                            "event": event,
-                        })
+                        # Once the client is gone nothing drains the queue, so
+                        # stop queuing events to avoid buffering the entire
+                        # response in memory -- only final_reply_parts is needed
+                        # for the push notification.
+                        if not client_disconnected.is_set():
+                            await confirmation_queue.put({
+                                "type": "stream_event",
+                                "event": event,
+                            })
 
-                    # Signal end of stream
-                    await confirmation_queue.put({"type": "stream_end"})
+                    # Signal end of stream (skip if nobody is listening).
+                    if not client_disconnected.is_set():
+                        await confirmation_queue.put({"type": "stream_end"})
 
-                    # If the client disconnected mid-turn, the SSE stream is gone,
-                    # so deliver the completed reply as a push notification.
+                    # Wait for the consumer to finish delivering (or to observe the
+                    # disconnect) before deciding whether to notify, so the
+                    # decision reflects the true delivery outcome instead of racing
+                    # the disconnect signal. If the reply never reached the client,
+                    # deliver it as a push notification.
+                    await consumer_finished.wait()
                     if client_disconnected.is_set():
                         await _notify_disconnected_reply(
                             stream_db_context,
@@ -1370,7 +1386,8 @@ async def api_chat_send_message_stream(
             except Exception as e:
                 # Queue error event
                 logger.error(f"Error in process_stream: {e}", exc_info=True)
-                await confirmation_queue.put({"type": "error", "error": str(e)})
+                if not client_disconnected.is_set():
+                    await confirmation_queue.put({"type": "error", "error": str(e)})
 
         # Emit attachment events for user-uploaded attachments first
         if attachment_metadata:
@@ -1578,6 +1595,9 @@ async def api_chat_send_message_stream(
                 error_msg = str(e)
             yield f"event: error\ndata: {json.dumps({'error': error_msg, 'error_id': error_id})}\n\n"
         finally:
+            # Unblock process_stream's final notify decision (it waits on this so
+            # the decision reflects the true delivery outcome).
+            consumer_finished.set()
             if not stream_task.done():
                 if client_disconnected.is_set():
                     # Detach the processing task so it runs to completion in the
@@ -1589,7 +1609,9 @@ async def api_chat_send_message_stream(
                     stream_task.add_done_callback(background_tasks.discard)
                     stream_task.add_done_callback(_log_detached_stream_result)
                 else:
-                    stream_task.cancel()
+                    # Normal (or consumer-error) completion: consumer_finished is
+                    # set, so let process_stream finish its wrap-up and commit its
+                    # DB context rather than cancelling it mid-write.
                     with contextlib.suppress(asyncio.CancelledError):
                         await stream_task
             if send_close_event:

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncGenerator, Mapping
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Annotated, Any, Literal, TypedDict
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -38,6 +38,8 @@ from family_assistant.services.confirmation_service import (
 from family_assistant.services.confirmation_waiters import (
     ConfirmationResultWaiterRegistry,
 )
+from family_assistant.services.notification_targets import notify_conversation
+from family_assistant.services.notifier import MESSAGE_CATEGORY, NotificationMetadata
 from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.tools import MCPToolsProvider, find_provider_by_type
 from family_assistant.tools.infrastructure import ToolDescriptorProvider
@@ -86,6 +88,70 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 chat_api_router = APIRouter()
+
+
+def _get_background_chat_tasks(app: FastAPI) -> set[asyncio.Task[None]]:
+    """Return the set tracking detached chat-processing tasks for this app.
+
+    When a streaming client disconnects mid-turn the processing keeps running in
+    the background. The resulting task is parked here so it is not garbage
+    collected before it finishes and delivers the reply via push notification.
+    """
+    tasks = getattr(app.state, "background_chat_tasks", None)
+    if tasks is None:
+        tasks = set()
+        app.state.background_chat_tasks = tasks
+    return tasks
+
+
+def _log_detached_stream_result(task: asyncio.Task[None]) -> None:
+    """Log unexpected failures from a detached background chat task."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(
+            "Background chat processing task failed after client disconnect: %s",
+            exc,
+            exc_info=exc,
+        )
+
+
+async def _notify_disconnected_reply(
+    db_context: DatabaseContext,
+    web_chat_interface: "WebChatInterface",
+    *,
+    interface_type: str,
+    conversation_id: str,
+    reply_text: str,
+) -> None:
+    """Deliver a completed assistant reply via push when the SSE client is gone.
+
+    The streaming path relays the reply over SSE and persists it directly, so it
+    never calls ``WebChatInterface.send_message`` (where push delivery lives). A
+    client that closed the app would otherwise never learn the turn finished.
+    This sends the same message-category push used for other background replies.
+    """
+    notifier = getattr(web_chat_interface, "notifier", None)
+    if not reply_text or notifier is None:
+        return
+    try:
+        await notify_conversation(
+            notifier,
+            db_context,
+            interface_type=interface_type,
+            conversation_id=conversation_id,
+            title="New message",
+            body=reply_text[:200],
+            metadata=NotificationMetadata(
+                category=MESSAGE_CATEGORY,
+                conversation_id=conversation_id,
+            ),
+        )
+    except Exception as e:
+        logger.warning(
+            f"Failed to send disconnect push notification: {e}", exc_info=True
+        )
 
 
 _TOKEN_IDENTITY_SOURCES = {"api_token", "app_token_session"}
@@ -998,6 +1064,12 @@ async def api_chat_send_message_stream(
         # ast-grep-ignore: no-dict-any - SSE event queue carries heterogeneous event types (stream, confirmation, error)
         confirmation_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
 
+        # Set when the SSE client goes away mid-turn (e.g. the app is closed or
+        # backgrounded). When set, processing continues in the background and the
+        # final reply is delivered via push notification instead of the now-dead
+        # SSE stream.
+        client_disconnected = asyncio.Event()
+
         # Create confirmation callback that queues events
         async def web_confirmation_callback(
             interface_type: str,
@@ -1238,6 +1310,11 @@ async def api_chat_send_message_stream(
         )
 
         async def process_stream() -> None:
+            # Accumulate the final assistant reply text so it can be delivered via
+            # push notification if the client disconnects before the turn finishes.
+            # Text from earlier agentic turns (preamble before a tool call) is
+            # discarded so the notification reflects the final answer.
+            final_reply_parts: list[str] = []
             try:
                 async with get_db_context(
                     request.app.state.database_engine
@@ -1263,7 +1340,13 @@ async def api_chat_send_message_stream(
                         request_confirmation_callback=web_confirmation_callback,
                         trigger_attachments=attachment_metadata,
                     ):
-                        if event.type == "error":
+                        if event.type == "content" and event.content:
+                            final_reply_parts.append(event.content)
+                        elif event.type == "tool_call":
+                            # A new tool round means more turns follow; drop any
+                            # preamble so only the final answer is notified.
+                            final_reply_parts.clear()
+                        elif event.type == "error":
                             logger.error(f"Stream event error: {event.error}")
                         # Add events to queue
                         await confirmation_queue.put({
@@ -1273,6 +1356,17 @@ async def api_chat_send_message_stream(
 
                     # Signal end of stream
                     await confirmation_queue.put({"type": "stream_end"})
+
+                    # If the client disconnected mid-turn, the SSE stream is gone,
+                    # so deliver the completed reply as a push notification.
+                    if client_disconnected.is_set():
+                        await _notify_disconnected_reply(
+                            stream_db_context,
+                            web_chat_interface,
+                            interface_type=interface_type,
+                            conversation_id=conversation_id,
+                            reply_text="".join(final_reply_parts).strip(),
+                        )
             except Exception as e:
                 # Queue error event
                 logger.error(f"Error in process_stream: {e}", exc_info=True)
@@ -1463,7 +1557,12 @@ async def api_chat_send_message_stream(
                     break
 
         except asyncio.CancelledError:
+            # The SSE client went away (e.g. the app was closed or backgrounded).
+            # Mark the turn as disconnected so the background task delivers the
+            # reply via push notification, and skip the close event on the now
+            # dead connection.
             send_close_event = False
+            client_disconnected.set()
             raise
         except Exception as e:
             error_id = str(uuid.uuid4())
@@ -1480,9 +1579,19 @@ async def api_chat_send_message_stream(
             yield f"event: error\ndata: {json.dumps({'error': error_msg, 'error_id': error_id})}\n\n"
         finally:
             if not stream_task.done():
-                stream_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await stream_task
+                if client_disconnected.is_set():
+                    # Detach the processing task so it runs to completion in the
+                    # background and delivers the reply via push notification,
+                    # instead of being cancelled with the request. Keep a strong
+                    # reference so it isn't garbage collected before it finishes.
+                    background_tasks = _get_background_chat_tasks(request.app)
+                    background_tasks.add(stream_task)
+                    stream_task.add_done_callback(background_tasks.discard)
+                    stream_task.add_done_callback(_log_detached_stream_result)
+                else:
+                    stream_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await stream_task
             if send_close_event:
                 # Send a final close event to ensure client knows stream is done
                 yield f"event: close\ndata: {json.dumps({})}\n\n"

--- a/tests/functional/web/api/test_chat_streaming.py
+++ b/tests/functional/web/api/test_chat_streaming.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from collections.abc import AsyncGenerator
@@ -26,6 +27,7 @@ from family_assistant.llm import (
 )
 from family_assistant.llm.messages import MessageReasoningInfo
 from family_assistant.processing import ProcessingService, ProcessingServiceConfig
+from family_assistant.services.notifier import MESSAGE_CATEGORY, NotificationMetadata
 from family_assistant.storage import init_db
 from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.storage.repositories.notes import NoteModel
@@ -719,3 +721,122 @@ async def test_streaming_no_database_connection_errors(
     assert db_error_messages == [], (
         f"Database connection errors found in logs: {db_error_messages}"
     )
+
+
+class _SpyNotifier:
+    """In-memory notifier capturing dispatched notifications for assertions."""
+
+    def __init__(self) -> None:
+        self.notified = asyncio.Event()
+        self.calls: list[tuple[str, str, str, NotificationMetadata | None]] = []
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    async def send_notification(
+        self,
+        user_identifier: str,
+        title: str,
+        body: str,
+        db_context: DatabaseContext,
+        *,
+        metadata: NotificationMetadata | None = None,
+    ) -> None:
+        self.calls.append((user_identifier, title, body, metadata))
+        self.notified.set()
+
+
+async def test_streaming_continues_and_notifies_after_client_disconnect(
+    app_fixture: FastAPI,
+    test_client: AsyncClient,
+    mock_llm_client: RuleBasedMockLLMClient,
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the client disconnects mid-turn, processing finishes in the background
+    and the final reply is delivered via push notification."""
+    user_prompt = "Keep working even if I close the app"
+    llm_response = "All done in the background!"
+    conversation_id = "disconnect-conv-1"
+
+    mock_llm_client.rules.append((
+        lambda args: any(
+            msg.role == "user" and user_prompt in str(msg.content or "")
+            for msg in args.get("messages", [])
+        ),
+        LLMOutput(
+            content=llm_response,
+            tool_calls=None,
+            reasoning_info=MessageReasoningInfo(
+                prompt_tokens=10, completion_tokens=10, total_tokens=20
+            ),
+        ),
+    ))
+
+    # Gate the LLM so the turn is still in flight when we simulate the disconnect.
+    started = asyncio.Event()
+    release = asyncio.Event()
+    original_generate = mock_llm_client.generate_response
+
+    async def gated_generate_response(*args: object, **kwargs: object) -> LLMOutput:
+        started.set()
+        await release.wait()
+        return await original_generate(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(mock_llm_client, "generate_response", gated_generate_response)
+
+    # Wire a spy notifier so we can observe the push delivery.
+    spy = _SpyNotifier()
+    app_fixture.state.web_chat_interface = WebChatInterface(db_engine, notifier=spy)
+
+    # Start the streaming request and wait until processing is underway.
+    request_task = asyncio.create_task(
+        test_client.post(
+            "/api/v1/chat/send_message_stream",
+            json={
+                "prompt": user_prompt,
+                "interface_type": "web",
+                "conversation_id": conversation_id,
+            },
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=5)
+
+    # Simulate the client closing the app: cancel the in-flight request.
+    request_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+
+    # Processing should continue in the background; let the LLM finish.
+    release.set()
+
+    # The completed reply must be delivered as a push notification.
+    await asyncio.wait_for(spy.notified.wait(), timeout=5)
+
+    # Let the detached background task fully settle before assertions/teardown.
+    background_tasks = list(getattr(app_fixture.state, "background_chat_tasks", set()))
+    if background_tasks:
+        await asyncio.gather(*background_tasks, return_exceptions=True)
+
+    assert len(spy.calls) == 1
+    user_identifier, _title, body, metadata = spy.calls[0]
+    assert user_identifier == "test_user"
+    assert llm_response in body
+    assert metadata is not None
+    assert metadata.category == MESSAGE_CATEGORY
+    assert metadata.conversation_id == conversation_id
+
+    # The assistant reply must also have been persisted despite the disconnect.
+    async with get_db_context(engine=db_engine) as fresh_ctx:
+        messages = await fresh_ctx.message_history.get_recent_with_metadata(
+            interface_type="web",
+            conversation_id=conversation_id,
+            limit=20,
+        )
+    assistant_messages = [
+        m
+        for m in messages
+        if m["role"] == "assistant" and llm_response in str(m.get("content") or "")
+    ]
+    assert assistant_messages, "Assistant reply should be persisted after disconnect"


### PR DESCRIPTION
When a web or iOS client sent a message and then closed/backgrounded the
app, the streaming endpoint cancelled the in-flight processing task in its
finally block, so the turn crashed mid-flight and the reply was lost.

Now, when the SSE client disconnects mid-turn, the processing task is
detached (kept alive on app.state so it isn't garbage collected) and runs
to completion. On completion, the final assistant reply is delivered as a
push notification (Web Push / APNs) via the existing NotificationDispatcher,
since the streaming path persists replies directly and never goes through
WebChatInterface.send_message. No extra push is sent while the client is
still watching the live stream.

Adds a functional test that gates the mock LLM, simulates a mid-turn client
disconnect, and asserts the reply is both persisted and delivered as a
message-category push notification.