### PR TITLE
iOS: report native errors and uncaught exceptions to /api/errors/

### DIFF
--- a/docs/design/ios_error_reporting.md
+++ b/docs/design/ios_error_reporting.md
@@ -1,0 +1,95 @@
+# iOS Native Error Reporting
+
+## Problem
+
+The native iOS app (TestFlight) surfaces failures as on-screen alerts/labels (the many
+`errorMessage = error.localizedDescription` sites) and writes to the on-device `os.Logger`. None of
+that reaches the server, so a tester hitting a bug in a TestFlight build leaves no trace we can
+inspect. The web frontend already reports JavaScript errors to `POST /api/errors/`
+(`frontend/src/api/errorClient.ts`), and those land in the server error log
+(`SQLAlchemyErrorHandler` → `/errors` UI and `GET /api/errors/`). The native app had no equivalent.
+
+## Goal
+
+Give the native app the same server-side error visibility the web frontend has, so an effective bug
+report can be gathered from a TestFlight build without relying on the tester to describe the problem
+— covering both:
+
+1. **Handled errors that pop up an alert** — the user-facing `errorMessage` sites.
+2. **Uncaught Objective-C exceptions** — global, app-wide capture.
+
+## Reuse of existing infrastructure
+
+We reuse the existing, intentionally **unauthenticated** endpoint:
+
+```
+POST /api/errors/        (errors_api.py:report_frontend_error)
+```
+
+`^/api(/.*)?$` is in `PUBLIC_PATHS` (`auth.py`), so the report goes through even before sign-in or
+when auth is broken. The JSON body matches `FrontendErrorReport`:
+
+| field            | iOS value                                                             |
+| ---------------- | --------------------------------------------------------------------- |
+| `message`        | `error.localizedDescription` / exception `name: reason`               |
+| `stack`          | `nil` for handled errors; `callStackSymbols` for uncaught exceptions  |
+| `url`            | synthetic `familyassistant://ios/<component>` (the field is required) |
+| `user_agent`     | `FamilyAssistant-iOS/<version> (build <n>; <os version>)`             |
+| `component_name` | a stable identifier, e.g. `Notes.editor.save`, `Chat.stream`          |
+| `error_type`     | `uncaught` (exceptions) or `manual` (handled)                         |
+| `extra_data`     | app version, build, OS version, `is_testflight`, `installation_id`    |
+
+The endpoint is unauthenticated, so reports are **not** attributed to a user via the bearer token
+(this also avoids triggering token-refresh side effects from a failure path). Reports instead carry
+the device's `installation_id` (the same id `NotificationManager` already persists under
+`fa_installation_id`) for correlation.
+
+## Component: `ErrorReporter`
+
+`ios/.../ErrorReporting/ErrorReporter.swift` — a thread-safe singleton (`ErrorReporter.shared`).
+
+- `configure(baseURLProvider:)` — resolves the backend base URL (from
+  `AuthManager.validatedServerURL()`); set once at launch.
+- `report(_:component:errorType:)` / `report(message:…)` — fire-and-forget. Deduplicates within a
+  60s window (matching the web client) and attaches device/build metadata.
+- **Best-effort delivery with disk spooling.** When the base URL is unknown (error happened before
+  sign-in) or the network send fails, the report is written to a capped spool directory under
+  Caches. `flushPersisted()` runs at launch and retries spooled reports.
+- `installGlobalHandlers()` — installs an `NSSetUncaughtExceptionHandler` (chained to any
+  previously-installed handler) that **synchronously persists** the exception. Async network sends
+  cannot complete while the process is terminating, so the report is spooled and delivered on the
+  next launch.
+
+### Why no POSIX signal handlers
+
+Hard crashes (Swift runtime traps, `SIGSEGV`, etc.) are deliberately **out of scope**. Apple already
+captures those for TestFlight builds and surfaces symbolicated reports in App Store Connect →
+TestFlight → Crashes. Re-implementing in-process signal handling is fragile (async-signal-safety
+constraints) and would duplicate what Apple already provides. `ErrorReporter` focuses on what
+TestFlight cannot see: handled errors and uncaught Objective-C exceptions, tied to our own
+server-side error log.
+
+## Wiring
+
+- `FamilyAssistantApp.init()` calls `configure(...)` and `installGlobalHandlers()`; `appContent`
+  flushes spooled reports via `.task`.
+- Each user-facing `catch` that assigns `errorMessage` from an `Error` gains one additive line:
+  `ErrorReporter.shared.report(error, component: "<Area.action>")`. Pure validation messages (e.g.
+  "Title and content are required.") are **not** reported — they are expected user input states, not
+  bugs.
+
+## Grabbing a bug report from TestFlight
+
+1. **Crashes** → App Store Connect → TestFlight → Crashes (automatic; upload dSYMs for
+   symbolication).
+2. **Tester-initiated feedback** → TestFlight app screenshot/feedback (includes device + build
+   metadata).
+3. **Handled errors / ObjC exceptions** → the server error log at `/errors` (filter by
+   `logger = frontend.javascript`, since the iOS reports reuse the same ingest path), with the
+   `component_name` and `is_testflight` fields identifying native reports.
+
+## Testing
+
+`ErrorReporterTests.swift` exercises payload shape, the dedup window, disk spooling on send failure,
+`flushPersisted()` delivery + cleanup, and base-URL resolution, using a `URLProtocol` mock (same
+pattern as `NotesAPIClientTests`) and a temporary spool directory.

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -687,6 +687,13 @@ various tasks with dark mode support and mobile optimization.
   right information ("Actually, the appointment is at 3 PM") or by updating a relevant note via the
   Web UI or a command ("Update the note 'Plumber Number' with content '555-9876'").
 
