### PR TITLE
Add TestFlight/App Review sandbox (runs entirely on OpenRouter)

### DIFF
--- a/deploy/testflight-sandbox/.env.example
+++ b/deploy/testflight-sandbox/.env.example
@@ -1,0 +1,29 @@
+# Environment for the docker-compose sandbox. Copy to .env and fill in.
+# Do NOT commit the filled-in .env.
+
+# --- Public URLs (behind your reverse proxy / TLS; no trailing slash) ---
+# Must be reachable identically from the browser AND the app container.
+APP_BASE_URL=https://fa-sandbox.example.com
+DEX_ISSUER=https://fa-sandbox-dex.example.com
+
+# --- Shared OIDC client credentials (app <-> dex) ---
+OIDC_CLIENT_ID=family-assistant-sandbox
+# Any long random string; must be identical on both services.
+#   openssl rand -hex 32
+OIDC_CLIENT_SECRET=
+
+# --- The single demo account handed to Apple ---
+DEMO_EMAIL=appreview-demo@example.com
+# bcrypt hash of the demo password:
+#   htpasswd -bnBC 10 "" 'your-demo-password' | tr -d ':\n'
+DEMO_PASSWORD_HASH=
+
+# --- App secrets ---
+#   openssl rand -hex 32
+SESSION_SECRET_KEY=
+POSTGRES_PASSWORD=
+# Dedicated, quota-capped OpenRouter key (https://openrouter.ai/settings/keys).
+# Used for BOTH chat (deepseek/deepseek-v4-flash) and embeddings
+# (openai/text-embedding-3-small) via OpenRouter's OpenAI-compatible API.
+# Set a hard credit limit on the key so a leaked demo login can't run up a bill.
+OPENROUTER_API_KEY=

--- a/deploy/testflight-sandbox/README.md
+++ b/deploy/testflight-sandbox/README.md
@@ -113,7 +113,9 @@ For a VPS you already run behind a reverse proxy with TLS.
 1. `cp .env.example .env` and fill every value. `APP_BASE_URL` and `DEX_ISSUER` must be the **public
    HTTPS URLs** your reverse proxy serves (see the reachability note at the top of
    `docker-compose.yaml`).
