### PR TITLE
Add actionable iOS confirmation notifications with in-app modal

### DIFF
--- a/docs/design/ios_push_notifications.md
+++ b/docs/design/ios_push_notifications.md
@@ -77,6 +77,12 @@ Both require authentication (`get_current_user`), matching the existing Web Push
   `{ "token": str, "environment": "production"|"sandbox", "bundle_id": str | null }`. The payload
   key is `token`, matching the iOS client.
 - `DELETE /api/ios/push-tokens/{token}` — unregister a device token for the current user.
+- `GET /api/v1/chat/confirmations/{request_id}` — fetch a single durable confirmation owned by the
+  current user, including its current `status` (`pending`/`approved`/`rejected`/`expired`). Used by
+  the iOS confirmation modal (see below) so it can render the full prompt, arguments, and live
+  status when opened from a notification. Requests that do not exist or belong to another user
+  return `404` so existence is not leaked across users. This complements
+  `GET /api/v1/chat/confirmations/pending` (which only lists `pending` requests).
 
 ## Interactive notifications
 
@@ -93,6 +99,28 @@ Send points set:
   actions can resolve the request).
 - **Messages, task failures, worker completions** → `category=FAMILY_ASSISTANT_MESSAGE` +
   `conversation_id` (so a tap deep-links to the conversation).
+
+### iOS confirmation notification behaviour
+
+Confirmation notifications are **actionable** on iOS. The native app registers the
+`FAMILY_ASSISTANT_CONFIRMATION` category with two buttons:
+
+- **Approve / Reject buttons** (long-press or pull-down the notification) → the app submits the
+  decision directly to `POST /api/v1/chat/confirm_tool` (`approving_interface: "ios"`) without
+  opening any UI.
+- **Tapping the notification body** → the app opens an in-app **confirmation modal**
+  (`ConfirmationModalView`). The modal fetches the request via
+  `GET /api/v1/chat/confirmations/{request_id}` to show the tool name, prompt, arguments, and live
+  status, and offers Approve/Reject buttons backed by the same `confirm_tool` endpoint. A request
+  that already resolved or expired (on another device, via the action buttons, or by timeout) is
+  shown read-only with an explanatory status line. If the detail fetch fails, the modal falls back
+  to the notification's own title/body and still lets the user respond, letting the server
+  arbitrate.
+
+The `NotificationManager.handleNotificationAction(...)` seam routes the action identifier to either
+direct submission (approve/deny actions) or the modal (default tap on a confirmation). This split is
+exposed separately from `handleNotificationResponse(_:)` because `UNNotificationResponse` cannot be
+constructed in unit tests.
 
 ## Send points
 
@@ -130,4 +158,11 @@ owning user is resolved from the most recent user message in that conversation (
 - `APNsService`: an injected `httpx` client backed by `httpx.MockTransport` simulates APNs
   responses, allowing deterministic tests of success, `Unregistered` deletion, sandbox/production
   retry, and JWT refresh without contacting Apple.
-- Endpoints: functional tests through the FastAPI app, mirroring `test_push_api.py`.
+- Endpoints: functional tests through the FastAPI app, mirroring `test_push_api.py`. The single
+  confirmation `GET` endpoint is covered in `tests/functional/web/api/test_chat_confirmations.py`
+  (owner detail, status after resolution, `404` for unknown/other-user requests).
+- iOS client: `NotificationManagerTests` covers action routing (approve/deny submit to
+  `confirm_tool`, default tap presents the modal, message taps still deep-link), and
+  `ConfirmationModalModelTests` covers the modal's load/submit logic (detail fetch, read-only
+  resolved/expired states, offline fallback, and approve/reject submission) against a mocked
+  backend. These run in CI on macOS (`.github/workflows/ios-tests.yml`).

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -430,6 +430,10 @@ When the assistant needs to perform important actions, you'll be asked to confir
   - In Telegram: You'll see inline buttons to "Approve" or "Deny" the action
   - In the Web Interface: A dialog box will appear with details about the action and options to
     approve or deny
+  - On the iOS app: confirmation push notifications are actionable. Long-press (or pull down) the
+    notification to "Approve" or "Reject" it directly from the lock screen, or **tap the
+    notification** to open a confirmation dialog inside the app that shows the full request and lets
+    you approve or reject it there.
   - Pending web approvals are stored durably. If you reload the page or the assistant process
     restarts, the web interface can show the pending approval again and your approval still uses the
     background task queue for execution.
@@ -458,7 +462,9 @@ various tasks with dark mode support and mobile optimization.
   gathers the long-tail destinations — Voice, Events, History, Automations, Tools, and more — and a
   single **Settings** screen with notification controls and sign-out. Use the tab bar to move
   between sections; each tab remembers where you were. When enabled, iOS notifications can open the
-  relevant tab or page, and confirmation notifications may include approve/deny actions.
+  relevant tab or page, and confirmation notifications are actionable: they include approve/reject
+  actions, and tapping the notification opens an in-app confirmation dialog showing the full
+  request.
 
 - **Chat Features:**
 

--- a/ios/FamilyAssistant/FamilyAssistant.xcodeproj/project.pbxproj
+++ b/ios/FamilyAssistant/FamilyAssistant.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		A10030 /* RootTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10030 /* RootTabView.swift */; };
 		A10031 /* WebDestinationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10031 /* WebDestinationView.swift */; };
 		A10032 /* MoreTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10032 /* MoreTabView.swift */; };
+		A10025 /* ConfirmationModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10027 /* ConfirmationModalView.swift */; };
 		A10024 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = H10002 /* Markdown */; };
 		A20001 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20002 /* RouteTests.swift */; };
 		A20002 /* NotesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20003 /* NotesModelTests.swift */; };
@@ -42,6 +43,7 @@
 		A20008 /* ChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20009 /* ChatViewModelTests.swift */; };
 		A20009 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20010 /* MarkdownRendererTests.swift */; };
 		A20010 /* ToolRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20011 /* ToolRenderingTests.swift */; };
+		A20011 /* ConfirmationModalModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20012 /* ConfirmationModalModelTests.swift */; };
 		A30001 /* FamilyAssistantUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30002 /* FamilyAssistantUITests.swift */; };
 /* End PBXBuildFile section */
 