+- **iOS App Errors (TestFlight & beyond):** When the native iOS app shows an error message, it now
+  also reports that error to the server automatically, so the family member who manages the
+  assistant can see what went wrong without you having to describe it. Uncaught app errors are
+  captured the same way (and outright crashes are reported through Apple/TestFlight). Administrators
+  can review these reports in the web **Error Logs** page (`/errors`); native iOS reports are tagged
+  with a `component_name` and an `is_testflight` flag.
+
 - **If you need more help:** Contact the family member who set up and manages the assistant for your
   family. They can help with configuration issues or more complex problems.
 

--- a/ios/FamilyAssistant/FamilyAssistant.xcodeproj/project.pbxproj
+++ b/ios/FamilyAssistant/FamilyAssistant.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		A10045 /* AssistantReplySnippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10045 /* AssistantReplySnippet.swift */; };
 		A10046 /* FamilyAssistantAppShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10046 /* FamilyAssistantAppShortcuts.swift */; };
 		A10025 /* ConfirmationModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10027 /* ConfirmationModalView.swift */; };
+		A10050 /* ErrorReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10050 /* ErrorReporter.swift */; };
 		A10024 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = H10002 /* Markdown */; };
 		A20001 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20002 /* RouteTests.swift */; };
 		A20002 /* NotesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20003 /* NotesModelTests.swift */; };
@@ -52,6 +53,7 @@
 		A20010 /* ToolRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20011 /* ToolRenderingTests.swift */; };
 		A20012 /* AppIntentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20013 /* AppIntentsTests.swift */; };
 		A20011 /* ConfirmationModalModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20012 /* ConfirmationModalModelTests.swift */; };
+		A20020 /* ErrorReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20020 /* ErrorReporterTests.swift */; };
 		A30001 /* FamilyAssistantUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30002 /* FamilyAssistantUITests.swift */; };
 /* End PBXBuildFile section */
 
@@ -108,6 +110,7 @@
 		B10045 /* AssistantReplySnippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantReplySnippet.swift; sourceTree = "<group>"; };
 		B10046 /* FamilyAssistantAppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyAssistantAppShortcuts.swift; sourceTree = "<group>"; };
 		B10027 /* ConfirmationModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationModalView.swift; sourceTree = "<group>"; };
+		B10050 /* ErrorReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReporter.swift; sourceTree = "<group>"; };
 		B20001 /* FamilyAssistantTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FamilyAssistantTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B20002 /* RouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTests.swift; sourceTree = "<group>"; };
 		B20003 /* NotesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesModelTests.swift; sourceTree = "<group>"; };
@@ -121,6 +124,7 @@
 		B20011 /* ToolRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRenderingTests.swift; sourceTree = "<group>"; };
 		B20013 /* AppIntentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentsTests.swift; sourceTree = "<group>"; };
 		B20012 /* ConfirmationModalModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationModalModelTests.swift; sourceTree = "<group>"; };
+		B20020 /* ErrorReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReporterTests.swift; sourceTree = "<group>"; };
 		B30001 /* FamilyAssistantUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FamilyAssistantUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B30002 /* FamilyAssistantUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilyAssistantUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -175,6 +179,7 @@
 				D10007 /* Notes */,
 				D10009 /* Chat */,
 				D10010 /* Intents */,
+				D10011 /* ErrorReporting */,
 				D10008 /* UITesting */,
 				B10008 /* Assets.xcassets */,
 				B10009 /* Info.plist */,
@@ -232,6 +237,14 @@
 			path = UITesting;
 			sourceTree = "<group>";
 		};