-2. Point your reverse proxy at `app:8000` and `dex:5556`.
+2. Point your reverse proxy at the published host ports `127.0.0.1:8000` (app) and
+   `127.0.0.1:5556` (dex). (Only a proxy running *inside* the compose network would
+   use the service names `app:8000` / `dex:5556`.)
 3. Bring it up:
    ```bash
    docker compose --env-file .env up --build -d

--- a/deploy/testflight-sandbox/README.md
+++ b/deploy/testflight-sandbox/README.md
@@ -1,0 +1,145 @@
+# TestFlight / App Review Sandbox
+
+A **separate, self-contained deployment** of Family Assistant for handing to Apple (TestFlight Beta
+App Review or App Store review) without exposing your real data or letting anyone on the internet
+use your LLM API key.
+
+It bundles a tiny [Dex](https://dexidp.io/) OIDC provider so the deployment can require a real login
+**with zero external identity-provider signup** — Dex owns a single demo account whose credentials
+you control and hand to Apple.
+
+## Why this is safe
+
+| Concern                                    | How it's handled                                                                                                                                                                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Private data exposure                      | Brand-new, empty database. Your family's data never touches this instance.                                                                                                                             |
+| Random internet users burning your API key | Every tool/LLM call sits behind OIDC auth. `ALLOWED_OIDC_EMAILS` restricts login to the one demo account — enforced for both the web session (`auth.py`) and the native iOS PKCE flow (`app_auth.py`). |
+| A leaked demo credential running up a bill | Use a **dedicated, quota-capped OpenRouter key** with a hard credit limit. The whole sandbox runs on the cheap `deepseek/deepseek-v4-flash` model, and `config.yaml` caps `max_iterations`.                |
+| Untrusted-input attack surface             | Telegram, email intake, Home Assistant, calendars, and push are all left unconfigured (disabled), leaving only the web + iOS surfaces a reviewer needs.                                                |
+
+> Auth note: this sandbox deliberately does **not** set a `users:` mapping. With no users
+> configured, Family Assistant uses the OIDC email/subject directly as the identity, so the email
+> allowlist is the only gate you need to manage.
+
+## Models (one cheap key for everything)
+
+Both the LLM and embeddings run through **OpenRouter's OpenAI-compatible API** — i.e. the app's
+`openai` provider pointed at `https://openrouter.ai/api/v1` via `OPENAI_BASE_URL`. A single
+quota-capped OpenRouter key powers both:
+
+| Use        | Model                            | Why                                                                                                              |
+| ---------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Chat       | `deepseek/deepseek-v4-flash`     | Cheapest output ($0.18/1M) among reputable tool-calling models, with the best agentic-tool-use benchmarks in its tier — reliable function calling is what the demo needs. |
+| Embeddings | `openai/text-embedding-3-small`  | 1536-dim, cheap, served by OpenRouter on the same key.                                                           |
+
+`config.yaml` pins **every** service profile to the chat model with `provider: openai`, so even the
+research / complex-tasks / automation profiles route to the one cheap model instead of their
+default Gemini/Claude/GPT pins.
+
+> **Dependency:** the OpenAI-compatible embedding provider comes from PR #909
+> (`feat/openai-compatible-embeddings`). This sandbox must be deployed from a branch that includes
+> it (it is already merged into this branch's base).
+
+## What's in this folder
+
+| File                  | Purpose                                                  |
+| --------------------- | -------------------------------------------------------- |
+| `render.yaml`         | Render Blueprint: Postgres + app + Dex, wired together.  |
+| `docker-compose.yaml` | Self-hosted (VPS / local) variant of the same stack.     |
+| `.env.example`        | Template for the compose variant. Copy to `.env`.        |
+| `config.yaml`         | Family Assistant overrides (cost cap, integrations off). |
+| `dex/config.yaml`     | Dex config — one static demo user, one OIDC client.      |
+| `dex/Dockerfile`      | Official Dex image with the config baked in.             |
+
+## Prerequisites (both paths)
+
+1. **A dedicated, quota-capped OpenRouter key.** Create a key at
+   <https://openrouter.ai/settings/keys> and set a hard credit limit on it. This single key powers
+   both chat and embeddings (via OpenRouter's OpenAI-compatible API). Never reuse your personal key
+   here.
+2. **A demo password hash.** Pick a demo password and bcrypt it:
+   ```bash
+   htpasswd -bnBC 10 "" 'your-demo-password' | tr -d ':\n'
+   ```
+   (`htpasswd` ships with `apache2-utils` / `httpd-tools`.)
+3. A demo email address, e.g. `appreview-demo@example.com`. It does **not** need to be a real,
+   deliverable mailbox — Dex just checks the password — but pick something sensible to show the
+   reviewer.
+
+______________________________________________________________________
+
+## Path A — Render (recommended)
+
+Render reads `render.yaml` from the repo root by default, so either point the Blueprint instance at
+this file's path, or copy it to the repo root on a dedicated sandbox branch.
+
+### First deploy
+
+1. Create the Blueprint from `deploy/testflight-sandbox/render.yaml`. Render provisions the database
+   and both web services and prompts for the `sync: false` values — you can leave the three URL
+   values blank for now.
+
+2. Once the services are up, note their assigned public URLs, e.g. `https://fa-sandbox.onrender.com`
+   and `https://fa-sandbox-dex.onrender.com`.
+
+3. Set the URL env vars that couldn't be known until now, then redeploy both services:
+
+   | Service          | Variable              | Value                                                                  |
+   | ---------------- | --------------------- | ---------------------------------------------------------------------- |
+   | `fa-sandbox-dex` | `DEX_ISSUER`          | `https://fa-sandbox-dex.onrender.com`                                  |
+   | `fa-sandbox-dex` | `APP_BASE_URL`        | `https://fa-sandbox.onrender.com`                                      |
+   | `fa-sandbox-dex` | `DEMO_EMAIL`          | `appreview-demo@example.com`                                           |
+   | `fa-sandbox-dex` | `DEMO_PASSWORD_HASH`  | *(bcrypt hash from above)*                                             |
+   | `fa-sandbox`     | `OIDC_DISCOVERY_URL`  | `https://fa-sandbox-dex.onrender.com/.well-known/openid-configuration` |
+   | `fa-sandbox`     | `ALLOWED_OIDC_EMAILS` | `appreview-demo@example.com`                                           |
+   | `fa-sandbox`     | `OPENAI_API_KEY`      | *(your capped OpenRouter key)*                                         |
+
+   `OIDC_CLIENT_SECRET` is generated on the app and copied to Dex automatically;
+   `SESSION_SECRET_KEY` is auto-generated. You don't set either by hand.
+
+4. Visit `https://fa-sandbox.onrender.com`, log in with the demo email + password, and confirm it
+   works end to end.
+
+> **Cold starts:** Render's `starter` instances sleep when idle and take ~30–60s to wake. That can
+> make the reviewer's *first* request look broken. Warm both services right before you submit, or
+> bump to a plan that doesn't idle.
+
+______________________________________________________________________
+
+## Path B — Self-hosted (docker-compose)
+
+For a VPS you already run behind a reverse proxy with TLS.
+
+1. `cp .env.example .env` and fill every value. `APP_BASE_URL` and `DEX_ISSUER` must be the **public
+   HTTPS URLs** your reverse proxy serves (see the reachability note at the top of
+   `docker-compose.yaml`).
+2. Point your reverse proxy at `app:8000` and `dex:5556`.
+3. Bring it up:
+   ```bash
+   docker compose --env-file .env up --build -d
+   ```
+
+______________________________________________________________________
+
+## Pointing the app at the sandbox
+
+The iOS app authenticates against whatever server URL it's configured with, and the OIDC redirect
+URIs Dex accepts are `<APP_BASE_URL>/auth` (web) and `<APP_BASE_URL>/app-auth-callback` (native).
+Make sure the TestFlight build either targets the sandbox host or lets the tester enter it — and
+tell Apple which URL to use in the review notes if it's user-entered.
+
+## What to give Apple
+
+In App Store Connect → your build → **Beta App Review Information** (or App Review Information),
+provide:
+
+- **Sign-in required:** Yes
+- **Username:** the demo email
+- **Password:** the demo password (the plaintext you hashed)
+- **Notes:** the sandbox server URL, if the app asks the tester to enter one.
+
+## Tearing it down
+
+Delete the Render Blueprint (or `docker compose down -v`) when review is complete. Because the
+database was never shared with production, nothing of yours is left behind. Revoke the capped
+OpenRouter key for good measure.

--- a/deploy/testflight-sandbox/config.yaml
+++ b/deploy/testflight-sandbox/config.yaml
@@ -1,0 +1,94 @@
+# Family Assistant config overrides for the TestFlight / App Review sandbox.
+#
+# This is deep-merged on top of the shipped defaults.yaml. It is mounted into
+# the app container by docker-compose.yaml, and baked into the image on Render
+# (see deploy/testflight-sandbox/app/Dockerfile + render.yaml).
+#
+# Goal: run the WHOLE sandbox on a single, cheap OpenRouter model so a reviewer
+# can exercise the full agentic feature set without burning a real provider key.
+#
+# How the routing works:
+#   * Chat: every profile is pinned to "deepseek/deepseek-v4-flash" with
+#     provider "openai". The OpenAI client is pointed at OpenRouter via the
+#     OPENAI_BASE_URL env var (see docker-compose.yaml / render.yaml), so this is
+#     literally "the OpenAI provider with a custom base URL". provider must be
+#     set explicitly because "deepseek/..." is not auto-detected.
+#   * Embeddings: openai/text-embedding-3-small through the same OpenRouter
+#     endpoint, configured entirely via env vars (EMBEDDING_PROVIDER=openai etc.;
+#     see docker-compose.yaml). Requires the OpenAI-compatible embedding provider
+#     from PR #909.
+#
+# Why deepseek/deepseek-v4-flash: cheapest output ($0.18/1M) among reputable
+# tool-calling models on OpenRouter, with the best agentic-tool-use benchmarks in
+# its price tier (tau2-bench 95.6, GPQA-D 86.7). It tool-calls reliably, which is
+# what the demo needs. The OpenRouter key should be a dedicated, quota-capped key.
+
+default_profile_settings:
+  processing_config:
+    # Replace the shipped google/openai retry_config with the single cheap model.
+    # null here clears the inherited retry_config so the simple llm_model+provider
+    # path is used. This covers every profile that does not pin its own model
+    # (default_assistant, email_intake, reminder, browser_profile,
+    # data_visualization, telephone, telephone_external).
+    retry_config: null
+    provider: "openai"
+    llm_model: "deepseek/deepseek-v4-flash"
+    # Cap the per-request reasoning/tool-call budget to bound API cost.
+    max_iterations: 8
+
+# Profiles that pin their own model in defaults.yaml must be overridden by id
+# (service_profiles is merged by id, so unlisted profiles are preserved). Each is
+# collapsed onto the single cheap model.
+service_profiles:
+  - id: "browser_visual_profile"
+    processing_config:
+      provider: "openai"
+      llm_model: "deepseek/deepseek-v4-flash"
+      retry_config: null
+  - id: "research"
+    processing_config:
+      provider: "openai"
+      llm_model: "deepseek/deepseek-v4-flash"
+  - id: "research_max"
+    processing_config:
+      provider: "openai"
+      llm_model: "deepseek/deepseek-v4-flash"
+  - id: "event_handler"
+    processing_config:
+      provider: "openai"
+      llm_model: "deepseek/deepseek-v4-flash"
+  - id: "automation_creation"
+    processing_config:
+      provider: "openai"
+      llm_model: "deepseek/deepseek-v4-flash"
+  - id: "artist"
+    processing_config:
+      provider: "openai"
+      llm_model: "deepseek/deepseek-v4-flash"
+  - id: "complex_tasks"
+    processing_config:
+      provider: "openai"
+      llm_model: "deepseek/deepseek-v4-flash"
+      # Keep the cost cap even for the "complex" profile in the sandbox.
+      max_iterations: 8
+  - id: "engineer"
+    processing_config:
+      provider: "openai"
+      llm_model: "deepseek/deepseek-v4-flash"
+  # camera_analyst pins its model via retry_config, which takes precedence over
+  # llm_model/provider. Override the retry_config itself: single cheap primary,
+  # no fallback.
+  - id: "camera_analyst"
+    processing_config:
+      retry_config:
+        primary:
+          provider: "openai"
+          model: "deepseek/deepseek-v4-flash"
+        fallback: null
+
+email_intake:
+  # The email webhook is the main untrusted-input channel. It is inert without
+  # a Mailgun signing key, but we also hard-disable actions and require
+  # authenticated senders as defence in depth.
+  enable_actions: false
+  require_authenticated_sender: true

--- a/deploy/testflight-sandbox/dex/Dockerfile
+++ b/deploy/testflight-sandbox/dex/Dockerfile
@@ -1,0 +1,14 @@
+# Minimal Dex image for the Family Assistant sandbox: the official Dex image
+# plus our baked-in config. All deployment-specific values are supplied at
+# runtime via environment variables (see config.yaml), so this image contains
+# no secrets and is safe to rebuild anywhere.
+#
+# Build context for this image is deploy/testflight-sandbox/dex (see render.yaml
+# / docker-compose.yaml), so config.yaml is referenced relative to that dir.
+FROM ghcr.io/dexidp/dex:v2.41.1
+
+COPY config.yaml /etc/dex/config.yaml
+
+# The base image's entrypoint is the dex binary wrapper; we only override the
+# config path it serves.
+CMD ["dex", "serve", "/etc/dex/config.yaml"]

--- a/deploy/testflight-sandbox/dex/config.yaml
+++ b/deploy/testflight-sandbox/dex/config.yaml
@@ -1,0 +1,55 @@
+# Dex configuration for the Family Assistant TestFlight / App Review sandbox.
+#
+# This runs a tiny, self-contained OIDC provider so the sandbox can require a
+# real login without depending on any external identity provider (Google,
+# Auth0, etc.). A single static demo account is defined; only that account can
+# ever obtain a token, which is what keeps the deployment's LLM API key out of
+# the hands of anyone on the internet.
+#
+# All deployment-specific values are injected via environment variables and
+# expanded by Dex at startup (Dex performs ${VAR} substitution on this file).
+# See deploy/testflight-sandbox/README.md for the full setup.
+
+# Public, browser-reachable URL of THIS Dex service (no trailing slash).
+# e.g. https://family-assistant-sandbox-dex.onrender.com
+issuer: ${DEX_ISSUER}
+
+# In-memory storage keeps things brain-dead: no database, no disk.
+# Signing keys regenerate on restart, which only forces a fresh login. The
+# API tokens Family Assistant issues after login live in ITS database (bcrypt
+# hashed) and are unaffected by Dex restarting.
+storage:
+  type: memory
+
+web:
+  # Render injects $PORT; docker-compose sets it explicitly. Dex must listen
+  # on this address for the platform to route traffic to it.
+  http: 0.0.0.0:${PORT}
+
+oauth2:
+  # Skip the "Grant Access" consent screen — there is one client and one user,
+  # so the screen adds nothing but friction for the reviewer.
+  skipApprovalScreen: true
+
+# Local username/password database (no upstream connectors needed).
+enablePasswordDB: true
+staticPasswords:
+  - email: "${DEMO_EMAIL}"
+    # bcrypt hash of the demo password. Passed via env so the literal '$'
+    # characters in the hash are not themselves treated as variables.
+    # Generate with:  htpasswd -bnBC 10 "" 'your-password' | tr -d ':\n'
+    hash: "${DEMO_PASSWORD_HASH}"
+    username: "App Review Demo"
+    userID: "appreview-demo-0001"
+
+staticClients:
+  - id: "${OIDC_CLIENT_ID}"
+    secret: "${OIDC_CLIENT_SECRET}"
+    name: "Family Assistant Sandbox"
+    # Family Assistant uses two OIDC callbacks on its OWN host:
+    #   /auth               -> web UI session login (auth.py)
+    #   /app-auth-callback  -> native iOS PKCE login (app_auth.py)
+    redirectURIs:
+      - "${APP_BASE_URL}/auth"
+      - "${APP_BASE_URL}/app-auth-callback"
+

--- a/deploy/testflight-sandbox/dex/config.yaml
+++ b/deploy/testflight-sandbox/dex/config.yaml
@@ -6,13 +6,13 @@
 # ever obtain a token, which is what keeps the deployment's LLM API key out of
 # the hands of anyone on the internet.
 #
-# All deployment-specific values are injected via environment variables and
-# expanded by Dex at startup (Dex performs ${VAR} substitution on this file).
-# See deploy/testflight-sandbox/README.md for the full setup.
+# Templating: the official Dex image's docker-entrypoint renders this file with
+# gomplate (NOT shell ${VAR} substitution), so values are injected with
+# `{{ getenv "VAR" }}`. See deploy/testflight-sandbox/README.md for setup.
 
 # Public, browser-reachable URL of THIS Dex service (no trailing slash).
 # e.g. https://family-assistant-sandbox-dex.onrender.com
-issuer: ${DEX_ISSUER}
+issuer: '{{ getenv "DEX_ISSUER" }}'
 
 # In-memory storage keeps things brain-dead: no database, no disk.
 # Signing keys regenerate on restart, which only forces a fresh login. The
@@ -24,7 +24,7 @@ storage:
 web:
   # Render injects $PORT; docker-compose sets it explicitly. Dex must listen
   # on this address for the platform to route traffic to it.
-  http: 0.0.0.0:${PORT}
+  http: '0.0.0.0:{{ getenv "PORT" }}'
 
 oauth2:
   # Skip the "Grant Access" consent screen — there is one client and one user,
@@ -34,24 +34,22 @@ oauth2:
 # Local username/password database (no upstream connectors needed).
 enablePasswordDB: true
 staticPasswords:
-  - email: "${DEMO_EMAIL}"
-    # bcrypt hash of the demo password. Use hashFromEnv (NOT hash: ${...}): the
-    # hash contains literal '$' characters which Dex's ${VAR} expansion would
-    # otherwise mangle ("malformed bcrypt hash"). hashFromEnv reads the env var
-    # value verbatim, so the '$' survive.
+  - email: '{{ getenv "DEMO_EMAIL" }}'
+    # bcrypt hash of the demo password. Use hashFromEnv (NOT a templated hash):
+    # Dex reads the env var value verbatim, so the literal '$' characters in the
+    # bcrypt hash are safe. (gomplate would otherwise need careful escaping.)
     # Generate with:  htpasswd -bnBC 10 "" 'your-password' | tr -d ':\n'
     hashFromEnv: "DEMO_PASSWORD_HASH"
     username: "App Review Demo"
     userID: "appreview-demo-0001"
 
 staticClients:
-  - id: "${OIDC_CLIENT_ID}"
-    secret: "${OIDC_CLIENT_SECRET}"
+  - id: '{{ getenv "OIDC_CLIENT_ID" }}'
+    secret: '{{ getenv "OIDC_CLIENT_SECRET" }}'
     name: "Family Assistant Sandbox"
     # Family Assistant uses two OIDC callbacks on its OWN host:
     #   /auth               -> web UI session login (auth.py)
     #   /app-auth-callback  -> native iOS PKCE login (app_auth.py)
     redirectURIs:
-      - "${APP_BASE_URL}/auth"
-      - "${APP_BASE_URL}/app-auth-callback"
-
+      - '{{ getenv "APP_BASE_URL" }}/auth'
+      - '{{ getenv "APP_BASE_URL" }}/app-auth-callback'

--- a/deploy/testflight-sandbox/dex/config.yaml
+++ b/deploy/testflight-sandbox/dex/config.yaml
@@ -35,10 +35,12 @@ oauth2:
 enablePasswordDB: true
 staticPasswords:
   - email: "${DEMO_EMAIL}"
-    # bcrypt hash of the demo password. Passed via env so the literal '$'
-    # characters in the hash are not themselves treated as variables.
+    # bcrypt hash of the demo password. Use hashFromEnv (NOT hash: ${...}): the
+    # hash contains literal '$' characters which Dex's ${VAR} expansion would
+    # otherwise mangle ("malformed bcrypt hash"). hashFromEnv reads the env var
+    # value verbatim, so the '$' survive.
     # Generate with:  htpasswd -bnBC 10 "" 'your-password' | tr -d ':\n'
-    hash: "${DEMO_PASSWORD_HASH}"
+    hashFromEnv: "DEMO_PASSWORD_HASH"
     username: "App Review Demo"
     userID: "appreview-demo-0001"
 

--- a/deploy/testflight-sandbox/docker-compose.yaml
+++ b/deploy/testflight-sandbox/docker-compose.yaml
@@ -50,7 +50,9 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://assistant:${POSTGRES_PASSWORD}@postgres:5432/family_assistant
+      # SQLAlchemy's async engine needs the asyncpg driver scheme (plain
+      # postgresql:// resolves to a sync driver and fails at startup).
+      DATABASE_URL: postgresql+asyncpg://assistant:${POSTGRES_PASSWORD}@postgres:5432/family_assistant
       SESSION_SECRET_KEY: ${SESSION_SECRET_KEY:?random session secret}
       TIMEZONE: UTC
       OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-family-assistant-sandbox}

--- a/deploy/testflight-sandbox/docker-compose.yaml
+++ b/deploy/testflight-sandbox/docker-compose.yaml
@@ -72,6 +72,9 @@ services:
       EMBEDDING_BASE_URL: https://openrouter.ai/api/v1
       EMBEDDING_MODEL: openai/text-embedding-3-small
       EMBEDDING_DIMENSIONS: "1536"
+      # Disable the bundled MCP servers (need API keys, slow startup). A non-empty
+      # MCP_CONFIG_PATH replaces the default mcp_config with zero servers.
+      MCP_CONFIG_PATH: /app/deploy/testflight-sandbox/mcp-empty.json
       DOCUMENT_STORAGE_PATH: /data/documents
       ATTACHMENT_STORAGE_PATH: /data/attachments
       CHAT_ATTACHMENT_STORAGE_PATH: /data/chat_attachments

--- a/deploy/testflight-sandbox/docker-compose.yaml
+++ b/deploy/testflight-sandbox/docker-compose.yaml
@@ -8,7 +8,9 @@
 #   it must match Dex's configured issuer exactly. The reliable way to satisfy
 #   this is to put both services behind your own reverse proxy with real
 #   HTTPS hostnames and set APP_BASE_URL / DEX_ISSUER to those public URLs.
-#   The proxy should forward to app:8000 and dex:5556 respectively.
+#   A host-level reverse proxy should forward to the published host ports
+#   127.0.0.1:8000 (app) and 127.0.0.1:5556 (dex). Only if the proxy itself runs
+#   inside this compose network would it use the service names app:8000 / dex:5556.
 #
 # Copy .env.example to .env and fill it in before running:
 #   docker compose --env-file .env up --build
@@ -40,7 +42,9 @@ services:
       DEMO_EMAIL: ${DEMO_EMAIL:?demo account email}
       DEMO_PASSWORD_HASH: ${DEMO_PASSWORD_HASH:?bcrypt hash of demo password}
     ports:
-      - "5556:5556"
+      # Bind to localhost only: the reverse proxy (which terminates TLS) forwards
+      # here. Publishing on all interfaces would expose the plain-HTTP backend.
+      - "127.0.0.1:5556:5556"
 
   app:
     build:
@@ -83,7 +87,8 @@ services:
       - ./config.yaml:/app/config.yaml:ro
       - appdata:/data
     ports:
-      - "8000:8000"
+      # Localhost only; the TLS-terminating reverse proxy forwards here.
+      - "127.0.0.1:8000:8000"
 
 volumes:
   pgdata:

--- a/deploy/testflight-sandbox/docker-compose.yaml
+++ b/deploy/testflight-sandbox/docker-compose.yaml
@@ -1,0 +1,86 @@
+# Self-hosted (VPS / local) variant of the Family Assistant TestFlight / App
+# Review sandbox. Stands up Postgres + the app + a self-contained Dex OIDC
+# provider, all locked to a single demo account.
+#
+# IMPORTANT — OIDC URL reachability:
+#   The OIDC issuer/discovery URL must resolve to the SAME address from both
+#   the user's browser (redirect) and the app container (token exchange), and
+#   it must match Dex's configured issuer exactly. The reliable way to satisfy
+#   this is to put both services behind your own reverse proxy with real
+#   HTTPS hostnames and set APP_BASE_URL / DEX_ISSUER to those public URLs.
+#   The proxy should forward to app:8000 and dex:5556 respectively.
+#
+# Copy .env.example to .env and fill it in before running:
+#   docker compose --env-file .env up --build
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: assistant
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set in .env}
+      POSTGRES_DB: family_assistant
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U assistant -d family_assistant"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  dex:
+    build:
+      context: ./dex
+    environment:
+      PORT: "5556"
+      DEX_ISSUER: ${DEX_ISSUER:?public https URL of the dex service}
+      APP_BASE_URL: ${APP_BASE_URL:?public https URL of the app service}
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-family-assistant-sandbox}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:?shared OIDC client secret}
+      DEMO_EMAIL: ${DEMO_EMAIL:?demo account email}
+      DEMO_PASSWORD_HASH: ${DEMO_PASSWORD_HASH:?bcrypt hash of demo password}
+    ports:
+      - "5556:5556"
+
+  app:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://assistant:${POSTGRES_PASSWORD}@postgres:5432/family_assistant
+      SESSION_SECRET_KEY: ${SESSION_SECRET_KEY:?random session secret}
+      TIMEZONE: UTC
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-family-assistant-sandbox}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:?shared OIDC client secret}
+      OIDC_DISCOVERY_URL: ${DEX_ISSUER}/.well-known/openid-configuration
+      ALLOWED_OIDC_EMAILS: ${DEMO_EMAIL}
+      # --- LLM: OpenRouter via the OpenAI-compatible API ("OpenAI provider with
+      # a custom base URL"). The whole sandbox runs on one cheap model; see
+      # config.yaml, which pins every profile to it with provider "openai". ---
+      OPENAI_API_KEY: ${OPENROUTER_API_KEY:?quota-capped OpenRouter key}
+      OPENAI_BASE_URL: https://openrouter.ai/api/v1
+      LLM_MODEL: deepseek/deepseek-v4-flash
+      # --- Embeddings: same OpenRouter endpoint via the OpenAI-compatible
+      # embedding provider (PR #909). EMBEDDING_API_KEY is omitted because it
+      # falls back to OPENAI_API_KEY (the OpenRouter key set above). ---
+      EMBEDDING_PROVIDER: openai
+      EMBEDDING_BASE_URL: https://openrouter.ai/api/v1
+      EMBEDDING_MODEL: openai/text-embedding-3-small
+      EMBEDDING_DIMENSIONS: "1536"
+      DOCUMENT_STORAGE_PATH: /data/documents
+      ATTACHMENT_STORAGE_PATH: /data/attachments
+      CHAT_ATTACHMENT_STORAGE_PATH: /data/chat_attachments
+    volumes:
+      # Sandbox config overrides (cost cap, integrations off).
+      - ./config.yaml:/app/config.yaml:ro
+      - appdata:/data
+    ports:
+      - "8000:8000"
+
+volumes:
+  pgdata:
+  appdata:
+

