### PR TITLE
Add Xcode Cloud TestFlight delivery for iOS app

### DIFF
--- a/docs/design/ios_testflight_delivery.md
+++ b/docs/design/ios_testflight_delivery.md
@@ -1,0 +1,81 @@
+# Automatic TestFlight Delivery for the iOS App
+
+## Goal
+
+Automatically build and upload the `FamilyAssistant` iOS app to TestFlight whenever changes land on
+`main`, with zero manual signing or build-number management.
+
+## Decision: Xcode Cloud (hybrid with GitHub Actions)
+
+We deliver to TestFlight via **Xcode Cloud** and keep the existing GitHub Actions
+[`ios-tests.yml`](../../.github/workflows/ios-tests.yml) workflow for fast, PR-integrated unit-test
+gating.
+
+| Concern | Xcode Cloud | GitHub Actions |
+| --- | --- | --- |
+| Cost at our volume | Free — 25 compute-hrs/mo; we use ~2.5 hrs | macOS minutes billed 10×; ~$12–25/mo on a private repo |
+| Code signing | Automatic via App Store Connect (no secrets) | Must store ASC API key + certs/profiles as repo secrets (fastlane `match`) |
+| TestFlight upload | Built in | Add fastlane `pilot` / `altool` step |
+| Setup | Mostly clicks in Xcode + App Store Connect | YAML + fastlane + `ExportOptions.plist` + secrets |
+| Version control | Workflow config lives in Apple's console | Fully version-controlled |
+
+### Why this split
+
+The build itself is trivial — a clean archive measured **~20s** locally (M-series), and the only
+SwiftPM dependencies are `swift-markdown` / `swift-cmark`. End-to-end CI wall time is ~3–5 min,
+dominated by runner spin-up, checkout, package resolution, signing, and upload. At an anticipated
+20–30 builds/month, performance is a non-factor; **cost and signing-plumbing** decide it.
+
+Xcode Cloud is free at this volume and removes the single most painful part of iOS CI — managing
+signing certificates, provisioning profiles, and App Store Connect API keys as CI secrets. The
+existing GitHub Actions workflow already gives fast PR test checks, so there is no reason to move
+those. Net result:
+
+- **Pull requests:** GitHub Actions runs unit tests (unchanged).
+- **Merge to `main`:** Xcode Cloud archives and uploads to TestFlight.
+
+Revisit if the iOS build slows materially or volume grows past the Xcode Cloud free tier, or if we
+later want the TestFlight build gated on the Python test suite (which would argue for consolidating
+on GitHub Actions).
+
+## What lives in the repo
+
+[`ios/FamilyAssistant/ci_scripts/ci_pre_xcodebuild.sh`](../../ios/FamilyAssistant/ci_scripts/ci_pre_xcodebuild.sh)
+— Xcode Cloud runs this automatically before each `xcodebuild` invocation. It stamps
+`CURRENT_PROJECT_VERSION` (the source of `CFBundleVersion`, since the target uses
+`GENERATE_INFOPLIST_FILE = YES`) with the monotonically increasing `CI_BUILD_NUMBER`, so every
+upload has a unique build number with no manual bumping. The edit happens in the ephemeral CI
+checkout only and is never committed.
+
+The `ci_scripts` directory must sit next to the `.xcodeproj` and the script must be executable and
+not part of any build target.
+
+## One-time console setup (manual)
+
+These steps happen in Xcode / App Store Connect and cannot be scripted from the repo:
+
+1. **App Store Connect** — ensure an app record exists for bundle id `dev.andrewgarrett.assistant`
+   under team `H7NBC2S52X`.
+2. **Xcode → Product → Xcode Cloud → Create Workflow** (or App Store Connect → the app → Xcode
+   Cloud). Grant access to the `werdnum/family-assistant` GitHub repository when prompted.
+3. Configure the workflow:
+   - **Start condition:** Branch Changes → `main`.
+   - **Environment:** latest Xcode (matches `macos-26` / Xcode 26.x used by `ios-tests.yml`).
+   - **Action:** Archive — iOS, configuration `Release`.
+   - **Post-action:** TestFlight (Internal Testing), select the internal tester group.
+4. Let Xcode Cloud manage signing automatically (it provisions a cloud-managed distribution
+   certificate; no secrets land in the repo).
+5. Trigger the first build manually to confirm the archive uploads and the build number reflects
+   `CI_BUILD_NUMBER`.
+
+### Optional: run tests inside Xcode Cloud too
+
+The Archive action can be preceded by a Test action if we ever want the TestFlight build gated on
+unit tests independently of the GitHub Actions PR run. We skip this initially to avoid paying for
+duplicate test runs.
+
+## Marketing version
+
+`MARKETING_VERSION` (the user-facing `CFBundleShortVersionString`, currently `1.0`) is intentionally
+left to manual control — bump it in the Xcode project when shipping a new user-facing version. Only
+the build number is automated.