+		D10011 /* ErrorReporting */ = {
+			isa = PBXGroup;
+			children = (
+				B10050 /* ErrorReporter.swift */,
+			);
+			path = ErrorReporting;
+			sourceTree = "<group>";
+		};
 		D10009 /* Chat */ = {
 			isa = PBXGroup;
 			children = (
@@ -283,6 +296,7 @@
 				B20011 /* ToolRenderingTests.swift */,
 				B20013 /* AppIntentsTests.swift */,
 				B20012 /* ConfirmationModalModelTests.swift */,
+				B20020 /* ErrorReporterTests.swift */,
 			);
 			path = FamilyAssistantTests;
 			sourceTree = "<group>";
@@ -461,6 +475,7 @@
 				A10045 /* AssistantReplySnippet.swift in Sources */,
 				A10046 /* FamilyAssistantAppShortcuts.swift in Sources */,
 				A10025 /* ConfirmationModalView.swift in Sources */,
+				A10050 /* ErrorReporter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -480,6 +495,7 @@
 				A20010 /* ToolRenderingTests.swift in Sources */,
 				A20012 /* AppIntentsTests.swift in Sources */,
 				A20011 /* ConfirmationModalModelTests.swift in Sources */,
+				A20020 /* ErrorReporterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/FamilyAssistant/FamilyAssistant/Auth/AuthManager.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Auth/AuthManager.swift
@@ -93,6 +93,7 @@ final class AuthManager {
                         return
                     }
                     self.errorMessage = error.localizedDescription
+                    ErrorReporter.shared.report(error, component: "Auth.login")
                     self.isLoading = false
                     return
                 }
@@ -136,6 +137,7 @@ final class AuthManager {
             isAuthenticated = true
         } catch {
             errorMessage = "Authentication failed: \(error.localizedDescription)"
+            ErrorReporter.shared.report(error, component: "Auth.callback")
         }
 
         isLoading = false

--- a/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViewModel.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViewModel.swift
@@ -124,6 +124,7 @@ final class ChatViewModel {
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Chat.conversations")
         }
         isLoadingConversations = false
     }
@@ -143,6 +144,7 @@ final class ChatViewModel {
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Chat.recentConversations")
         }
     }
 
@@ -206,6 +208,7 @@ final class ChatViewModel {
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Chat.messages")
         }
         isLoadingMessages = false
     }
@@ -236,6 +239,7 @@ final class ChatViewModel {
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Chat.mergeMessages")
         }
     }
 
@@ -288,6 +292,7 @@ final class ChatViewModel {
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Chat.profiles")
         }
         isLoadingProfiles = false
     }
@@ -453,6 +458,7 @@ final class ChatViewModel {
             await addAttachment(fileURL: url, mimeType: mimeType, displayName: filename)
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Chat.importAttachment")
         }
     }
 
@@ -481,6 +487,7 @@ final class ChatViewModel {
                 try await apiClient.deleteAttachment(attachmentID: attachmentID)
             } catch {
                 errorMessage = "Could not remove attachment. \(error.localizedDescription)"
+                ErrorReporter.shared.report(error, component: "Chat.removeAttachment")
                 return
             }
         }
@@ -500,6 +507,7 @@ final class ChatViewModel {
             if let index = pendingConfirmations.firstIndex(where: { $0.requestID == confirmation.requestID }) {
                 pendingConfirmations[index].errorMessage = error.localizedDescription
             }
+            ErrorReporter.shared.report(error, component: "Chat.confirmTool")
         }
     }
 
@@ -518,6 +526,7 @@ final class ChatViewModel {
             return try await downloadAttachment(attachment)
         } catch {
             errorMessage = "Could not download attachment. \(error.localizedDescription)"
+            ErrorReporter.shared.report(error, component: "Chat.downloadAttachment")
             return nil
         }
     }
@@ -576,6 +585,7 @@ final class ChatViewModel {
             errorMessage = nil
         } catch {
             errorMessage = "Could not load pending approvals. \(error.localizedDescription)"
+            ErrorReporter.shared.report(error, component: "Chat.pendingApprovals")
         }
     }
 
@@ -779,6 +789,7 @@ final class ChatViewModel {
             messages[index].text += "\n\n\(message)"
         }
         errorMessage = message
+        ErrorReporter.shared.report(message: message, component: "Chat.stream")
     }
 
     private func updateToolCall(

--- a/ios/FamilyAssistant/FamilyAssistant/ErrorReporting/ErrorReporter.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/ErrorReporting/ErrorReporter.swift
@@ -1,0 +1,342 @@
+import Foundation
+import os
+
+/// Reports native iOS errors to the backend `POST /api/errors/` endpoint so problems surfaced in a
+/// TestFlight build land in the same server-side error log as web-frontend errors, without relying
+/// on the tester to describe them.
+///
+/// Delivery is best-effort. When the server URL is not yet known (e.g. the error happened before
+/// sign-in) or the network send fails, the report is spooled to disk and retried by
+/// ``flushPersisted()`` on the next launch. Uncaught Objective-C exceptions are persisted
+/// synchronously from the `NSSetUncaughtExceptionHandler` callback, since the process is
+/// terminating and an asynchronous send would not complete.
+///
+/// Hard crashes (Swift traps, signals) are intentionally out of scope: Apple already captures those
+/// for TestFlight builds. See `docs/design/ios_error_reporting.md`.
+final class ErrorReporter: @unchecked Sendable {
+    static let shared = ErrorReporter()
+
+    enum ErrorType: String {
+        case uncaught
+        case handled = "manual"
+        case component = "component_error"
+    }
+
+    private let session: URLSession
+    private let spoolDirectory: URL?
+    private let dedupeWindow: TimeInterval
+    private let logger = Logger(subsystem: "com.familyassistant.app", category: "error-reporting")
+
+    private let lock = NSLock()
+    private var baseURLProvider: (() -> URL?)?
+    private var recentReports: [String: Date] = [:]
+
+    /// Cap on spooled reports so a server outage cannot grow the cache without bound.
+    private let maxSpooledReports = 50
+
+    private static var previousExceptionHandler: (@convention(c) (NSException) -> Void)?
+
+    init(
+        session: URLSession = .shared,
+        spoolDirectory: URL? = ErrorReporter.defaultSpoolDirectory,
+        dedupeWindow: TimeInterval = 60
+    ) {
+        self.session = session
+        self.spoolDirectory = spoolDirectory
+        self.dedupeWindow = dedupeWindow
+    }
+
+    // MARK: - Configuration
+
+    /// Provide a resolver for the backend base URL (e.g. `https://assistant.example.com`).
+    func configure(baseURLProvider: @escaping () -> URL?) {
+        lock.withLock { self.baseURLProvider = baseURLProvider }
+    }
+
+    /// Install a global uncaught-exception handler that persists the exception for delivery on the
+    /// next launch. Chains to any previously-installed handler.
+    func installGlobalHandlers() {
+        Self.previousExceptionHandler = NSGetUncaughtExceptionHandler()
+        NSSetUncaughtExceptionHandler { exception in
+            ErrorReporter.shared.persistException(exception)
+            ErrorReporter.previousExceptionHandler?(exception)
+        }
+    }
+
+    // MARK: - Reporting
+
+    /// Report a Swift `Error` surfaced to the user. Fire-and-forget.
+    func report(_ error: Error, component: String, errorType: ErrorType = .handled) {
+        let message = error.localizedDescription
+        let typeName = String(describing: type(of: error))
+        Task { [weak self] in
+            await self?.deliver(
+                message: message,
+                component: component,
+                errorType: errorType,
+                stack: nil,
+                extraData: ["error_type_name": typeName]
+            )
+        }
+    }
+
+    /// Report a free-form message. Fire-and-forget.
+    func report(
+        message: String,
+        component: String,
+        errorType: ErrorType = .handled,
+        stack: String? = nil,
+        extraData: [String: String] = [:]
+    ) {
+        Task { [weak self] in
+            await self?.deliver(
+                message: message,
+                component: component,
+                errorType: errorType,
+                stack: stack,
+                extraData: extraData
+            )
+        }
+    }
+
+    /// Awaitable delivery used by ``report(...)`` and tests. Deduplicates, then sends (spooling on
+    /// failure).
+    func deliver(
+        message: String,
+        component: String,
+        errorType: ErrorType,
+        stack: String?,
+        extraData: [String: String]
+    ) async {
+        guard !shouldDedupe(message: message, component: component, errorType: errorType) else {
+            return
+        }
+        let payload = makePayload(
+            message: message,
+            component: component,
+            errorType: errorType,
+            stack: stack,
+            extraData: extraData
+        )
+        await send(payload)
+    }
+
+    /// Retry any reports spooled to disk by a previous launch or a failed send. Stops on the first
+    /// failure so a persistent outage does not hammer the server.
+    func flushPersisted() async {
+        guard let directory = spoolDirectory,
+              let files = try? FileManager.default.contentsOfDirectory(
+                  at: directory,
+                  includingPropertiesForKeys: nil
+              ),
+              !files.isEmpty,
+              let baseURL = currentBaseURL()
+        else {
+            return
+        }
+
+        for file in files where file.pathExtension == "json" {
+            guard let data = try? Data(contentsOf: file),
+                  let payload = try? JSONDecoder().decode(ErrorReportPayload.self, from: data)
+            else {
+                try? FileManager.default.removeItem(at: file)
+                continue
+            }
+            do {
+                try await post(payload, to: baseURL)
+                try? FileManager.default.removeItem(at: file)
+            } catch {
+                break
+            }
+        }
+    }
+
+    // MARK: - Delivery
+
+    private func send(_ payload: ErrorReportPayload) async {
+        guard let baseURL = currentBaseURL() else {
+            persist(payload)
+            return
+        }
+        do {
+            try await post(payload, to: baseURL)
+        } catch {
+            persist(payload)
+        }
+    }
+
+    private func post(_ payload: ErrorReportPayload, to baseURL: URL) async throws {
+        guard let url = URL(string: "/api/errors/", relativeTo: baseURL)?.absoluteURL else {
+            throw ReporterError.invalidURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (_, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              200..<300 ~= httpResponse.statusCode
+        else {
+            throw ReporterError.badResponse
+        }
+    }
+
+    private func currentBaseURL() -> URL? {
+        let provider = lock.withLock { baseURLProvider }
+        return provider?()
+    }
+
+    // MARK: - Deduplication
+
+    private func shouldDedupe(message: String, component: String, errorType: ErrorType) -> Bool {
+        let key = "\(message)|\(component)|\(errorType.rawValue)"
+        return lock.withLock {
+            let now = Date()
+            recentReports = recentReports.filter { now.timeIntervalSince($0.value) < dedupeWindow }
+            if let last = recentReports[key], now.timeIntervalSince(last) < dedupeWindow {
+                return true
+            }
+            recentReports[key] = now
+            return false
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func persistException(_ exception: NSException) {
+        let payload = makePayload(
+            message: "\(exception.name.rawValue): \(exception.reason ?? "")",
+            component: "UncaughtException",
+            errorType: .uncaught,
+            stack: exception.callStackSymbols.joined(separator: "\n"),
+            extraData: [:]
+        )
+        persist(payload)
+    }
+
+    private func persist(_ payload: ErrorReportPayload) {
+        guard let directory = spoolDirectory else { return }
+        do {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+            let fileURL = directory.appendingPathComponent("\(UUID().uuidString).json")
+            try JSONEncoder().encode(payload).write(to: fileURL, options: .atomic)
+            trimSpool(in: directory)
+        } catch {
+            logger.error(
+                "Failed to persist error report: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    /// Keep the spool directory bounded by deleting the oldest reports beyond ``maxSpooledReports``.
+    private func trimSpool(in directory: URL) {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.creationDateKey]
+        ) else {
+            return
+        }
+        let jsonFiles = files.filter { $0.pathExtension == "json" }
+        guard jsonFiles.count > maxSpooledReports else { return }
+
+        let sorted = jsonFiles.sorted { lhs, rhs in
+            let lhsDate = (try? lhs.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+            let rhsDate = (try? rhs.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+            return lhsDate < rhsDate
+        }
+        for file in sorted.prefix(jsonFiles.count - maxSpooledReports) {
+            try? FileManager.default.removeItem(at: file)
+        }
+    }
+
+    // MARK: - Payload construction
+
+    private func makePayload(
+        message: String,
+        component: String,
+        errorType: ErrorType,
+        stack: String?,
+        extraData: [String: String]
+    ) -> ErrorReportPayload {
+        ErrorReportPayload(
+            message: message,
+            stack: stack,
+            url: Self.syntheticURL(component: component),
+            userAgent: Self.userAgent,
+            componentName: component,
+            errorType: errorType.rawValue,
+            extraData: Self.metadata().merging(extraData) { _, new in new }
+        )
+    }
+
+    private static func syntheticURL(component: String) -> String {
+        let encoded = component.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+            ?? component
+        return "familyassistant://ios/\(encoded)"
+    }
+
+    private static var userAgent: String {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let build = info?["CFBundleVersion"] as? String ?? "unknown"
+        return "FamilyAssistant-iOS/\(version) (build \(build); "
+            + "\(ProcessInfo.processInfo.operatingSystemVersionString))"
+    }
+
+    private static func metadata() -> [String: String] {
+        let info = Bundle.main.infoDictionary
+        var data: [String: String] = [
+            "platform": "ios",
+            "app_version": info?["CFBundleShortVersionString"] as? String ?? "unknown",
+            "build": info?["CFBundleVersion"] as? String ?? "unknown",
+            "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
+            "is_testflight": isTestFlight ? "true" : "false",
+        ]
+        if let installationID = UserDefaults.standard.string(forKey: "fa_installation_id") {
+            data["installation_id"] = installationID
+        }
+        return data
+    }
+
+    /// A TestFlight (sandbox) build ships a `sandboxReceipt` rather than a production receipt.
+    static var isTestFlight: Bool {
+        Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+    }
+
+    static var defaultSpoolDirectory: URL? {
+        FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("PendingErrorReports", isDirectory: true)
+    }
+
+    private enum ReporterError: Error {
+        case invalidURL
+        case badResponse
+    }
+}
+
+/// Wire payload matching the backend `FrontendErrorReport` model (`errors_api.py`).
+struct ErrorReportPayload: Codable, Sendable {
+    let message: String
+    let stack: String?
+    let url: String
+    let userAgent: String?
+    let componentName: String?
+    let errorType: String?
+    let extraData: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case message
+        case stack
+        case url
+        case userAgent = "user_agent"
+        case componentName = "component_name"
+        case errorType = "error_type"
+        case extraData = "extra_data"
+    }
+}

--- a/ios/FamilyAssistant/FamilyAssistant/FamilyAssistantApp.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/FamilyAssistantApp.swift
@@ -10,8 +10,12 @@ struct FamilyAssistantApp: App {
         #if DEBUG
         UITestConfiguration.applyIfNeeded()
         #endif
-        _authManager = State(initialValue: AuthManager())
+        let authManager = AuthManager()
+        _authManager = State(initialValue: authManager)
         _notificationManager = State(initialValue: NotificationManager())
+
+        ErrorReporter.shared.configure { [weak authManager] in authManager?.validatedServerURL() }
+        ErrorReporter.shared.installGlobalHandlers()
     }
 
     var body: some Scene {
@@ -39,6 +43,9 @@ struct FamilyAssistantApp: App {
             .onAppear {
                 appDelegate.notificationManager = notificationManager
                 notificationManager.bind(authManager: authManager)
+            }
+            .task {
+                await ErrorReporter.shared.flushPersisted()
             }
             .onOpenURL { url in
                 Task { @MainActor in

--- a/ios/FamilyAssistant/FamilyAssistant/Notes/NoteDetailView.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Notes/NoteDetailView.swift
@@ -125,6 +125,7 @@ struct NoteDetailView: View {
             note = try await NotesAPIClient(authManager: authManager).getNote(title: title)
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Notes.detail.load")
         }
         isLoading = false
     }
@@ -136,6 +137,7 @@ struct NoteDetailView: View {
             onDeleted()
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Notes.detail.delete")
         }
     }
 }

--- a/ios/FamilyAssistant/FamilyAssistant/Notes/NoteEditorView.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Notes/NoteEditorView.swift
@@ -121,6 +121,7 @@ struct NoteEditorView: View {
             visibilityLabels = note.visibilityLabels
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Notes.editor.load")
         }
         isLoading = false
     }
@@ -148,6 +149,7 @@ struct NoteEditorView: View {
             onSaved(trimmedTitle)
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Notes.editor.save")
         }
         isSaving = false
     }

--- a/ios/FamilyAssistant/FamilyAssistant/Notes/NotesListView.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Notes/NotesListView.swift
@@ -120,6 +120,7 @@ struct NotesListView: View {
             notes = try await NotesAPIClient(authManager: authManager).listNotes()
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Notes.list.load")
         }
         isLoading = false
     }
@@ -132,6 +133,7 @@ struct NotesListView: View {
             notes.removeAll { $0.title == note.title }
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Notes.list.delete")
         }
     }
 }

--- a/ios/FamilyAssistant/FamilyAssistant/Notifications/ConfirmationModalView.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Notifications/ConfirmationModalView.swift
@@ -145,6 +145,7 @@ final class ConfirmationModalModel {
             return true
         } catch {
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Confirmation.submit")
             return false
         }
     }

--- a/ios/FamilyAssistant/FamilyAssistant/Notifications/NotificationManager.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Notifications/NotificationManager.swift
@@ -138,6 +138,7 @@ final class NotificationManager {
             notificationsEnabled = false
             registrationState = .failed
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Notifications.enable")
         }
     }
 
@@ -156,6 +157,7 @@ final class NotificationManager {
                     "Failed to unregister APNs token: \(error.localizedDescription, privacy: .public)"
                 )
                 errorMessage = "Notifications were disabled locally, but the server could not be updated."
+                ErrorReporter.shared.report(error, component: "Notifications.disable")
             }
         }
 
@@ -180,6 +182,7 @@ final class NotificationManager {
     func handleAPNsRegistrationFailure(_ error: Error) {
         registrationState = .failed
         errorMessage = error.localizedDescription
+        ErrorReporter.shared.report(error, component: "Notifications.apnsRegistration")
         logger.error("APNs registration failed: \(error.localizedDescription, privacy: .public)")
     }
 
@@ -315,6 +318,7 @@ final class NotificationManager {
         } catch {
             registrationState = .failed
             errorMessage = error.localizedDescription
+            ErrorReporter.shared.report(error, component: "Notifications.tokenSync")
             logger.warning(
                 "Failed to sync APNs token: \(error.localizedDescription, privacy: .public)"
             )
@@ -382,6 +386,7 @@ final class NotificationManager {
                 }
             } catch {
                 errorMessage = error.localizedDescription
+                ErrorReporter.shared.report(error, component: "Notifications.confirm")
                 if let path = navigationPath(from: userInfo) {
                     pendingNavigationPath = path
                 }

--- a/ios/FamilyAssistant/FamilyAssistantTests/ErrorReporterTests.swift
+++ b/ios/FamilyAssistant/FamilyAssistantTests/ErrorReporterTests.swift
@@ -1,0 +1,265 @@
+import Foundation
+import XCTest
+
+@testable import FamilyAssistant
+
+final class ErrorReporterTests: XCTestCase {
+    private var spoolDirectory: URL!
+    private let baseURL = URL(string: "https://errors.example.test")!
+
+    override func setUp() {
+        super.setUp()
+        spoolDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ErrorReporterTests-\(UUID().uuidString)", isDirectory: true)
+        MockErrorURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        MockErrorURLProtocol.reset()
+        if let spoolDirectory {
+            try? FileManager.default.removeItem(at: spoolDirectory)
+        }
+        super.tearDown()
+    }
+
+    func testDeliverSendsPayloadToErrorsEndpoint() async throws {
+        MockErrorURLProtocol.respond { _ in .init(statusCode: 200) }
+        let reporter = makeReporter()
+        reporter.configure { self.baseURL }
+
+        await reporter.deliver(
+            message: "Boom",
+            component: "Notes.editor.save",
+            errorType: .handled,
+            stack: nil,
+            extraData: ["error_type_name": "NotesAPIError"]
+        )
+
+        XCTAssertEqual(MockErrorURLProtocol.requests.count, 1)
+        let request = try XCTUnwrap(MockErrorURLProtocol.requests.first)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://errors.example.test/api/errors/")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let payload = try XCTUnwrap(MockErrorURLProtocol.decodedBodies.first)
+        XCTAssertEqual(payload.message, "Boom")
+        XCTAssertEqual(payload.componentName, "Notes.editor.save")
+        XCTAssertEqual(payload.errorType, "manual")
+        XCTAssertEqual(payload.url, "familyassistant://ios/Notes.editor.save")
+        XCTAssertEqual(payload.extraData?["platform"], "ios")
+        XCTAssertEqual(payload.extraData?["error_type_name"], "NotesAPIError")
+        XCTAssertEqual(try XCTUnwrap(payload.userAgent).hasPrefix("FamilyAssistant-iOS/"), true)
+        XCTAssertTrue(spooledFiles().isEmpty)
+    }
+
+    func testDeliverDeduplicatesWithinWindow() async throws {
+        MockErrorURLProtocol.respond { _ in .init(statusCode: 200) }
+        let reporter = makeReporter()
+        reporter.configure { self.baseURL }
+
+        for _ in 0..<3 {
+            await reporter.deliver(
+                message: "Same",
+                component: "Chat.messages",
+                errorType: .handled,
+                stack: nil,
+                extraData: [:]
+            )
+        }
+
+        XCTAssertEqual(MockErrorURLProtocol.requests.count, 1)
+    }
+
+    func testDistinctComponentsAreNotDeduplicated() async throws {
+        MockErrorURLProtocol.respond { _ in .init(statusCode: 200) }
+        let reporter = makeReporter()
+        reporter.configure { self.baseURL }
+
+        await reporter.deliver(message: "Same", component: "A", errorType: .handled, stack: nil, extraData: [:])
+        await reporter.deliver(message: "Same", component: "B", errorType: .handled, stack: nil, extraData: [:])
+
+        XCTAssertEqual(MockErrorURLProtocol.requests.count, 2)
+    }
+
+    func testDeliverPersistsWhenBaseURLUnknown() async throws {
+        MockErrorURLProtocol.respond { _ in .init(statusCode: 200) }
+        let reporter = makeReporter()
+        // No base URL configured (e.g. error before sign-in).
+
+        await reporter.deliver(
+            message: "Pre-login failure",
+            component: "Auth.callback",
+            errorType: .handled,
+            stack: nil,
+            extraData: [:]
+        )
+
+        XCTAssertEqual(MockErrorURLProtocol.requests.count, 0)
+        XCTAssertEqual(spooledFiles().count, 1)
+    }
+
+    func testDeliverPersistsOnServerError() async throws {
+        MockErrorURLProtocol.respond { _ in .init(statusCode: 500) }
+        let reporter = makeReporter()
+        reporter.configure { self.baseURL }
+
+        await reporter.deliver(
+            message: "Server down",
+            component: "Chat.stream",
+            errorType: .handled,
+            stack: nil,
+            extraData: [:]
+        )
+
+        XCTAssertEqual(MockErrorURLProtocol.requests.count, 1)
+        XCTAssertEqual(spooledFiles().count, 1)
+    }
+
+    func testFlushPersistedDeliversAndRemovesSpooledReports() async throws {
+        // First, spool a report by delivering with no base URL.
+        let reporter = makeReporter()
+        await reporter.deliver(
+            message: "Queued",
+            component: "Notes.list.load",
+            errorType: .handled,
+            stack: nil,
+            extraData: [:]
+        )
+        XCTAssertEqual(spooledFiles().count, 1)
+
+        // Now the server is reachable: flushing should deliver and clean up.
+        MockErrorURLProtocol.respond { _ in .init(statusCode: 200) }
+        reporter.configure { self.baseURL }
+        await reporter.flushPersisted()
+
+        XCTAssertEqual(MockErrorURLProtocol.requests.count, 1)
+        let payload = try XCTUnwrap(MockErrorURLProtocol.decodedBodies.first)
+        XCTAssertEqual(payload.message, "Queued")
+        XCTAssertTrue(spooledFiles().isEmpty)
+    }
+
+    func testFlushPersistedKeepsReportsWhenServerStillFailing() async throws {
+        let reporter = makeReporter()
+        await reporter.deliver(
+            message: "Queued",
+            component: "Notes.list.load",
+            errorType: .handled,
+            stack: nil,
+            extraData: [:]
+        )
+
+        MockErrorURLProtocol.respond { _ in .init(statusCode: 503) }
+        reporter.configure { self.baseURL }
+        await reporter.flushPersisted()
+
+        XCTAssertEqual(spooledFiles().count, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeReporter() -> ErrorReporter {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockErrorURLProtocol.self]
+        return ErrorReporter(
+            session: URLSession(configuration: configuration),
+            spoolDirectory: spoolDirectory,
+            dedupeWindow: 60
+        )
+    }
+
+    private func spooledFiles() -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(at: spoolDirectory, includingPropertiesForKeys: nil))?
+            .filter { $0.pathExtension == "json" } ?? []
+    }
+}
+
+private final class MockErrorURLProtocol: URLProtocol {
+    struct Response {
+        let statusCode: Int
+    }
+
+    typealias Handler = (URLRequest) -> Response
+
+    private static let lock = NSLock()
+    private static var handler: Handler?
+    private static var recordedRequests: [URLRequest] = []
+
+    static var requests: [URLRequest] {
+        lock.withLock { recordedRequests }
+    }
+
+    static var decodedBodies: [ErrorReportPayload] {
+        lock.withLock {
+            recordedRequests.compactMap { request in
+                guard let body = request.httpBody ?? Data(reading: request.httpBodyStream) else {
+                    return nil
+                }
+                return try? JSONDecoder().decode(ErrorReportPayload.self, from: body)
+            }
+        }
+    }
+
+    static func respond(with handler: @escaping Handler) {
+        lock.withLock { self.handler = handler }
+    }
+
+    static func reset() {
+        lock.withLock {
+            handler = nil
+            recordedRequests = []
+        }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "errors.example.test"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.lock.withLock {
+            Self.recordedRequests.append(request)
+        }
+
+        guard let handler = Self.lock.withLock({ Self.handler }) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        let response = handler(request)
+        let httpResponse = HTTPURLResponse(
+            url: request.url!,
+            statusCode: response.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("{\"status\":\"reported\"}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private extension Data {
+    init?(reading stream: InputStream?) {
+        guard let stream else { return nil }
+        self.init()
+        stream.open()
+        defer { stream.close() }
+
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let bytesRead = stream.read(buffer, maxLength: bufferSize)
+            if bytesRead < 0 {
+                return nil
+            }
+            append(buffer, count: bytesRead)
+        }
+    }
+}


### PR DESCRIPTION
## Why

The native iOS app surfaces failures as on-screen alerts (the many
`errorMessage = error.localizedDescription` sites) and writes to the on-device `os.Logger` — none of
which reaches the server. A bug hit in a TestFlight build left no inspectable trace. The web frontend
already reports JS errors to the unauthenticated `POST /api/errors/` endpoint (those land in the DB
error log at `/errors`); this gives the native app the same server-side visibility.

## What

- **`ErrorReporter.swift`** — a shared, thread-safe reporter:
  - Fire-and-forget `report(...)` with a 60s dedup window (matching the web client) and
    device/build/`is_testflight` metadata.
  - **Best-effort delivery with disk spooling**: when the server URL isn't known yet (error before
    sign-in) or a send fails, the report is spooled to a capped Caches dir and retried by
    `flushPersisted()` on the next launch.
  - **`installGlobalHandlers()`** — an `NSSetUncaughtExceptionHandler` (chained to any existing
    handler) that *synchronously persists* uncaught Objective-C exceptions, since the process is
    terminating and an async send can't complete.
- Wires the user-facing `catch` sites across **Auth, Notifications, Notes, Confirmation, Chat** to
  report (one additive line each). Pure validation messages (e.g. "Title and content are required.")
  are intentionally not reported.
- `FamilyAssistantApp` configures the reporter + installs handlers at launch and flushes spooled
  reports via `.task`.
- Tests (`ErrorReporterTests.swift`), `project.pbxproj` registration (app + test targets), a design
  doc (`docs/design/ios_error_reporting.md`), and a USER_GUIDE note.

### Deliberate scope call: no raw POSIX signal handlers

Hard crashes (Swift traps, `SIGSEGV`) are out of scope — Apple already captures those for TestFlight
builds (App Store Connect → TestFlight → Crashes). In-process signal handling is fragile
(async-signal-safety) and would duplicate what Apple provides. This reporter focuses on what
TestFlight can't see: handled errors and uncaught ObjC exceptions, tied to our own error log.

## How to grab a TestFlight bug report

1. **Crashes** → TestFlight → Crashes (automatic; upload dSYMs for symbolication).
2. **Tester feedback** → TestFlight screenshot/feedback.
3. **Handled errors / ObjC exceptions** → server error log at `/errors`, identifiable by
   `component_name` and the `is_testflight` flag. (Native reports currently reuse the web ingest
   path, so they appear under the `frontend.javascript` logger — easy to split into a dedicated
   logger later if desired.)

## Testing

- iOS unit tests in `ErrorReporterTests.swift` cover payload shape, dedup, disk spooling on failure,
  `flushPersisted()` delivery + cleanup, and base-URL resolution (URLProtocol mock + temp spool dir).
- The Swift can't be compiled in the Linux dev sandbox — it's validated by the `ios-tests.yml` macOS
  CI job.
- `poe test` (Python/frontend) passes; the only failure was `test_mobile_chat_input_visibility`, a
  pre-existing Playwright timeout flake unrelated to this change (passes on re-run).

https://claude.ai/code/session_01PApWUmh7Yfe1Uhxh22VBsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01PApWUmh7Yfe1Uhxh22VBsR)_