--- a/deploy/testflight-sandbox/mcp-empty.json
+++ b/deploy/testflight-sandbox/mcp-empty.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/deploy/testflight-sandbox/render.yaml
+++ b/deploy/testflight-sandbox/render.yaml
@@ -69,13 +69,6 @@ services:
     plan: starter
     region: oregon
     healthCheckPath: /health
-    # The sandbox config.yaml ships inside the image (the root Dockerfile does
-    # `COPY . .`), but the app reads ./config.yaml from its workdir, which isn't
-    # populated on Render. Copy the overlay into place before starting so the
-    # per-profile model overrides apply. (docker-compose mounts it directly.)
-    dockerCommand: >-
-      sh -c "cp deploy/testflight-sandbox/config.yaml /app/config.yaml &&
-      exec opentelemetry-instrument family-assistant"
     envVars:
       - key: DATABASE_URL
         fromDatabase:
@@ -85,6 +78,11 @@ services:
         generateValue: true
       - key: TIMEZONE
         value: UTC
+      # The sandbox config.yaml ships inside the image (the root Dockerfile does
+      # `COPY . .`). CONFIG_FILE points the app at it without needing it mounted
+      # at ./config.yaml. (docker-compose mounts it at /app/config.yaml instead.)
+      - key: CONFIG_FILE
+        value: /app/deploy/testflight-sandbox/config.yaml
 
       # --- OIDC (points at the Dex service above) ---
       - key: OIDC_CLIENT_ID