--- a/ios/FamilyAssistant/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ios/FamilyAssistant/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# ci_pre_xcodebuild.sh
+#
+# Xcode Cloud runs this automatically before each xcodebuild invocation. It
+# stamps the archive's build number (CFBundleVersion) with the monotonically
+# increasing Xcode Cloud build number (CI_BUILD_NUMBER) so every TestFlight
+# upload is unique without anyone having to bump a counter by hand.
+#
+# The app target uses GENERATE_INFOPLIST_FILE = YES, so CFBundleVersion is
+# derived from the CURRENT_PROJECT_VERSION build setting at build time. We
+# rewrite that setting in the ephemeral CI checkout only -- this change is
+# never committed back to the repository.
+#
+# This script must live in a `ci_scripts` directory alongside the .xcodeproj
+# (ios/FamilyAssistant/) and must be executable. It must not be added to any
+# build target.
+
+set -eu
+
+if [ -z "${CI_BUILD_NUMBER:-}" ]; then
+  echo "CI_BUILD_NUMBER is not set; leaving CURRENT_PROJECT_VERSION unchanged."
+  exit 0
+fi
+
+PROJECT_FILE="${CI_PRIMARY_REPOSITORY_PATH}/ios/FamilyAssistant/FamilyAssistant.xcodeproj/project.pbxproj"
+
+if [ ! -f "$PROJECT_FILE" ]; then
+  echo "error: project file not found at $PROJECT_FILE" >&2
+  exit 1
+fi
+
+echo "Stamping CURRENT_PROJECT_VERSION = ${CI_BUILD_NUMBER}"
+/usr/bin/sed -i '' -E \
+  "s/CURRENT_PROJECT_VERSION = [^;]+;/CURRENT_PROJECT_VERSION = ${CI_BUILD_NUMBER};/g" \
+  "$PROJECT_FILE"


### PR DESCRIPTION
## Summary

Sets up automatic TestFlight delivery for the `FamilyAssistant` iOS app via **Xcode Cloud**, keeping the existing GitHub Actions `ios-tests.yml` for PR unit-test gating.

### Why Xcode Cloud (hybrid)

The build is trivially fast — a clean archive measured **~20s** locally (only SwiftPM deps are `swift-markdown`/`swift-cmark`), so performance is a non-factor at the anticipated 20–30 builds/month. The decision comes down to **cost** and **signing plumbing**:

- **Free at our volume** — Xcode Cloud's 25 compute-hrs/mo vs ~2.5 hrs we'd use. GitHub Actions macOS minutes bill at 10× (~$12–25/mo on a private repo).
- **No signing secrets** — Xcode Cloud signs via App Store Connect automatically; no certs/profiles/API keys stored as CI secrets.

Split: **PRs** → GitHub Actions tests (unchanged); **merge to `main`** → Xcode Cloud archives + uploads to TestFlight.

## What's in this PR

- `ios/FamilyAssistant/ci_scripts/ci_pre_xcodebuild.sh` — stamps `CURRENT_PROJECT_VERSION` (source of `CFBundleVersion` under `GENERATE_INFOPLIST_FILE`) with Xcode Cloud's `CI_BUILD_NUMBER` so every upload is unique with no manual bumping. Edits the ephemeral CI checkout only. shellcheck-clean, executable bit set, sed verified against the real pbxproj.
- `docs/design/ios_testflight_delivery.md` — records the decision, the measured build data, and the one-time App Store Connect console setup.

## Follow-up (manual, can't be scripted)

The Xcode Cloud workflow itself is created in Xcode / App Store Connect — see the "One-time console setup" section of the design doc. Steps: create/confirm the app record for `dev.andrewgarrett.assistant`, create an Xcode Cloud workflow on `main` → Archive (Release) → TestFlight post-action, let Xcode Cloud manage signing, then trigger one build to confirm.

## Test plan

- [x] `ci_pre_xcodebuild.sh` passes shellcheck
- [x] Build-number `sed` verified to rewrite all `CURRENT_PROJECT_VERSION` entries on the real `project.pbxproj`
- [x] Clean archive succeeds locally (`** ARCHIVE SUCCEEDED **`)
- [ ] First Xcode Cloud build uploads to TestFlight (requires console setup above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)