@@ -90,6 +92,7 @@
 		B10030 /* RootTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootTabView.swift; sourceTree = "<group>"; };
 		B10031 /* WebDestinationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDestinationView.swift; sourceTree = "<group>"; };
 		B10032 /* MoreTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreTabView.swift; sourceTree = "<group>"; };
+		B10027 /* ConfirmationModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationModalView.swift; sourceTree = "<group>"; };
 		B20001 /* FamilyAssistantTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FamilyAssistantTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B20002 /* RouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTests.swift; sourceTree = "<group>"; };
 		B20003 /* NotesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesModelTests.swift; sourceTree = "<group>"; };
@@ -101,6 +104,7 @@
 		B20009 /* ChatViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModelTests.swift; sourceTree = "<group>"; };
 		B20010 /* MarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRendererTests.swift; sourceTree = "<group>"; };
 		B20011 /* ToolRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRenderingTests.swift; sourceTree = "<group>"; };
+		B20012 /* ConfirmationModalModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationModalModelTests.swift; sourceTree = "<group>"; };
 		B30001 /* FamilyAssistantUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FamilyAssistantUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B30002 /* FamilyAssistantUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyAssistantUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -186,6 +190,7 @@
 			children = (
 				B10011 /* AppDelegate.swift */,
 				B10012 /* NotificationManager.swift */,
+				B10027 /* ConfirmationModalView.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -245,6 +250,7 @@
 				B20009 /* ChatViewModelTests.swift */,
 				B20010 /* MarkdownRendererTests.swift */,
 				B20011 /* ToolRenderingTests.swift */,
+				B20012 /* ConfirmationModalModelTests.swift */,
 			);
 			path = FamilyAssistantTests;
 			sourceTree = "<group>";
@@ -415,6 +421,7 @@
 				A10021 /* SSEParser.swift in Sources */,
 				A10022 /* ChatViewModel.swift in Sources */,
 				A10023 /* ChatViews.swift in Sources */,
+				A10025 /* ConfirmationModalView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -432,6 +439,7 @@
 				A20008 /* ChatViewModelTests.swift in Sources */,
 				A20009 /* MarkdownRendererTests.swift in Sources */,
 				A20010 /* ToolRenderingTests.swift in Sources */,