@@ -102,8 +100,8 @@ services:
 
       # --- LLM: OpenRouter via the OpenAI-compatible API ("OpenAI provider with
       # a custom base URL"). One cheap model runs the whole sandbox; config.yaml
-      # (copied into place by dockerCommand above) pins every profile to it with
-      # provider "openai". Use a dedicated, quota-capped OpenRouter key. ---
+      # (located via CONFIG_FILE above) pins every profile to it with provider
+      # "openai". Use a dedicated, quota-capped OpenRouter key. ---
       - key: OPENAI_API_KEY
         sync: false
       - key: OPENAI_BASE_URL

--- a/deploy/testflight-sandbox/render.yaml
+++ b/deploy/testflight-sandbox/render.yaml
@@ -83,6 +83,12 @@ services:
       # at ./config.yaml. (docker-compose mounts it at /app/config.yaml instead.)
       - key: CONFIG_FILE
         value: /app/deploy/testflight-sandbox/config.yaml
+      # Disable the bundled MCP servers (brave/google-maps/etc.): they need API
+      # keys, runtime-install npm packages, and add ~100s to startup waiting on a
+      # timeout. A non-empty MCP_CONFIG_PATH replaces the default mcp_config, so
+      # this empty file leaves the sandbox with zero MCP servers.
+      - key: MCP_CONFIG_PATH
+        value: /app/deploy/testflight-sandbox/mcp-empty.json
 
       # --- OIDC (points at the Dex service above) ---
       - key: OIDC_CLIENT_ID

--- a/deploy/testflight-sandbox/render.yaml
+++ b/deploy/testflight-sandbox/render.yaml
@@ -1,0 +1,140 @@
+# Render Blueprint for the Family Assistant TestFlight / App Review SANDBOX.
+# https://render.com/docs/blueprint-spec
+#
+# This is a SEPARATE, self-contained deployment from the production blueprint at
+# the repo root (render.yaml). It stands up three things:
+#   - a fresh PostgreSQL database (no production data ever touches it)
+#   - the Family Assistant app, locked to a single demo account
+#   - a tiny Dex OIDC provider that owns that demo account's credentials
+#
+# Because Render does not assign predictable public hostnames until services
+# exist, the three URL values below are marked `sync: false` and must be filled
+# in once, after the first deploy. See deploy/testflight-sandbox/README.md
+# ("First deploy" section) for the exact steps.
+#
+# Render reads `render.yaml` from the repo root by default. To deploy THIS
+# blueprint, create the Blueprint instance pointing at this file's path, or copy
+# it to the repo root on a dedicated sandbox branch.
+
+databases:
+  - name: fa-sandbox-db
+    plan: starter
+    databaseName: family_assistant
+    user: assistant
+    postgresMajorVersion: "16" # pgvector-capable
+
+services:
+  # --- Dex: self-contained OIDC provider -----------------------------------
+  - type: web
+    name: fa-sandbox-dex
+    runtime: docker
+    plan: starter
+    region: oregon
+    dockerfilePath: ./deploy/testflight-sandbox/dex/Dockerfile
+    dockerContext: ./deploy/testflight-sandbox/dex
+    # The discovery doc is always served once the issuer is set, so it makes a
+    # reliable readiness probe.
+    healthCheckPath: /.well-known/openid-configuration
+    envVars:
+      # Public URL of THIS service. Set after first deploy, e.g.
+      #   https://fa-sandbox-dex.onrender.com
+      - key: DEX_ISSUER
+        sync: false
+      # Public URL of the APP service (for OIDC redirect URIs). Set after first
+      # deploy, e.g. https://fa-sandbox.onrender.com
+      - key: APP_BASE_URL
+        sync: false
+      # OIDC client id/secret shared with the app. The id is a fixed string;
+      # the secret is generated on the app service and copied here so both
+      # sides always agree.
+      - key: OIDC_CLIENT_ID
+        value: family-assistant-sandbox
+      - key: OIDC_CLIENT_SECRET
+        fromService:
+          type: web
+          name: fa-sandbox
+          envVarKey: OIDC_CLIENT_SECRET
+      # The single demo account handed to Apple.
+      - key: DEMO_EMAIL
+        sync: false
+      # bcrypt hash of the demo password. Generate with:
+      #   htpasswd -bnBC 10 "" 'your-password' | tr -d ':\n'
+      - key: DEMO_PASSWORD_HASH
+        sync: false
+
+  # --- Family Assistant app ------------------------------------------------
+  - type: web
+    name: fa-sandbox
+    runtime: docker
+    plan: starter
+    region: oregon
+    healthCheckPath: /health
+    # The sandbox config.yaml ships inside the image (the root Dockerfile does
+    # `COPY . .`), but the app reads ./config.yaml from its workdir, which isn't
+    # populated on Render. Copy the overlay into place before starting so the
+    # per-profile model overrides apply. (docker-compose mounts it directly.)
+    dockerCommand: >-
+      sh -c "cp deploy/testflight-sandbox/config.yaml /app/config.yaml &&
+      exec opentelemetry-instrument family-assistant"
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: fa-sandbox-db
+          property: connectionString
+      - key: SESSION_SECRET_KEY
+        generateValue: true
+      - key: TIMEZONE
+        value: UTC
+
+      # --- OIDC (points at the Dex service above) ---
+      - key: OIDC_CLIENT_ID
+        value: family-assistant-sandbox
+      # Generated here, copied to Dex via fromService above.
+      - key: OIDC_CLIENT_SECRET
+        generateValue: true
+      # Dex discovery URL. Set after first deploy, e.g.
+      #   https://fa-sandbox-dex.onrender.com/.well-known/openid-configuration
+      - key: OIDC_DISCOVERY_URL
+        sync: false
+      # Only this email may log in (must match DEMO_EMAIL on the Dex service).
+      - key: ALLOWED_OIDC_EMAILS
+        sync: false
+
+      # --- LLM: OpenRouter via the OpenAI-compatible API ("OpenAI provider with
+      # a custom base URL"). One cheap model runs the whole sandbox; config.yaml
+      # (copied into place by dockerCommand above) pins every profile to it with
+      # provider "openai". Use a dedicated, quota-capped OpenRouter key. ---
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: OPENAI_BASE_URL
+        value: https://openrouter.ai/api/v1
+      - key: LLM_MODEL
+        value: deepseek/deepseek-v4-flash
+      # --- Embeddings: same OpenRouter endpoint via the OpenAI-compatible
+      # embedding provider (PR #909). EMBEDDING_API_KEY is omitted; it falls back
+      # to OPENAI_API_KEY (the OpenRouter key above). ---
+      - key: EMBEDDING_PROVIDER
+        value: openai
+      - key: EMBEDDING_BASE_URL
+        value: https://openrouter.ai/api/v1
+      - key: EMBEDDING_MODEL
+        value: openai/text-embedding-3-small
+      - key: EMBEDDING_DIMENSIONS
+        value: "1536"
+
+      # --- Storage (small disk is plenty for a demo) ---
+      - key: DOCUMENT_STORAGE_PATH
+        value: /data/documents
+      - key: ATTACHMENT_STORAGE_PATH
+        value: /data/attachments
+      - key: CHAT_ATTACHMENT_STORAGE_PATH
+        value: /data/chat_attachments
+    disk:
+      name: fa-sandbox-data
+      mountPath: /data
+      sizeGB: 1
+
+# Integrations intentionally omitted (Telegram, email intake, Home Assistant,
+# calendars, push, etc.): leaving their secrets unset disables them, which
+# keeps the sandbox to a single web/iOS surface for review.
+