+				A20011 /* ConfirmationModalModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/FamilyAssistant/FamilyAssistant/Chat/ChatAPIClient.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Chat/ChatAPIClient.swift
@@ -136,6 +136,17 @@ struct ChatAPIClient {
         return try JSONDecoder.chatDecoder.decode(ChatPendingConfirmationsResponse.self, from: data).confirmations
     }
 
+    func fetchConfirmation(requestID: String) async throws -> ChatConfirmationDetail {
+        let encodedID = Self.encodedPathComponent(requestID)
+        let request = try await authManager.authorizedRequest(
+            url: apiURL("/api/v1/chat/confirmations/\(encodedID)"),
+            method: "GET"
+        )
+        let (data, response) = try await urlSession.data(for: request)
+        try validate(response: response, data: data)
+        return try JSONDecoder.chatDecoder.decode(ChatConfirmationDetail.self, from: data)
+    }
+
     func confirmTool(requestID: String, conversationID: String?, approved: Bool) async throws {
         var request = try await authManager.authorizedRequest(
             url: apiURL("/api/v1/chat/confirm_tool"),

--- a/ios/FamilyAssistant/FamilyAssistant/Chat/ChatModels.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Chat/ChatModels.swift
@@ -262,6 +262,70 @@ struct ChatPendingConfirmationsResponse: Decodable {
     let confirmations: [ChatPendingConfirmation]
 }
 
+enum ChatConfirmationStatus: String, Decodable, Equatable {
+    case pending
+    case approved
+    case rejected
+    case expired
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = ChatConfirmationStatus(rawValue: raw) ?? .unknown
+    }
+
+    var isPending: Bool { self == .pending }
+}
+
+struct ChatConfirmationDetail: Decodable, Equatable {
+    let requestID: String
+    let toolName: String
+    let toolCallID: String?
+    let confirmationPrompt: String
+    let args: [String: JSONValue]
+    let status: ChatConfirmationStatus
+    let timeRemainingSeconds: Double
+
+    enum CodingKeys: String, CodingKey {
+        case requestID = "request_id"
+        case toolName = "tool_name"
+        case toolCallID = "tool_call_id"
+        case confirmationPrompt = "confirmation_prompt"
+        case args
+        case status
+        case timeRemainingSeconds = "time_remaining_seconds"
+    }
+
+    init(
+        requestID: String,
+        toolName: String,
+        toolCallID: String?,
+        confirmationPrompt: String,
+        args: [String: JSONValue],
+        status: ChatConfirmationStatus,
+        timeRemainingSeconds: Double
+    ) {
+        self.requestID = requestID
+        self.toolName = toolName
+        self.toolCallID = toolCallID
+        self.confirmationPrompt = confirmationPrompt
+        self.args = args
+        self.status = status
+        self.timeRemainingSeconds = timeRemainingSeconds
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        requestID = try container.decode(String.self, forKey: .requestID)
+        toolName = try container.decode(String.self, forKey: .toolName)
+        toolCallID = try container.decodeIfPresent(String.self, forKey: .toolCallID)
+        confirmationPrompt = try container.decode(String.self, forKey: .confirmationPrompt)
+        args = try container.decodeIfPresent([String: JSONValue].self, forKey: .args) ?? [:]
+        status = try container.decode(ChatConfirmationStatus.self, forKey: .status)
+        timeRemainingSeconds = try container.decodeIfPresent(Double.self, forKey: .timeRemainingSeconds) ?? 0
+    }
+}
+
 struct ChatConversationMessagesResponse: Decodable {
     let conversationID: String
     let messages: [ChatBackendMessage]

--- a/ios/FamilyAssistant/FamilyAssistant/ContentView.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/ContentView.swift
@@ -36,6 +36,16 @@ struct ContentView: View {
                         baseURL: baseURL
                     )
                 }
+                .sheet(item: Binding(
+                    get: { notificationManager.pendingConfirmationModal },
+                    set: { if $0 == nil { notificationManager.clearPendingConfirmationModal() } }
+                )) { modal in
+                    ConfirmationModalView(
+                        request: modal,
+                        authManager: authManager,
+                        onFinished: { notificationManager.clearPendingConfirmationModal() }
+                    )
+                }
             }
         } else {
             SetupView()

--- a/ios/FamilyAssistant/FamilyAssistant/Notifications/ConfirmationModalView.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Notifications/ConfirmationModalView.swift
@@ -1,0 +1,256 @@
+import Observation
+import SwiftUI
+
+/// A confirmation request surfaced by tapping the body of a confirmation push notification.
+///
+/// Carries the identifiers and the notification's own title/body so the modal can render
+/// immediately, before (or even if) the full details are fetched from the server.
+struct PendingConfirmationModal: Identifiable, Equatable {
+    let requestID: String
+    let conversationID: String?
+    let title: String
+    let body: String
+
+    var id: String { requestID }
+}
+
+@MainActor
+@Observable
+final class ConfirmationModalModel {
+    enum LoadState: Equatable {
+        case loading
+        case loaded(ChatConfirmationDetail)
+        case failed(String)
+    }
+
+    let request: PendingConfirmationModal
+    private(set) var loadState: LoadState = .loading
+    var isSubmitting = false
+    var errorMessage: String?
+    private(set) var didResolve = false
+
+    @ObservationIgnored private let apiClient: ChatAPIClient
+
+    init(request: PendingConfirmationModal, authManager: AuthManager) {
+        self.request = request
+        apiClient = ChatAPIClient(authManager: authManager)
+    }
+
+    var detail: ChatConfirmationDetail? {
+        if case .loaded(let detail) = loadState {
+            return detail
+        }
+        return nil
+    }
+
+    /// Whether to offer the approve/reject buttons.
+    ///
+    /// A request that resolved or expired elsewhere (another device, the action buttons, or a
+    /// timeout) is shown read-only. When the detail fetch fails we still offer the buttons and fall
+    /// back to the notification payload, letting the server arbitrate the decision rather than
+    /// stranding the user.
+    var canDecide: Bool {
+        guard !didResolve else {
+            return false
+        }
+        switch loadState {
+        case .loaded(let detail):
+            return detail.status.isPending
+        case .failed:
+            return true
+        case .loading:
+            return false
+        }
+    }
+
+    var promptText: String {
+        detail?.confirmationPrompt ?? request.body
+    }
+
+    var statusMessage: String? {
+        guard let detail else {
+            return nil
+        }
+        switch detail.status {
+        case .pending:
+            return didResolve ? "This request has been handled." : nil
+        case .approved:
+            return "This request was already approved."
+        case .rejected:
+            return "This request was already rejected."
+        case .expired:
+            return "This request has expired."
+        case .unknown:
+            return "This request is no longer available."
+        }
+    }
+
+    func load() async {
+        loadState = .loading
+        do {
+            let detail = try await apiClient.fetchConfirmation(requestID: request.requestID)
+            loadState = .loaded(detail)
+        } catch {
+            loadState = .failed(error.localizedDescription)
+        }
+    }
+
+    /// Submit the user's decision. Returns ``true`` when the modal should dismiss.
+    func submit(approved: Bool) async -> Bool {
+        guard !isSubmitting else {
+            return false
+        }
+        isSubmitting = true
+        errorMessage = nil
+        defer { isSubmitting = false }
+
+        do {
+            try await apiClient.confirmTool(
+                requestID: request.requestID,
+                conversationID: request.conversationID,
+                approved: approved
+            )
+            didResolve = true
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+}
+
+struct ConfirmationModalView: View {
+    @State private var model: ConfirmationModalModel
+    let onFinished: () -> Void
+
+    init(request: PendingConfirmationModal, authManager: AuthManager, onFinished: @escaping () -> Void) {
+        _model = State(initialValue: ConfirmationModalModel(request: request, authManager: authManager))
+        self.onFinished = onFinished
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    header
+                    Text(model.promptText)
+                        .font(.body)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .accessibilityIdentifier("confirmation-modal-prompt")
+
+                    if let detail = model.detail, !detail.args.isEmpty {
+                        argumentsView(detail.args)
+                    }
+
+                    if let statusMessage = model.statusMessage {
+                        Label(statusMessage, systemImage: "info.circle")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .accessibilityIdentifier("confirmation-modal-status")
+                    }
+
+                    if let errorMessage = model.errorMessage {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                            .font(.subheadline)
+                            .foregroundStyle(.red)
+                            .accessibilityIdentifier("confirmation-modal-error")
+                    }
+
+                    if case .failed = model.loadState {
+                        Label("Could not load the latest details. You can still respond below.", systemImage: "wifi.exclamationmark")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding()
+            }
+            .overlay {
+                if case .loading = model.loadState {
+                    ProgressView()
+                }
+            }
+            .safeAreaInset(edge: .bottom) {
+                actionButtons
+            }
+            .navigationTitle("Confirmation")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { onFinished() }
+                        .accessibilityIdentifier("confirmation-modal-close")
+                }
+            }
+        }
+        .task {
+            await model.load()
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "hand.raised.fill")
+                .font(.title2)
+                .foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.detail?.toolName ?? model.request.title)
+                    .font(.headline)
+                if let detail = model.detail, detail.status.isPending, detail.timeRemainingSeconds > 0 {
+                    Text("Expires in \(Int(detail.timeRemainingSeconds))s")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func argumentsView(_ args: [String: JSONValue]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Details")
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+            Text(JSONValue.object(args).jsonString)
+                .font(.caption.monospaced())
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 8))
+                .textSelection(.enabled)
+        }
+        .accessibilityIdentifier("confirmation-modal-args")
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        if model.canDecide {
+            HStack(spacing: 12) {
+                Button(role: .destructive) {
+                    Task {
+                        if await model.submit(approved: false) {
+                            onFinished()
+                        }
+                    }
+                } label: {
+                    Label("Reject", systemImage: "xmark")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("confirmation-modal-reject")
+
+                Button {
+                    Task {
+                        if await model.submit(approved: true) {
+                            onFinished()
+                        }
+                    }
+                } label: {
+                    Label("Approve", systemImage: "checkmark")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("confirmation-modal-approve")
+            }
+            .disabled(model.isSubmitting)
+            .padding()
+            .background(.bar)
+        }
+    }
+}

--- a/ios/FamilyAssistant/FamilyAssistant/Notifications/ConfirmationModalView.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Notifications/ConfirmationModalView.swift
@@ -1,3 +1,4 @@
+import Combine
 import Observation
 import SwiftUI
 
@@ -28,11 +29,21 @@ final class ConfirmationModalModel {
     var isSubmitting = false
     var errorMessage: String?
     private(set) var didResolve = false
+    private(set) var didExpire = false
 
     @ObservationIgnored private let apiClient: ChatAPIClient
+    @ObservationIgnored private let now: () -> Date
+    /// Absolute deadline derived from the loaded pending request, so the modal can disable decisions
+    /// once it passes even though the detail was only fetched once.
+    @ObservationIgnored private var expiresAt: Date?
 
-    init(request: PendingConfirmationModal, authManager: AuthManager) {
+    init(
+        request: PendingConfirmationModal,
+        authManager: AuthManager,
+        now: @escaping () -> Date = Date.init
+    ) {
         self.request = request
+        self.now = now
         apiClient = ChatAPIClient(authManager: authManager)
     }
 
@@ -50,7 +61,7 @@ final class ConfirmationModalModel {
     /// back to the notification payload, letting the server arbitrate the decision rather than
     /// stranding the user.
     var canDecide: Bool {
-        guard !didResolve else {
+        guard !didResolve, !didExpire else {
             return false
         }
         switch loadState {
@@ -68,6 +79,9 @@ final class ConfirmationModalModel {
     }
 
     var statusMessage: String? {
+        if didExpire {
+            return "This request has expired."
+        }
         guard let detail else {
             return nil
         }
@@ -87,11 +101,28 @@ final class ConfirmationModalModel {
 
     func load() async {
         loadState = .loading
+        didExpire = false
+        expiresAt = nil
         do {
             let detail = try await apiClient.fetchConfirmation(requestID: request.requestID)
             loadState = .loaded(detail)
+            if detail.status.isPending {
+                expiresAt = now().addingTimeInterval(detail.timeRemainingSeconds)
+                refreshExpiry()
+            }
         } catch {
             loadState = .failed(error.localizedDescription)
+        }
+    }
+
+    /// Re-evaluate whether the captured deadline has passed. Driven by a timer while the sheet is
+    /// open so the buttons disappear once the request can no longer be approved or rejected.
+    func refreshExpiry() {
+        guard let expiresAt, !didResolve, !didExpire else {
+            return
+        }
+        if now() >= expiresAt {
+            didExpire = true
         }
     }
 
@@ -122,6 +153,8 @@ final class ConfirmationModalModel {
 struct ConfirmationModalView: View {
     @State private var model: ConfirmationModalModel
     let onFinished: () -> Void
+
+    private let expiryTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     init(request: PendingConfirmationModal, authManager: AuthManager, onFinished: @escaping () -> Void) {
         _model = State(initialValue: ConfirmationModalModel(request: request, authManager: authManager))
@@ -172,6 +205,9 @@ struct ConfirmationModalView: View {
             .safeAreaInset(edge: .bottom) {
                 actionButtons
             }
+            .onReceive(expiryTimer) { _ in
+                model.refreshExpiry()
+            }
             .navigationTitle("Confirmation")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -194,7 +230,9 @@ struct ConfirmationModalView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(model.detail?.toolName ?? model.request.title)
                     .font(.headline)
-                if let detail = model.detail, detail.status.isPending, detail.timeRemainingSeconds > 0 {
+                if let detail = model.detail, detail.status.isPending, !model.didExpire,
+                   detail.timeRemainingSeconds > 0
+                {
                     Text("Expires in \(Int(detail.timeRemainingSeconds))s")
                         .font(.caption)
                         .foregroundStyle(.secondary)

--- a/ios/FamilyAssistant/FamilyAssistant/Notifications/NotificationManager.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Notifications/NotificationManager.swift
@@ -23,6 +23,7 @@ final class NotificationManager {
     }
     var errorMessage: String?
     var pendingNavigationPath: String?
+    var pendingConfirmationModal: PendingConfirmationModal?
 
     @ObservationIgnored private weak var authManager: AuthManager?
     @ObservationIgnored private let logger = Logger(
@@ -183,17 +184,48 @@ final class NotificationManager {
     }
 
     func handleNotificationResponse(_ response: UNNotificationResponse) {
-        let userInfo = response.notification.request.content.userInfo
+        let content = response.notification.request.content
+        handleNotificationAction(
+            actionIdentifier: response.actionIdentifier,
+            categoryIdentifier: content.categoryIdentifier,
+            title: content.title,
+            body: content.body,
+            userInfo: content.userInfo
+        )
+    }
 
-        switch response.actionIdentifier {
+    /// Route a notification response to confirmation submission, a confirmation modal, or a deep
+    /// link. Exposed separately from ``handleNotificationResponse(_:)`` because
+    /// ``UNNotificationResponse`` cannot be constructed directly in unit tests.
+    func handleNotificationAction(
+        actionIdentifier: String,
+        categoryIdentifier: String,
+        title: String,
+        body: String,
+        userInfo: [AnyHashable: Any]
+    ) {
+        switch actionIdentifier {
         case Actions.approve:
             submitConfirmation(from: userInfo, approved: true)
         case Actions.deny:
             submitConfirmation(from: userInfo, approved: false)
-        default:
-            if let path = navigationPath(from: userInfo) {
+        case UNNotificationDefaultActionIdentifier:
+            // Tapping the notification body opens the in-app confirmation modal when the
+            // notification is a confirmation; otherwise it deep-links like any other notification.
+            if categoryIdentifier == Categories.confirmation,
+               let requestID = stringValue(userInfo["request_id"])
+            {
+                pendingConfirmationModal = PendingConfirmationModal(
+                    requestID: requestID,
+                    conversationID: stringValue(userInfo["conversation_id"]),
+                    title: title,
+                    body: body
+                )
+            } else if let path = navigationPath(from: userInfo) {
                 pendingNavigationPath = path
             }
+        default:
+            break
         }
     }
 
@@ -227,6 +259,10 @@ final class NotificationManager {
 
     func clearPendingNavigationPath() {
         pendingNavigationPath = nil
+    }
+
+    func clearPendingConfirmationModal() {
+        pendingConfirmationModal = nil
     }
 
     var statusLabel: String {

--- a/ios/FamilyAssistant/FamilyAssistantTests/ConfirmationModalModelTests.swift
+++ b/ios/FamilyAssistant/FamilyAssistantTests/ConfirmationModalModelTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import XCTest
+
+@testable import FamilyAssistant
+
+@MainActor
+final class ConfirmationModalModelTests: XCTestCase {
+    private let serverURL = "https://assistant.example.test"
+    private let apiToken = "modal-api-token"
+
+    override func setUp() {
+        super.setUp()
+        resetStoredAuth()
+        KeychainHelper.save(key: "fa_api_token", string: apiToken)
+        UserDefaults.standard.set(
+            ISO8601DateFormatter().string(from: Date().addingTimeInterval(7200)),
+            forKey: "fa_token_expiry"
+        )
+        URLProtocol.registerClass(ChatMockBackendURLProtocol.self)
+        ChatMockBackendURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        ChatMockBackendURLProtocol.reset()
+        URLProtocol.unregisterClass(ChatMockBackendURLProtocol.self)
+        resetStoredAuth()
+        super.tearDown()
+    }
+
+    func testLoadFetchesConfirmationDetail() async throws {
+        ChatMockBackendURLProtocol.respond { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/v1/chat/confirmations/confirm_abc")
+            return .json(Self.detailJSON(status: "pending"))
+        }
+
+        let model = makeModel(requestID: "confirm_abc")
+        await model.load()
+
+        let detail = try XCTUnwrap(model.detail)
+        XCTAssertEqual(detail.toolName, "add_or_update_note")
+        XCTAssertEqual(detail.status, .pending)
+        let title = try XCTUnwrap(detail.args["title"])
+        XCTAssertEqual(title, .string("Trip"))
+        XCTAssertTrue(model.canDecide)
+        XCTAssertEqual(model.promptText, "Create a note for this itinerary?")
+        XCTAssertNil(model.statusMessage)
+    }
+
+    func testResolvedConfirmationIsReadOnly() async {
+        ChatMockBackendURLProtocol.respond { _ in
+            .json(Self.detailJSON(status: "approved"))
+        }
+
+        let model = makeModel(requestID: "confirm_done")
+        await model.load()
+
+        XCTAssertFalse(model.canDecide)
+        XCTAssertEqual(model.statusMessage, "This request was already approved.")
+    }
+
+    func testExpiredConfirmationIsReadOnly() async {
+        ChatMockBackendURLProtocol.respond { _ in
+            .json(Self.detailJSON(status: "expired"))
+        }
+
+        let model = makeModel(requestID: "confirm_old")
+        await model.load()
+
+        XCTAssertFalse(model.canDecide)
+        XCTAssertEqual(model.statusMessage, "This request has expired.")
+    }
+
+    func testLoadFailureFallsBackToNotificationBody() async {
+        ChatMockBackendURLProtocol.respond { _ in
+            .json(#"{"detail":"not found"}"#, statusCode: 404)
+        }
+
+        let model = makeModel(requestID: "confirm_missing", body: "Original body")
+        await model.load()
+
+        XCTAssertNil(model.detail)
+        XCTAssertTrue(model.canDecide)
+        XCTAssertEqual(model.promptText, "Original body")
+    }
+
+    func testSubmitApprovalPostsToConfirmEndpoint() async throws {
+        var capturedPayload: [String: Any]?
+        ChatMockBackendURLProtocol.respond { request in
+            if request.url?.path == "/api/v1/chat/confirm_tool" {
+                capturedPayload = try Self.jsonObject(from: request) as? [String: Any]
+                return .json(#"{"success":true}"#)
+            }
+            return .json(Self.detailJSON(status: "pending"))
+        }
+
+        let model = makeModel(requestID: "confirm_abc", conversationID: "web_conv_2")
+        let shouldDismiss = await model.submit(approved: true)
+
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertTrue(model.didResolve)
+        let payload = try XCTUnwrap(capturedPayload)
+        XCTAssertEqual(payload["request_id"] as? String, "confirm_abc")
+        XCTAssertEqual(payload["approved"] as? Bool, true)
+        XCTAssertEqual(payload["conversation_id"] as? String, "web_conv_2")
+        XCTAssertEqual(payload["approving_interface"] as? String, "ios")
+    }
+
+    func testSubmitRejectionPostsRejection() async throws {
+        var capturedApproved: Bool?
+        ChatMockBackendURLProtocol.respond { request in
+            let payload = try Self.jsonObject(from: request) as? [String: Any]
+            capturedApproved = payload?["approved"] as? Bool
+            return .json(#"{"success":true}"#)
+        }
+
+        let model = makeModel(requestID: "confirm_abc")
+        let shouldDismiss = await model.submit(approved: false)
+
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertEqual(capturedApproved, false)
+    }
+
+    func testSubmitFailureSurfacesErrorAndDoesNotDismiss() async {
+        ChatMockBackendURLProtocol.respond { _ in
+            .json(#"{"detail":"already handled"}"#, statusCode: 409)
+        }
+
+        let model = makeModel(requestID: "confirm_abc")
+        let shouldDismiss = await model.submit(approved: false)
+
+        XCTAssertFalse(shouldDismiss)
+        XCTAssertFalse(model.didResolve)
+        XCTAssertNotNil(model.errorMessage)
+    }
+
+    private func makeModel(
+        requestID: String,
+        conversationID: String? = nil,
+        body: String = "Notification body"
+    ) -> ConfirmationModalModel {
+        let authManager = AuthManager()
+        authManager.serverURL = serverURL
+        return ConfirmationModalModel(
+            request: PendingConfirmationModal(
+                requestID: requestID,
+                conversationID: conversationID,
+                title: "Confirmation needed",
+                body: body
+            ),
+            authManager: authManager
+        )
+    }
+
+    private func resetStoredAuth() {
+        KeychainHelper.delete(key: "fa_api_token")
+        KeychainHelper.delete(key: "fa_refresh_token")
+        UserDefaults.standard.removeObject(forKey: "fa_token_expiry")
+        UserDefaults.standard.removeObject(forKey: "fa_server_url")
+    }
+
+    private static func detailJSON(status: String) -> String {
+        """
+        {
+          "request_id": "confirm_abc",
+          "tool_name": "add_or_update_note",
+          "tool_call_id": "tool-call-123",
+          "confirmation_prompt": "Create a note for this itinerary?",
+          "args": {"title": "Trip", "content": "Flight lands at 6pm"},
+          "status": "\(status)",
+          "created_at": "2026-06-08T12:00:00Z",
+          "expires_at": "2026-06-08T12:30:00Z",
+          "time_remaining_seconds": 1800.0
+        }
+        """
+    }
+
+    private static func jsonObject(from request: URLRequest) throws -> Any {
+        try JSONSerialization.jsonObject(with: request.bodyData)
+    }
+}

--- a/ios/FamilyAssistant/FamilyAssistantTests/ConfirmationModalModelTests.swift
+++ b/ios/FamilyAssistant/FamilyAssistantTests/ConfirmationModalModelTests.swift
@@ -71,6 +71,27 @@ final class ConfirmationModalModelTests: XCTestCase {
         XCTAssertEqual(model.statusMessage, "This request has expired.")
     }
 
+    func testDecisionsDisabledOnceDeadlinePasses() async {
+        // detailJSON reports time_remaining_seconds: 1800.
+        var clock = Date(timeIntervalSince1970: 1_000_000)
+        ChatMockBackendURLProtocol.respond { _ in
+            .json(Self.detailJSON(status: "pending"))
+        }
+
+        let model = makeModel(requestID: "confirm_abc", now: { clock })
+        await model.load()
+
+        XCTAssertTrue(model.canDecide)
+        XCTAssertFalse(model.didExpire)
+
+        clock = clock.addingTimeInterval(2000)
+        model.refreshExpiry()
+
+        XCTAssertTrue(model.didExpire)
+        XCTAssertFalse(model.canDecide)
+        XCTAssertEqual(model.statusMessage, "This request has expired.")
+    }
+
     func testLoadFailureFallsBackToNotificationBody() async {
         ChatMockBackendURLProtocol.respond { _ in
             .json(#"{"detail":"not found"}"#, statusCode: 404)
@@ -137,7 +158,8 @@ final class ConfirmationModalModelTests: XCTestCase {
     private func makeModel(
         requestID: String,
         conversationID: String? = nil,
-        body: String = "Notification body"
+        body: String = "Notification body",
+        now: @escaping () -> Date = Date.init
     ) -> ConfirmationModalModel {
         let authManager = AuthManager()
         authManager.serverURL = serverURL
@@ -148,7 +170,8 @@ final class ConfirmationModalModelTests: XCTestCase {
                 title: "Confirmation needed",
                 body: body
             ),
-            authManager: authManager
+            authManager: authManager,
+            now: now
         )
     }
 

--- a/ios/FamilyAssistant/FamilyAssistantTests/NotificationManagerTests.swift
+++ b/ios/FamilyAssistant/FamilyAssistantTests/NotificationManagerTests.swift
@@ -179,8 +179,10 @@ final class NotificationManagerTests: XCTestCase {
 
     func testApproveActionSubmitsApprovalToConfirmEndpoint() async throws {
         seedStoredAuth()
+        // NotificationManager holds authManager weakly, so keep a strong reference for the test.
+        let authManager = makeAuthManager()
         let manager = NotificationManager()
-        manager.bind(authManager: makeAuthManager())
+        manager.bind(authManager: authManager)
 
         let requestCompleted = expectation(description: "confirm_tool POST")
         NotificationBackendURLProtocol.respond { request in
@@ -208,8 +210,10 @@ final class NotificationManagerTests: XCTestCase {
 
     func testDenyActionSubmitsRejectionToConfirmEndpoint() async throws {
         seedStoredAuth()
+        // NotificationManager holds authManager weakly, so keep a strong reference for the test.
+        let authManager = makeAuthManager()
         let manager = NotificationManager()
-        manager.bind(authManager: makeAuthManager())
+        manager.bind(authManager: authManager)
 
         let requestCompleted = expectation(description: "confirm_tool POST")
         NotificationBackendURLProtocol.respond { request in

--- a/ios/FamilyAssistant/FamilyAssistantTests/NotificationManagerTests.swift
+++ b/ios/FamilyAssistant/FamilyAssistantTests/NotificationManagerTests.swift
@@ -177,6 +177,124 @@ final class NotificationManagerTests: XCTestCase {
         XCTAssertNil(UserDefaults.standard.string(forKey: "fa_apns_device_token"))
     }
 
+    func testApproveActionSubmitsApprovalToConfirmEndpoint() async throws {
+        seedStoredAuth()
+        let manager = NotificationManager()
+        manager.bind(authManager: makeAuthManager())
+
+        let requestCompleted = expectation(description: "confirm_tool POST")
+        NotificationBackendURLProtocol.respond { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/api/v1/chat/confirm_tool")
+            let payload = try XCTUnwrap(Self.jsonObject(from: request) as? [String: Any])
+            XCTAssertEqual(payload["request_id"] as? String, "confirm_abc")
+            XCTAssertEqual(payload["approved"] as? Bool, true)
+            XCTAssertEqual(payload["approving_interface"] as? String, "ios")
+            requestCompleted.fulfill()
+            return .json(#"{"success":true}"#)
+        }
+
+        manager.handleNotificationAction(
+            actionIdentifier: "FAMILY_ASSISTANT_APPROVE",
+            categoryIdentifier: "FAMILY_ASSISTANT_CONFIRMATION",
+            title: "Confirmation needed",
+            body: "Create a note?",
+            userInfo: ["request_id": "confirm_abc", "conversation_id": "web_conv_1"]
+        )
+
+        await fulfillment(of: [requestCompleted], timeout: 2.0)
+        XCTAssertNil(manager.pendingConfirmationModal)
+    }
+
+    func testDenyActionSubmitsRejectionToConfirmEndpoint() async throws {
+        seedStoredAuth()
+        let manager = NotificationManager()
+        manager.bind(authManager: makeAuthManager())
+
+        let requestCompleted = expectation(description: "confirm_tool POST")
+        NotificationBackendURLProtocol.respond { request in
+            let payload = try XCTUnwrap(Self.jsonObject(from: request) as? [String: Any])
+            XCTAssertEqual(payload["request_id"] as? String, "confirm_def")
+            XCTAssertEqual(payload["approved"] as? Bool, false)
+            requestCompleted.fulfill()
+            return .json(#"{"success":true}"#)
+        }
+
+        manager.handleNotificationAction(
+            actionIdentifier: "FAMILY_ASSISTANT_DENY",
+            categoryIdentifier: "FAMILY_ASSISTANT_CONFIRMATION",
+            title: "Confirmation needed",
+            body: "Create a note?",
+            userInfo: ["request_id": "confirm_def"]
+        )
+
+        await fulfillment(of: [requestCompleted], timeout: 2.0)
+    }
+
+    func testDefaultTapOnConfirmationPresentsModalWithoutNavigating() throws {
+        let manager = NotificationManager()
+
+        manager.handleNotificationAction(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            categoryIdentifier: "FAMILY_ASSISTANT_CONFIRMATION",
+            title: "Confirmation needed",
+            body: "Create a note for this itinerary?",
+            userInfo: ["request_id": "confirm_xyz", "conversation_id": "web_conv_9"]
+        )
+
+        let modal = try XCTUnwrap(manager.pendingConfirmationModal)
+        XCTAssertEqual(modal.requestID, "confirm_xyz")
+        XCTAssertEqual(modal.conversationID, "web_conv_9")
+        XCTAssertEqual(modal.body, "Create a note for this itinerary?")
+        XCTAssertNil(manager.pendingNavigationPath)
+    }
+
+    func testDefaultTapOnMessageNotificationSetsNavigationPathWithoutModal() {
+        let manager = NotificationManager()
+
+        manager.handleNotificationAction(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            categoryIdentifier: "FAMILY_ASSISTANT_MESSAGE",
+            title: "New message",
+            body: "Hello there",
+            userInfo: ["conversation_id": "web_conv_5"]
+        )
+
+        XCTAssertNil(manager.pendingConfirmationModal)
+        XCTAssertEqual(manager.pendingNavigationPath, "/chat?conversation_id=web_conv_5")
+    }
+
+    func testDismissingConfirmationDoesNothing() {
+        let manager = NotificationManager()
+
+        manager.handleNotificationAction(
+            actionIdentifier: UNNotificationDismissActionIdentifier,
+            categoryIdentifier: "FAMILY_ASSISTANT_CONFIRMATION",
+            title: "Confirmation needed",
+            body: "Create a note?",
+            userInfo: ["request_id": "confirm_dismissed"]
+        )
+
+        XCTAssertNil(manager.pendingConfirmationModal)
+        XCTAssertNil(manager.pendingNavigationPath)
+    }
+
+    func testClearPendingConfirmationModalResetsState() {
+        let manager = NotificationManager()
+        manager.handleNotificationAction(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            categoryIdentifier: "FAMILY_ASSISTANT_CONFIRMATION",
+            title: "Confirmation needed",
+            body: "Create a note?",
+            userInfo: ["request_id": "confirm_clear"]
+        )
+        XCTAssertNotNil(manager.pendingConfirmationModal)
+
+        manager.clearPendingConfirmationModal()
+
+        XCTAssertNil(manager.pendingConfirmationModal)
+    }
+
     private func makeAuthManager() -> AuthManager {
         let authManager = AuthManager()
         authManager.serverURL = "https://assistant.example.test"

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -1797,13 +1797,20 @@ async def get_tool_confirmation(
         ) from exc
 
     now = datetime.now(UTC)
+    # A pending row whose deadline has passed but that the background sweep (mark_expired) has not
+    # processed yet must still be reported as expired, so a client does not offer Approve/Reject for
+    # a request that confirm_tool would reject. The GET stays read-only; the sweep persists the
+    # transition.
+    status = row["status"]
+    if status == "pending" and row["expires_at"] <= now:
+        status = "expired"
     return ToolConfirmationDetail(
         request_id=row["id"],
         tool_name=row["tool_name"],
         tool_call_id=row["tool_call_id"],
         confirmation_prompt=row["confirmation_prompt"],
         args=row["tool_args_json"],
-        status=row["status"],
+        status=status,
         created_at=row["created_at"],
         expires_at=row["expires_at"],
         time_remaining_seconds=max(0.0, (row["expires_at"] - now).total_seconds()),

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -547,6 +547,30 @@ class PendingToolConfirmationsResponse(BaseModel):
     )
 
 
+class ToolConfirmationDetail(BaseModel):
+    """A single durable tool confirmation, including its current status.
+
+    Unlike :class:`PendingToolConfirmation`, this is returned regardless of status so a client (for
+    example the iOS confirmation modal opened from a push notification) can render the request even
+    when it has already been approved, rejected, or expired.
+    """
+
+    request_id: str = Field(..., description="Confirmation request ID")
+    tool_name: str = Field(..., description="Tool awaiting approval")
+    tool_call_id: str | None = Field(None, description="Associated LLM tool call ID")
+    confirmation_prompt: str = Field(..., description="Prompt shown to the user")
+    # ast-grep-ignore: no-dict-any - Tool arguments vary per tool and cannot be statically typed
+    args: dict[str, Any] = Field(..., description="Tool arguments awaiting approval")
+    status: str = Field(
+        ..., description="Current status: pending, approved, rejected, or expired"
+    )
+    created_at: datetime = Field(..., description="Request creation timestamp")
+    expires_at: datetime = Field(..., description="Request expiration timestamp")
+    time_remaining_seconds: float = Field(
+        ..., description="Seconds from response generation until expiration"
+    )
+
+
 class ServiceProfile(BaseModel):
     """Information about an available service profile."""
 
@@ -1743,6 +1767,47 @@ async def list_pending_tool_confirmations(
         for row in rows
     ]
     return PendingToolConfirmationsResponse(confirmations=confirmations)
+
+
+@chat_api_router.get("/v1/chat/confirmations/{request_id}")
+async def get_tool_confirmation(
+    request_id: str,
+    request: Request,
+    current_user: Annotated[dict, Depends(get_current_user)],
+) -> ToolConfirmationDetail:
+    """Return a single durable tool confirmation owned by the current user.
+
+    Used by clients that open a confirmation directly (for example the iOS modal launched by
+    tapping a confirmation push notification) and need the full prompt, arguments, and current
+    status. Requests that do not exist or belong to another user return 404 so existence is not
+    leaked across users.
+    """
+    confirmation_service = _get_confirmation_service(request)
+    try:
+        row = await confirmation_service.get_for_user(
+            request_id=request_id,
+            user_id=current_user["user_identifier"],
+        )
+    except (ConfirmationNotFoundError, ConfirmationAuthorizationError) as exc:
+        logger.info(
+            "Confirmation %s not available to current user: %s", request_id, exc
+        )
+        raise HTTPException(
+            status_code=404, detail="Confirmation request not found"
+        ) from exc
+
+    now = datetime.now(UTC)
+    return ToolConfirmationDetail(
+        request_id=row["id"],
+        tool_name=row["tool_name"],
+        tool_call_id=row["tool_call_id"],
+        confirmation_prompt=row["confirmation_prompt"],
+        args=row["tool_args_json"],
+        status=row["status"],
+        created_at=row["created_at"],
+        expires_at=row["expires_at"],
+        time_remaining_seconds=max(0.0, (row["expires_at"] - now).total_seconds()),
+    )
 
 
 @chat_api_router.get("/v1/chat/events")

--- a/tests/functional/web/api/test_chat_confirmations.py
+++ b/tests/functional/web/api/test_chat_confirmations.py
@@ -104,6 +104,73 @@ async def test_pending_confirmations_lists_only_current_user_unexpired_requests(
 
 
 @pytest.mark.asyncio
+async def test_get_confirmation_returns_detail_for_owner(
+    api_test_client: AsyncClient,
+    db_engine: AsyncEngine,
+) -> None:
+    request_id = await _create_confirmation(db_engine)
+
+    response = await api_test_client.get(f"/api/v1/chat/confirmations/{request_id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["request_id"] == request_id
+    assert body["tool_name"] == "add_or_update_note"
+    assert body["tool_call_id"] == "tool-call-123"
+    assert body["confirmation_prompt"] == "Create a note for this itinerary?"
+    assert body["args"] == {"title": "Trip", "content": "Flight lands at 6pm"}
+    assert body["status"] == "pending"
+    assert body["time_remaining_seconds"] > 0
+
+
+@pytest.mark.asyncio
+async def test_get_confirmation_reports_status_after_resolution(
+    api_test_client: AsyncClient,
+    db_engine: AsyncEngine,
+) -> None:
+    request_id = await _create_confirmation(db_engine)
+
+    await api_test_client.post(
+        "/api/v1/chat/confirm_tool",
+        json={"request_id": request_id, "approved": False},
+    )
+
+    response = await api_test_client.get(f"/api/v1/chat/confirmations/{request_id}")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_get_confirmation_unknown_request_returns_404(
+    api_test_client: AsyncClient,
+) -> None:
+    response = await api_test_client.get("/api/v1/chat/confirmations/confirm_missing")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_confirmation_for_other_user_returns_404(
+    app_fixture: FastAPI,
+    api_test_client: AsyncClient,
+    db_engine: AsyncEngine,
+) -> None:
+    request_id = await _create_confirmation(db_engine, request_user_id="owner_user")
+
+    async def other_user() -> dict[str, object]:
+        return {"user_identifier": "other_user"}
+
+    app_fixture.dependency_overrides[get_current_user] = other_user
+    try:
+        response = await api_test_client.get(f"/api/v1/chat/confirmations/{request_id}")
+    finally:
+        app_fixture.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_approving_pending_confirmation_via_web_enqueues_execution_task(
     api_test_client: AsyncClient,
     db_engine: AsyncEngine,

--- a/tests/functional/web/api/test_chat_confirmations.py
+++ b/tests/functional/web/api/test_chat_confirmations.py
@@ -142,6 +142,24 @@ async def test_get_confirmation_reports_status_after_resolution(
 
 
 @pytest.mark.asyncio
+async def test_get_confirmation_derives_expired_status_before_sweep(
+    api_test_client: AsyncClient,
+    db_engine: AsyncEngine,
+) -> None:
+    request_id = await _create_confirmation(
+        db_engine,
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+
+    response = await api_test_client.get(f"/api/v1/chat/confirmations/{request_id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "expired"
+    assert body["time_remaining_seconds"] == 0
+
+
+@pytest.mark.asyncio
 async def test_get_confirmation_unknown_request_returns_404(
     api_test_client: AsyncClient,
 ) -> None:


### PR DESCRIPTION
Confirmation push notifications on iOS already carried Approve/Reject
action buttons. This makes tapping the notification body open an in-app
confirmation modal showing the full request, with Approve/Reject buttons.

Backend:
- Add GET /api/v1/chat/confirmations/{request_id} returning a single
  confirmation with its live status (pending/approved/rejected/expired),
  404 for unknown or other-user requests so existence is not leaked.

iOS:
- NotificationManager routes a confirmation body-tap to a new
  pendingConfirmationModal instead of deep-linking; action handling is
  extracted into a testable handleNotificationAction seam.
- ConfirmationModalView fetches the confirmation detail, renders the
  prompt/tool/arguments and live status, and submits Approve/Reject via
  confirm_tool. Resolved/expired requests are read-only; a failed detail
  fetch falls back to the notification payload so the user can still act.
- ContentView presents the modal as a top-level sheet.

Tests: backend endpoint coverage, NotificationManager action routing, and
ConfirmationModalModel load/submit behaviour.

Docs: updated the iOS push design doc and user guide.