--- a/src/family_assistant/__main__.py
+++ b/src/family_assistant/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import logging
+import os
 import signal
 import sys
 from typing import Any
@@ -68,7 +69,10 @@ parser.add_argument(
 
 def main() -> int:
     """Loads config, parses args, sets up event loop, and runs the application."""
-    config = load_config()
+    # CONFIG_FILE lets a deployment point at a config overlay without mounting it
+    # at ./config.yaml (e.g. Render, where the file ships in the image under a
+    # subdirectory). Defaults to the conventional ./config.yaml.
+    config = load_config(config_file_path=os.getenv("CONFIG_FILE", "config.yaml"))
     args = parser.parse_args()
 
     # Apply CLI Overrides to config using model_copy for immutable updates

--- a/src/family_assistant/embeddings.py
+++ b/src/family_assistant/embeddings.py
@@ -4,6 +4,7 @@ Module defining the interface and implementations for generating text embeddings
 
 import asyncio
 import hashlib
+import importlib.util
 import logging
 import math
 import re
@@ -15,26 +16,14 @@ from google.genai import types as genai_types
 from google.genai.client import DebugConfig
 from openai import AsyncOpenAI
 
-# Declare module/class variables that will be conditionally populated
-
-_SentenceTransformer_cls: Any | None = None
-_np_module: Any | None = None
-SENTENCE_TRANSFORMERS_AVAILABLE: bool  # Will be set in the try/except block
-
-# Import sentence-transformers if available, otherwise skip the class definition
-try:
-    # sentence-transformers returns numpy arrays or torch tensors, need numpy for conversion
-    import numpy  # pyright: ignore[reportMissingTypeStubs]
-    from sentence_transformers import (  # pyright: ignore[reportMissingTypeStubs, reportMissingImports]
-        SentenceTransformer as ActualSentenceTransformer,
-    )
-
-    _np_module = numpy
-    _SentenceTransformer_cls = ActualSentenceTransformer
-    SENTENCE_TRANSFORMERS_AVAILABLE = True
-except ImportError:
-    SENTENCE_TRANSFORMERS_AVAILABLE = False
-    # _SentenceTransformer_cls and _np_module remain None as initialized
+# Whether the optional sentence-transformers stack is installed. This is detected
+# WITHOUT importing it: importing sentence_transformers pulls in torch (hundreds of
+# MB resident), and most deployments use a cloud embedding provider and never need
+# it. The actual import is deferred to SentenceTransformerEmbeddingGenerator, so
+# torch is only loaded when a local embedding model is genuinely used.
+SENTENCE_TRANSFORMERS_AVAILABLE = (
+    importlib.util.find_spec("sentence_transformers") is not None
+)
 
 logger = logging.getLogger(__name__)
 
@@ -369,13 +358,12 @@ class SentenceTransformerEmbeddingGenerator:
             logger.info(
                 f"Loading SentenceTransformer model: {model_name_or_path} on device: {device or 'auto'}"
             )
-            if (
-                _SentenceTransformer_cls is None
-            ):  # Should not happen if SENTENCE_TRANSFORMERS_AVAILABLE is True
-                raise RuntimeError(
-                    "SentenceTransformer class is None, though library was reported as available."
-                )
-            self.model = _SentenceTransformer_cls(
+            # Lazy import so torch is only loaded when a local model is used.
+            from sentence_transformers import (  # noqa: PLC0415 # pyright: ignore[reportMissingImports] # lazy import: avoid loading torch at module import
+                SentenceTransformer,
+            )
+
+            self.model = SentenceTransformer(
                 model_name_or_path, device=device, **self.model_kwargs
             )
             logger.info(
@@ -423,13 +411,10 @@ class SentenceTransformerEmbeddingGenerator:
             loop = asyncio.get_running_loop()
             embeddings_np = await loop.run_in_executor(None, self.model.encode, texts)
 
-            if (
-                _np_module is None
-            ):  # Should not happen if SENTENCE_TRANSFORMERS_AVAILABLE
-                raise RuntimeError(
-                    "Numpy module is None, though library was reported as available."
-                )
-            embeddings_list = [_np_module.array(arr).tolist() for arr in embeddings_np]
+            # numpy ships with sentence-transformers; import lazily alongside it.
+            import numpy  # noqa: PLC0415 # deferred to avoid importing torch stack at module load
+
+            embeddings_list = [numpy.array(arr).tolist() for arr in embeddings_np]
 
             logger.debug(
                 f"SentenceTransformer generated {len(embeddings_list)} embeddings."

--- a/src/family_assistant/storage/base.py
+++ b/src/family_assistant/storage/base.py
@@ -40,6 +40,12 @@ DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///family_assistant.d
 
 def create_engine_with_sqlite_optimizations(database_url: str) -> AsyncEngine:
     """Create engine with SQLite optimizations if applicable."""
+    # SQLAlchemy's async engine needs an async driver. A bare "postgresql://"
+    # URL (e.g. Render's connectionString, or a standard libpq URL) resolves to
+    # the sync psycopg2 dialect and fails. Normalize it to asyncpg, the driver
+    # this project ships.
+    if database_url.startswith("postgresql://"):
+        database_url = database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
     # Determine pool class based on database type.
     #
     # SQLite uses StaticPool to funnel all access through a SINGLE DBAPI


### PR DESCRIPTION
## Summary

A self-contained **TestFlight / App Review sandbox** deployment of Family Assistant — isolated from
production, gated to a single demo account via a bundled [Dex](https://dexidp.io/) OIDC provider, and
running the **entire agentic feature set on one cheap model through OpenRouter** so a reviewer can
exercise the app without exposing real data or a production LLM key.

Lives entirely under `deploy/testflight-sandbox/` plus a few small, general core improvements (below).

## How it runs on OpenRouter

- **Chat + embeddings both go through OpenRouter's OpenAI-compatible API** — i.e. the app's `openai`
  provider pointed at `https://openrouter.ai/api/v1` via `OPENAI_BASE_URL` (and `EMBEDDING_BASE_URL`).
  One quota-capped OpenRouter key powers everything.
  - Chat: `deepseek/deepseek-v4-flash` — cheapest output among reputable tool-calling models, with
    the best agentic-tool-use benchmarks in its tier (reliable function calling is what the demo needs).
  - Embeddings: `openai/text-embedding-3-small` (1536-dim), via the OpenAI-compatible embedding
    provider from #909.
- `config.yaml` pins **every** service profile (default + research / complex_tasks / automation /
  camera / etc.) to that one model with `provider: openai`, so nothing falls back to a
  Gemini/Claude/GPT model that would need another key. (OpenRouter rejects the `openrouter/` model
  prefix, so `provider: openai` + a base-URL override is the correct path.)

## What's in `deploy/testflight-sandbox/`

| File | Purpose |
| --- | --- |
| `render.yaml` | Render Blueprint: Postgres + app + Dex, wired together. |
| `docker-compose.yaml` | Self-hosted (VPS) variant behind a reverse proxy. |
| `.env.example` | Template for the compose variant. |
| `config.yaml` | Pins all profiles to the cheap model; caps `max_iterations`; disables untrusted channels. |
| `mcp-empty.json` | Empty MCP config (disables the bundled MCP servers in the sandbox). |
| `dex/` | Minimal Dex image + config (one static demo account, gomplate-templated). |
| `README.md` | Security model, prerequisites, Render + self-hosted instructions. |

## Small core changes (general improvements, needed to deploy)

- **`embeddings.py`: lazy-import sentence-transformers.** It was imported at module load whenever
  installed, pulling in **torch (~600 MB resident)** for every process — even when a cloud embedding
  provider is used and the local model is never instantiated. Detected via `find_spec` and deferred
  to actual use. This also cuts prod RAM substantially (prod uses Gemini embeddings).
- **`__main__.py`: `CONFIG_FILE` env** to point at a config overlay without mounting `./config.yaml`
  (Render ships it in the image under a subdir).
- **`storage/base.py`: normalize `postgresql://` → `postgresql+asyncpg://`** so the async engine
  accepts standard libpq / Render connection strings.
- **`dex/config.yaml`: gomplate templating + `hashFromEnv`.** The official Dex image renders config
  with gomplate (`{{ getenv "X" }}`), not shell `${X}`; the bcrypt hash uses `hashFromEnv` so its
  `$` aren't mangled.

## Dependency

Builds on **#909** (OpenAI-compatible embedding provider), now merged to `main`.

## Status

Deployed and verified live on Render: OIDC login (demo account), an LLM chat round-trip through
OpenRouter (`deepseek/deepseek-v4-flash`), and embeddings all confirmed working end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
