### PR TITLE
Execute automation scripts under their creating profile

### DIFF
--- a/alembic/versions/2026_06_10-add_automation_provenance.py
+++ b/alembic/versions/2026_06_10-add_automation_provenance.py
@@ -1,0 +1,47 @@
+"""Add creator provenance to automation tables
+
+Adds ``processing_profile_id`` and ``created_by_user_id`` to the
+``event_listeners`` and ``schedule_automations`` tables so that scripts are
+validated and executed under the processing profile (and on behalf of the user)
+that created them, rather than the task worker's default profile.
+
+Revision ID: add_automation_provenance
+Revises: add_ios_push_tokens
+Create Date: 2026-06-10 00:00:00.000000+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_automation_provenance"
+down_revision: str | None = "add_ios_push_tokens"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_TABLES = ("event_listeners", "schedule_automations")
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    for table in _TABLES:
+        op.add_column(
+            table,
+            sa.Column("processing_profile_id", sa.String(length=255), nullable=True),
+        )
+        op.add_column(
+            table,
+            sa.Column("created_by_user_id", sa.String(length=255), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    for table in _TABLES:
+        op.drop_column(table, "created_by_user_id")
+        op.drop_column(table, "processing_profile_id")

--- a/alembic/versions/2026_06_11-add_confirmation_origin.py
+++ b/alembic/versions/2026_06_11-add_confirmation_origin.py
@@ -1,0 +1,43 @@
+"""Record the origin interface/conversation on confirmation requests
+
+Adds ``origin_interface_type`` and ``origin_conversation_id`` to
+``confirmation_requests``. Automation-script confirmations have no source
+message row, so without these the deferred ``confirmation_tool_execution``
+rebuilt its context from the worker defaults ("unknown_conversation") and
+approved tools could stamp or act in the wrong conversation.
+
+Revision ID: add_confirmation_origin
+Revises: add_confirmation_profile
+Create Date: 2026-06-11 12:00:00.000000+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_confirmation_origin"
+down_revision: str | None = "add_confirmation_profile"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "confirmation_requests",
+        sa.Column("origin_interface_type", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "confirmation_requests",
+        sa.Column("origin_conversation_id", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("confirmation_requests", "origin_conversation_id")
+    op.drop_column("confirmation_requests", "origin_interface_type")

--- a/alembic/versions/2026_06_11-add_confirmation_processing_profile.py
+++ b/alembic/versions/2026_06_11-add_confirmation_processing_profile.py
@@ -1,0 +1,38 @@
+"""Record the originating processing profile on confirmation requests
+
+Adds ``processing_profile_id`` to ``confirmation_requests`` so that a deferred
+tool execution (``confirmation_tool_execution``) runs under the profile that
+originally requested confirmation. Script-originated confirmations have no
+source message row to derive the profile from, so without this the approved
+action would fall back to the worker's default profile.
+
+Revision ID: add_confirmation_profile
+Revises: add_automation_provenance
+Create Date: 2026-06-11 00:00:00.000000+00:00
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_confirmation_profile"
+down_revision: str | None = "add_automation_provenance"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "confirmation_requests",
+        sa.Column("processing_profile_id", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("confirmation_requests", "processing_profile_id")

--- a/docs/design/automation_provenance.md
+++ b/docs/design/automation_provenance.md
@@ -1,0 +1,68 @@
+# Automation Provenance: Profile-Consistent Script Validation and Execution
+
+## Problem
+
+Automation scripts were **validated** against one processing profile but **executed** under a
+different one, so a script could pass validation at creation time and then behave differently (or
+fail outright) when it ran.
+
+- **Validation** (`create_automation_tool` in `tools/automations.py`) generated tool stubs from the
+  tools provider of whatever profile was *creating* the automation (typically `automation_creation`
+  or `default_assistant`).
+- **Execution** (`handle_script_execution` in `task_worker.py`) always used
+  `exec_context.processing_service`, which the task worker builds from its **default** processing
+  service. The docstring claimed scripts ran under the restricted `event_handler` profile, but no
+  profile switch actually happened — unlike `handle_llm_callback`, which switches to the `reminder`
+  profile via the processing services registry.
+
+The result: the tool set the validator checked against was not the tool set available at runtime.
+
+## Security model
+
+The injection threat for a deterministic **script** action is limited to *data flow*: an attacker
+who controls the triggering event can influence the *arguments* at the call sites the author wired
+up, but cannot change *which* tools are called. That is much weaker than injecting an LLM, so it is
+proportionate to run a script with the authority of the profile (and user) that created it:
+
+> If the agent can do X, it is fine to let it schedule X to happen later.
+
+This also makes capability **monotone** through the create→execute chain: a script created under a
+restricted profile can never gain access to tools that profile lacks. (A restricted profile that
+could itself author automations would otherwise be a privilege‑escalation path.)
+
+`wake_llm` actions are different: the woken LLM reads attacker-influenced event content and *is* the
+injectable component. Those intentionally keep running under the restricted `event_handler` profile
+and are **not** affected by this change.
+
+## Design
+
+Capture the creating profile (and user) on the automation, thread it through to the script execution
+task, and resolve it at execution time:
+
+1. **Schema** — `event_listeners` and `schedule_automations` gain nullable `processing_profile_id`
+   and `created_by_user_id` columns (migration `add_automation_provenance`).
+2. **Capture** — `create_automation_tool` stores `exec_context.processing_profile_id` and
+   `exec_context.user_id`. `update_automation_tool` re-validates a changed inline script and
+   re-stamps the provenance with the *updating* profile/user, so the updater's authority governs.
+3. **Thread** — the `script_execution` task payload carries `processing_profile_id` (and
+   `created_by_user_id`). For schedule automations this flows through `_build_script_payload`; for
+   event automations it flows through the event processor's action context.
+4. **Resolve** — `handle_script_execution` resolves the recorded profile via the processing services
+   registry (`_resolve_script_execution_service`) and re-points the execution context (tools
+   provider, visibility grants, note labels) at it. Validation, which already uses the creating
+   profile's tools provider, is therefore consistent with execution by construction.
+
+### Fallback
+
+Legacy automations created before provenance was tracked have a `NULL` profile and fall back to the
+task worker's default profile (the previous behaviour), with a warning logged. The same fallback
+applies if the recorded profile is no longer registered or is not a local profile.
+
+## Confirm-gated tools
+
+A profile's policy may mark some tools `confirm` (e.g. `delete_calendar_event`). Scripts execute in
+the task worker with no interactive channel, so confirm-gated tool calls are routed through the
+existing durable confirmation machinery: a confirmation request is created and delivered to the
+automation's owner, and the script receives a "pending approval — not run yet" result. The tool runs
+later, after the user approves, via the `confirmation_tool_execution` task. This mirrors the email
+intake profile, which already defers confirm-gated tools the same way.

--- a/docs/design/automation_provenance.md
+++ b/docs/design/automation_provenance.md
@@ -44,13 +44,24 @@ task, and resolve it at execution time:
 2. **Capture** — `create_automation_tool` stores `exec_context.processing_profile_id` and
    `exec_context.user_id`. `update_automation_tool` re-validates a changed inline script and
    re-stamps the provenance with the *updating* profile/user, so the updater's authority governs.
+   The web automations API stamps the default profile and the authenticated web user the same way
+   (re-stamping on updates that change the action config), and the `schedule_action` tool threads
+   the acting profile/user into one-time scheduled script payloads via `execute_action`.
 3. **Thread** — the `script_execution` task payload carries `processing_profile_id` (and
    `created_by_user_id`). For schedule automations this flows through `_build_script_payload`; for
-   event automations it flows through the event processor's action context.
+   event automations and one-time scheduled actions it flows through `execute_action`.
 4. **Resolve** — `handle_script_execution` resolves the recorded profile via the processing services
    registry (`_resolve_script_execution_service`) and re-points the execution context (tools
    provider, visibility grants, note labels) at it. Validation, which already uses the creating
    profile's tools provider, is therefore consistent with execution by construction.
+
+### Known limitation: stored scripts
+
+Automations can reference a stored script by `script_name` instead of inline code. Stored scripts
+are validated against the tools of the profile that *saved* them, while an automation referencing
+one executes it under the *automation creator's* profile. Creation-time validation for the
+`script_name` case only checks that the script exists, so a saved-vs-referenced profile mismatch is
+still possible there; the tool policy is enforced at runtime either way.
 
 ### Fallback
 

--- a/docs/design/automation_provenance.md
+++ b/docs/design/automation_provenance.md
@@ -55,19 +55,23 @@ task, and resolve it at execution time:
    provider, visibility grants, note labels) at it. Validation, which already uses the creating
    profile's tools provider, is therefore consistent with execution by construction.
 
-### Known limitation: stored scripts
+### Stored scripts
 
 Automations can reference a stored script by `script_name` instead of inline code. Stored scripts
-are validated against the tools of the profile that *saved* them, while an automation referencing
-one executes it under the *automation creator's* profile. Creation-time validation for the
-`script_name` case only checks that the script exists, so a saved-vs-referenced profile mismatch is
-still possible there; the tool policy is enforced at runtime either way.
+are global and validated against the tools of the profile that *saved* them, while an automation
+referencing one executes it under the *automation creator's* profile — so creating or updating such
+an automation re-validates the stored script's code against the creating profile's tools
+(`validate_action_scripts_with_provider`), using the automation runtime globals plus the script's
+declared and supplied parameters as inputs. A profile that lacks a tool the stored script uses is
+rejected at the boundary rather than failing at runtime.
 
 ### Fallback
 
 Legacy automations created before provenance was tracked have a `NULL` profile and fall back to the
-task worker's default profile (the previous behaviour), with a warning logged. The same fallback
-applies if the recorded profile is no longer registered or is not a local profile.
+task worker's default profile (the previous behaviour). An automation explicitly stamped with a
+non-default profile that can no longer be resolved (renamed/removed profile, or a non-local one)
+fails loudly instead of downgrading: the script was validated for that profile's tools and
+visibility, so running it under a different policy could change its capabilities.
 
 ## Confirm-gated tools
 

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -278,7 +278,12 @@ You can ask the assistant a wide variety of things:
   script automations: \*"Show me the script for my temperature alert" \*"Test this script with a
   sample temperature event: [provide script code]" \*"Convert my garage door automation to use a
   script instead" \*If you want to validate a script before it touches live state, ask the assistant
-  to test it with simulated tools first.
+  to test it with simulated tools first. \*Automation scripts run with the same tools the assistant
+  had when it created them, and that tool set is checked when the automation is saved — so a script
+  that passes validation will have the tools it needs when it later runs. If a script calls an
+  action that normally needs your approval (like deleting a calendar event), it won't run silently
+  in the background: a confirmation lands in Telegram or the Web UI, and the action only happens
+  once you approve it.
 
 ## 4. Working with Attachments
 

--- a/src/family_assistant/actions.py
+++ b/src/family_assistant/actions.py
@@ -99,6 +99,7 @@ async def execute_action(
         script_payload: dict[str, object] = {
             "config": action_config,
             "conversation_id": conversation_id,
+            "interface_type": interface_type,
             **context,
         }
         if action_config.get("script_code"):

--- a/src/family_assistant/actions.py
+++ b/src/family_assistant/actions.py
@@ -36,6 +36,8 @@ async def execute_action(
     context: dict[str, Any] | None = None,
     scheduled_at: datetime | None = None,
     recurrence_rule: str | None = None,
+    processing_profile_id: str | None = None,
+    created_by_user_id: str | None = None,
 ) -> None:
     """
     Execute an action. Used by both event listeners and scheduled tasks.
@@ -50,6 +52,12 @@ async def execute_action(
         context: Additional context (e.g., event data, trigger info)
         scheduled_at: When to execute the action (None for immediate)
         recurrence_rule: RRULE for recurring tasks (None for one-time)
+        processing_profile_id: Creating profile for script actions; scripts
+            execute under this profile so validation and execution agree.
+            Ignored for wake_llm actions, which run under the event handler
+            profile.
+        created_by_user_id: Creating user for script actions; confirm-gated
+            tool calls from the script are addressed to this user.
     """
     if context is None:
         context = {}
@@ -101,6 +109,10 @@ async def execute_action(
                 script_payload["script_parameters"] = action_config["parameters"]
         if user_name:
             script_payload["user_name"] = user_name
+        if processing_profile_id is not None:
+            script_payload["processing_profile_id"] = processing_profile_id
+        if created_by_user_id is not None:
+            script_payload["created_by_user_id"] = created_by_user_id
 
         await enqueue_task(
             db_context=db_ctx,

--- a/src/family_assistant/email_intake/actions.py
+++ b/src/family_assistant/email_intake/actions.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import re
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING, TypedDict, cast
 
 from sqlalchemy import select
@@ -15,41 +13,27 @@ from family_assistant.email_intake.outbound import (
     email_conversation_id,
 )
 from family_assistant.llm.messages import text_content
-from family_assistant.services.confirmation_service import (
-    ConfirmationService,
-    create_durable_confirmation,
+from family_assistant.services.deferred_tool_confirmation import (
+    create_deferred_tool_confirmation,
 )
-from family_assistant.services.user_identity import UserIdentityResolver
-from family_assistant.storage.context import get_db_context
 from family_assistant.storage.email import received_emails_table
-from family_assistant.tools.confirmation import TOOL_CONFIRMATION_RENDERERS
 from family_assistant.tools.types import ConfirmationOutcome, ToolExecutionContext
 
 if TYPE_CHECKING:
     from family_assistant.interfaces import ChatInterface
     from family_assistant.processing import ProcessingService
-    from family_assistant.tools.types import ToolArguments, ToolArgumentsView
+    from family_assistant.tools.types import ToolArguments
 
 logger = logging.getLogger(__name__)
 
 EMAIL_INTAKE_ACTION_TASK_TYPE = "email_intake_action"
 MAX_EMAIL_EVIDENCE_CHARS = 50000
-MAX_CONFIRMATION_ARGS_CHARS = 6000
 UNTRUSTED_EMAIL_EVIDENCE_START_TAG = "<untrusted_email_evidence>"
 UNTRUSTED_EMAIL_EVIDENCE_END_TAG = "</untrusted_email_evidence>"
 UNTRUSTED_EMAIL_EVIDENCE_TAG_RE = re.compile(
     r"<\s*/?\s*untrusted_email_evidence\b[^>]*>",
     re.IGNORECASE,
 )
-
-
-def _markdown_code_block(text: str, *, language: str = "") -> str:
-    """Render a markdown code block with a fence longer than any content fence."""
-    fence = "```"
-    while fence in text:
-        fence += "`"
-    language_suffix = language if language else ""
-    return f"{fence}{language_suffix}\n{text}\n{fence}"
 
 
 def _neutralize_untrusted_evidence_boundaries(text: str) -> str:
@@ -164,27 +148,6 @@ def _resolve_email_processing_service(
     return cast("ProcessingService", candidate)
 
 
-async def _render_confirmation_prompt(
-    *,
-    tool_name: str,
-    tool_args: ToolArgumentsView,
-    context: ToolExecutionContext,
-) -> str:
-    renderer = TOOL_CONFIRMATION_RENDERERS.get(tool_name)
-    if renderer is not None:
-        rendered = await renderer(tool_args, context)
-    else:
-        args_json = json.dumps(tool_args, indent=2, sort_keys=True, default=str)
-        if len(args_json) > MAX_CONFIRMATION_ARGS_CHARS:
-            args_json = args_json[:MAX_CONFIRMATION_ARGS_CHARS] + "\n... [truncated]"
-        rendered = (
-            f"Tool: {tool_name}\n\n"
-            "Arguments:\n"
-            f"{_markdown_code_block(args_json, language='json')}"
-        )
-    return f"From your email — approve to run:\n\n{rendered}"
-
-
 async def _create_email_confirmation_callback(
     *,
     context: ToolExecutionContext,
@@ -198,112 +161,15 @@ async def _create_email_confirmation_callback(
             kind="failed",
             result="Cannot request confirmation without a resolved user id.",
         )
-    target_user_id = context.user_id
-
-    confirmation_prompt = await _render_confirmation_prompt(
-        tool_name=tool_name,
-        tool_args=tool_args,
+    return await create_deferred_tool_confirmation(
         context=context,
-    )
-    confirmation_service = ConfirmationService(
-        db_context_factory=lambda: get_db_context(engine=context.db_context.engine)
-    )
-    now = context.clock.now() if context.clock is not None else datetime.now(UTC)
-    request = await create_durable_confirmation(
-        confirmation_service=confirmation_service,
-        db_context=context.db_context,
-        target_user_id=target_user_id,
         tool_name=tool_name,
-        tool_call_id=call_id,
+        call_id=call_id,
         tool_args=tool_args,
-        confirmation_prompt=confirmation_prompt,
         timeout_seconds=timeout_seconds,
-        turn_id=context.turn_id,
-        now=now,
+        target_user_id=context.user_id,
+        source_prefix="From your email — approve to run:",
     )
-    logger.info(
-        "Created durable confirmation %s for email-originated tool %s",
-        request["id"],
-        tool_name,
-    )
-    request_id = str(request["id"])
-    notification_warning = await _send_primary_confirmation_request(
-        context=context,
-        target_user_id=target_user_id,
-        request_id=request_id,
-        confirmation_prompt=confirmation_prompt,
-    )
-    result = (
-        f"Waiting on the user to approve this in Telegram or the web UI "
-        f"(request {request_id}). It hasn't run yet."
-    )
-    if notification_warning is not None:
-        result = f"{result}\n\nWarning: {notification_warning}"
-    return ConfirmationOutcome(
-        kind="completed",
-        result=result,
-    )
-
-
-async def _send_primary_confirmation_request(
-    *,
-    context: ToolExecutionContext,
-    target_user_id: str,
-    request_id: str,
-    confirmation_prompt: str,
-) -> str | None:
-    if context.confirmation_ui_managers is None:
-        message = "No confirmation UI manager registry is available."
-        logger.info("%s Email confirmation: %s", message, request_id)
-        return message
-    telegram_confirmation_manager = context.confirmation_ui_managers.get("telegram")
-    if telegram_confirmation_manager is None:
-        message = "No Telegram confirmation UI is available."
-        logger.info("%s Email confirmation: %s", message, request_id)
-        return message
-
-    processing_service = context.processing_service
-    if processing_service is None:
-        message = (
-            "No processing service is available to resolve the user's Telegram "
-            "notification target."
-        )
-        logger.info("%s Email confirmation: %s", message, request_id)
-        return message
-    telegram_user_id = UserIdentityResolver(
-        processing_service.app_config
-    ).get_primary_telegram_user_id(target_user_id)
-    if telegram_user_id is None:
-        message = (
-            f"User {target_user_id!r} has no primary Telegram mapping for "
-            "confirmation delivery."
-        )
-        logger.info("%s Email confirmation: %s", message, request_id)
-        return message
-
-    telegram_conversation_id = str(telegram_user_id)
-    outcome = await telegram_confirmation_manager.send_existing_confirmation_request(
-        conversation_id=telegram_conversation_id,
-        request_id=request_id,
-        prompt_text=confirmation_prompt,
-    )
-    if outcome.kind != "completed":
-        message = (
-            f"Could not send Telegram confirmation UI to user {telegram_user_id}: "
-            f"{outcome.result or outcome.kind}."
-        )
-        logger.warning(
-            "%s Email confirmation: %s",
-            message,
-            request_id,
-        )
-        return message
-    logger.info(
-        "Sent Telegram confirmation UI to user %s for email confirmation %s",
-        telegram_user_id,
-        request_id,
-    )
-    return None
 
 
 async def handle_email_intake_action(

--- a/src/family_assistant/events/processor.py
+++ b/src/family_assistant/events/processor.py
@@ -326,6 +326,14 @@ class EventProcessor:
         ):
             context["event_data"] = event_data
 
+        # Scripts execute under the profile that created the listener so that
+        # validation and execution agree. wake_llm intentionally keeps running
+        # under the restricted event_handler profile (untrusted event content
+        # reaches the LLM), so provenance is only threaded for scripts.
+        if action_type == ActionType.SCRIPT:
+            context["processing_profile_id"] = listener.get("processing_profile_id")
+            context["created_by_user_id"] = listener.get("created_by_user_id")
+
         await execute_action(
             db_ctx=db_ctx,
             action_type=action_type,

--- a/src/family_assistant/events/processor.py
+++ b/src/family_assistant/events/processor.py
@@ -326,14 +326,6 @@ class EventProcessor:
         ):
             context["event_data"] = event_data
 
-        # Scripts execute under the profile that created the listener so that
-        # validation and execution agree. wake_llm intentionally keeps running
-        # under the restricted event_handler profile (untrusted event content
-        # reaches the LLM), so provenance is only threaded for scripts.
-        if action_type == ActionType.SCRIPT:
-            context["processing_profile_id"] = listener.get("processing_profile_id")
-            context["created_by_user_id"] = listener.get("created_by_user_id")
-
         await execute_action(
             db_ctx=db_ctx,
             action_type=action_type,
@@ -341,6 +333,8 @@ class EventProcessor:
             conversation_id=listener["conversation_id"],
             interface_type=listener.get("interface_type", "telegram"),
             context=context,
+            processing_profile_id=listener.get("processing_profile_id"),
+            created_by_user_id=listener.get("created_by_user_id"),
         )
 
         logger.info(

--- a/src/family_assistant/services/confirmation_service.py
+++ b/src/family_assistant/services/confirmation_service.py
@@ -73,6 +73,7 @@ class ConfirmationService:
         source_message_internal_id: int | None,
         confirmation_prompt: str,
         expires_at: datetime,
+        processing_profile_id: str | None = None,
     ) -> ConfirmationRequestRow:
         """Create a durable pending confirmation request."""
         request_id = f"confirm_{uuid.uuid4().hex[:12]}"
@@ -86,6 +87,7 @@ class ConfirmationService:
                 source_message_internal_id=source_message_internal_id,
                 confirmation_prompt=confirmation_prompt,
                 expires_at=expires_at,
+                processing_profile_id=processing_profile_id,
             )
         # Notify only after the request transaction has committed, so a recipient that immediately
         # approves/rejects (on a separate connection) can resolve the request_id.
@@ -300,6 +302,7 @@ async def create_durable_confirmation(
     timeout_seconds: float,
     turn_id: str | None,
     now: datetime,
+    processing_profile_id: str | None = None,
 ) -> ConfirmationRequestRow:
     """Record a durable pending confirmation for a tool that needs approval.
 
@@ -307,7 +310,9 @@ async def create_durable_confirmation(
     waiting on a live channel (email intake, the non-streaming chat API, and the
     durable half of the streaming chat path). Resolves the originating user
     message from ``turn_id`` so the approval threads back to the right
-    conversation.
+    conversation. ``processing_profile_id`` records the requesting profile so the
+    deferred execution runs under it, which matters for callers (automation
+    scripts) whose background turn has no source message row.
     """
     source_message_internal_id: int | None = None
     if turn_id is not None:
@@ -323,4 +328,5 @@ async def create_durable_confirmation(
         source_message_internal_id=source_message_internal_id,
         confirmation_prompt=confirmation_prompt,
         expires_at=now + timedelta(seconds=timeout_seconds),
+        processing_profile_id=processing_profile_id,
     )

--- a/src/family_assistant/services/confirmation_service.py
+++ b/src/family_assistant/services/confirmation_service.py
@@ -74,6 +74,8 @@ class ConfirmationService:
         confirmation_prompt: str,
         expires_at: datetime,
         processing_profile_id: str | None = None,
+        origin_interface_type: str | None = None,
+        origin_conversation_id: str | None = None,
     ) -> ConfirmationRequestRow:
         """Create a durable pending confirmation request."""
         request_id = f"confirm_{uuid.uuid4().hex[:12]}"
@@ -88,6 +90,8 @@ class ConfirmationService:
                 confirmation_prompt=confirmation_prompt,
                 expires_at=expires_at,
                 processing_profile_id=processing_profile_id,
+                origin_interface_type=origin_interface_type,
+                origin_conversation_id=origin_conversation_id,
             )
         # Notify only after the request transaction has committed, so a recipient that immediately
         # approves/rejects (on a separate connection) can resolve the request_id.
@@ -303,6 +307,8 @@ async def create_durable_confirmation(
     turn_id: str | None,
     now: datetime,
     processing_profile_id: str | None = None,
+    origin_interface_type: str | None = None,
+    origin_conversation_id: str | None = None,
 ) -> ConfirmationRequestRow:
     """Record a durable pending confirmation for a tool that needs approval.
 
@@ -310,9 +316,10 @@ async def create_durable_confirmation(
     waiting on a live channel (email intake, the non-streaming chat API, and the
     durable half of the streaming chat path). Resolves the originating user
     message from ``turn_id`` so the approval threads back to the right
-    conversation. ``processing_profile_id`` records the requesting profile so the
-    deferred execution runs under it, which matters for callers (automation
-    scripts) whose background turn has no source message row.
+    conversation. ``processing_profile_id`` and the origin interface/conversation
+    record the requesting context so the deferred execution runs under the same
+    profile and conversation, which matters for callers (automation scripts)
+    whose background turn has no source message row.
     """
     source_message_internal_id: int | None = None
     if turn_id is not None:
@@ -329,4 +336,6 @@ async def create_durable_confirmation(
         confirmation_prompt=confirmation_prompt,
         expires_at=now + timedelta(seconds=timeout_seconds),
         processing_profile_id=processing_profile_id,
+        origin_interface_type=origin_interface_type,
+        origin_conversation_id=origin_conversation_id,
     )

--- a/src/family_assistant/services/deferred_tool_confirmation.py
+++ b/src/family_assistant/services/deferred_tool_confirmation.py
@@ -165,6 +165,7 @@ async def create_deferred_tool_confirmation(
         timeout_seconds=timeout_seconds,
         turn_id=context.turn_id,
         now=now,
+        processing_profile_id=context.processing_profile_id,
     )
     request_id = str(request["id"])
     logger.info(

--- a/src/family_assistant/services/deferred_tool_confirmation.py
+++ b/src/family_assistant/services/deferred_tool_confirmation.py
@@ -166,6 +166,8 @@ async def create_deferred_tool_confirmation(
         turn_id=context.turn_id,
         now=now,
         processing_profile_id=context.processing_profile_id,
+        origin_interface_type=context.interface_type,
+        origin_conversation_id=context.conversation_id,
     )
     request_id = str(request["id"])
     logger.info(

--- a/src/family_assistant/services/deferred_tool_confirmation.py
+++ b/src/family_assistant/services/deferred_tool_confirmation.py
@@ -1,0 +1,185 @@
+"""Defer confirm-gated tool calls to durable confirmations.
+
+Non-interactive task-worker paths (inbound email actions, automation scripts)
+cannot prompt the user inline when a tool requires confirmation. Instead they
+record a durable confirmation request, deliver it to the user's primary channel,
+and return immediately with a "pending approval" result. The tool runs later via
+the ``confirmation_tool_execution`` task once the user approves.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from family_assistant.services.confirmation_service import (
+    ConfirmationService,
+    create_durable_confirmation,
+)
+from family_assistant.services.user_identity import UserIdentityResolver
+from family_assistant.storage.context import get_db_context
+from family_assistant.tools.confirmation import TOOL_CONFIRMATION_RENDERERS
+from family_assistant.tools.types import ConfirmationOutcome
+
+if TYPE_CHECKING:
+    from family_assistant.tools.types import (
+        ToolArguments,
+        ToolArgumentsView,
+        ToolExecutionContext,
+    )
+
+logger = logging.getLogger(__name__)
+
+MAX_CONFIRMATION_ARGS_CHARS = 6000
+
+
+def _markdown_code_block(text: str, *, language: str = "") -> str:
+    """Render a markdown code block with a fence longer than any content fence."""
+    fence = "```"
+    while fence in text:
+        fence += "`"
+    return f"{fence}{language}\n{text}\n{fence}"
+
+
+async def render_tool_confirmation_prompt(
+    *,
+    tool_name: str,
+    tool_args: ToolArgumentsView,
+    context: ToolExecutionContext,
+    source_prefix: str,
+) -> str:
+    """Render a human-facing confirmation prompt for a deferred tool call."""
+    renderer = TOOL_CONFIRMATION_RENDERERS.get(tool_name)
+    if renderer is not None:
+        rendered = await renderer(tool_args, context)
+    else:
+        args_json = json.dumps(tool_args, indent=2, sort_keys=True, default=str)
+        if len(args_json) > MAX_CONFIRMATION_ARGS_CHARS:
+            args_json = args_json[:MAX_CONFIRMATION_ARGS_CHARS] + "\n... [truncated]"
+        rendered = (
+            f"Tool: {tool_name}\n\n"
+            "Arguments:\n"
+            f"{_markdown_code_block(args_json, language='json')}"
+        )
+    return f"{source_prefix}\n\n{rendered}"
+
+
+async def deliver_confirmation_to_primary_channel(
+    *,
+    context: ToolExecutionContext,
+    target_user_id: str,
+    request_id: str,
+    confirmation_prompt: str,
+) -> str | None:
+    """Send the Telegram confirmation UI for a durable request.
+
+    Returns a human-readable warning string if delivery could not be performed
+    (the durable request still exists and can be approved elsewhere), or None on
+    success.
+    """
+    if context.confirmation_ui_managers is None:
+        message = "No confirmation UI manager registry is available."
+        logger.info("%s Deferred confirmation: %s", message, request_id)
+        return message
+    telegram_confirmation_manager = context.confirmation_ui_managers.get("telegram")
+    if telegram_confirmation_manager is None:
+        message = "No Telegram confirmation UI is available."
+        logger.info("%s Deferred confirmation: %s", message, request_id)
+        return message
+
+    processing_service = context.processing_service
+    if processing_service is None:
+        message = (
+            "No processing service is available to resolve the user's Telegram "
+            "notification target."
+        )
+        logger.info("%s Deferred confirmation: %s", message, request_id)
+        return message
+    telegram_user_id = UserIdentityResolver(
+        processing_service.app_config
+    ).get_primary_telegram_user_id(target_user_id)
+    if telegram_user_id is None:
+        message = (
+            f"User {target_user_id!r} has no primary Telegram mapping for "
+            "confirmation delivery."
+        )
+        logger.info("%s Deferred confirmation: %s", message, request_id)
+        return message
+
+    outcome = await telegram_confirmation_manager.send_existing_confirmation_request(
+        conversation_id=str(telegram_user_id),
+        request_id=request_id,
+        prompt_text=confirmation_prompt,
+    )
+    if outcome.kind != "completed":
+        message = (
+            f"Could not send Telegram confirmation UI to user {telegram_user_id}: "
+            f"{outcome.result or outcome.kind}."
+        )
+        logger.warning("%s Deferred confirmation: %s", message, request_id)
+        return message
+    logger.info(
+        "Sent Telegram confirmation UI to user %s for deferred confirmation %s",
+        telegram_user_id,
+        request_id,
+    )
+    return None
+
+
+async def create_deferred_tool_confirmation(
+    *,
+    context: ToolExecutionContext,
+    tool_name: str,
+    call_id: str,
+    tool_args: ToolArguments,
+    timeout_seconds: float,
+    target_user_id: str,
+    source_prefix: str,
+) -> ConfirmationOutcome:
+    """Record a durable confirmation for a confirm-gated tool and notify the user.
+
+    Returns a ``completed`` outcome whose ``result`` tells the caller the tool has
+    not run yet and is awaiting approval. The policy layer surfaces this result in
+    place of the tool's return value.
+    """
+    confirmation_prompt = await render_tool_confirmation_prompt(
+        tool_name=tool_name,
+        tool_args=tool_args,
+        context=context,
+        source_prefix=source_prefix,
+    )
+    confirmation_service = ConfirmationService(
+        db_context_factory=lambda: get_db_context(engine=context.db_context.engine)
+    )
+    now = context.clock.now() if context.clock is not None else datetime.now(UTC)
+    request = await create_durable_confirmation(
+        confirmation_service=confirmation_service,
+        db_context=context.db_context,
+        target_user_id=target_user_id,
+        tool_name=tool_name,
+        tool_call_id=call_id,
+        tool_args=tool_args,
+        confirmation_prompt=confirmation_prompt,
+        timeout_seconds=timeout_seconds,
+        turn_id=context.turn_id,
+        now=now,
+    )
+    request_id = str(request["id"])
+    logger.info(
+        "Created durable confirmation %s for deferred tool %s", request_id, tool_name
+    )
+    notification_warning = await deliver_confirmation_to_primary_channel(
+        context=context,
+        target_user_id=target_user_id,
+        request_id=request_id,
+        confirmation_prompt=confirmation_prompt,
+    )
+    result = (
+        f"Waiting on the user to approve this in Telegram or the web UI "
+        f"(request {request_id}). It hasn't run yet."
+    )
+    if notification_warning is not None:
+        result = f"{result}\n\nWarning: {notification_warning}"
+    return ConfirmationOutcome(kind="completed", result=result)

--- a/src/family_assistant/storage/confirmation_requests.py
+++ b/src/family_assistant/storage/confirmation_requests.py
@@ -40,6 +40,11 @@ confirmation_requests_table = Table(
     # execution runs under the same profile (script-originated confirmations
     # have no source message row to derive it from).
     Column("processing_profile_id", String(255), nullable=True),
+    # Origin interface/conversation of the turn that requested confirmation, so
+    # deferred execution can rebuild its context when there is no source message
+    # row (automation scripts) instead of falling back to worker defaults.
+    Column("origin_interface_type", String(50), nullable=True),
+    Column("origin_conversation_id", String(255), nullable=True),
     Column("expires_at", DateTime(timezone=True), nullable=False, index=True),
     Column("created_at", DateTime(timezone=True), nullable=False),
     Column("updated_at", DateTime(timezone=True), nullable=False),

--- a/src/family_assistant/storage/confirmation_requests.py
+++ b/src/family_assistant/storage/confirmation_requests.py
@@ -36,6 +36,10 @@ confirmation_requests_table = Table(
         index=True,
     ),
     Column("confirmation_prompt", Text, nullable=False),
+    # Processing profile that requested the confirmation, so the deferred
+    # execution runs under the same profile (script-originated confirmations
+    # have no source message row to derive it from).
+    Column("processing_profile_id", String(255), nullable=True),
     Column("expires_at", DateTime(timezone=True), nullable=False, index=True),
     Column("created_at", DateTime(timezone=True), nullable=False),
     Column("updated_at", DateTime(timezone=True), nullable=False),

--- a/src/family_assistant/storage/events.py
+++ b/src/family_assistant/storage/events.py
@@ -100,6 +100,11 @@ event_listeners_table = Table(
     ),
     Column("one_time", Boolean, nullable=False, server_default="false"),
     Column("enabled", Boolean, nullable=False, server_default="true"),
+    # Creator provenance: the processing profile and user that created this
+    # listener. Scripts are validated and executed under this profile so that
+    # validation and execution agree (see docs/design/automation_provenance.md).
+    Column("processing_profile_id", String(255), nullable=True),
+    Column("created_by_user_id", String(255), nullable=True),
     Column(
         "created_at",
         DateTime(timezone=True),

--- a/src/family_assistant/storage/repositories/confirmation_requests.py
+++ b/src/family_assistant/storage/repositories/confirmation_requests.py
@@ -28,6 +28,7 @@ class ConfirmationRequestRow(TypedDict):
     tool_call_id: str | None
     source_message_internal_id: int | None
     confirmation_prompt: str
+    processing_profile_id: str | None
     expires_at: datetime
     created_at: datetime
     updated_at: datetime
@@ -51,6 +52,7 @@ class ConfirmationRequestsRepository(BaseRepository):
         source_message_internal_id: int | None,
         confirmation_prompt: str,
         expires_at: datetime,
+        processing_profile_id: str | None = None,
     ) -> ConfirmationRequestRow:
         """Create a pending confirmation request."""
         if expires_at.tzinfo is None:
@@ -68,6 +70,7 @@ class ConfirmationRequestsRepository(BaseRepository):
                 tool_call_id=tool_call_id,
                 source_message_internal_id=source_message_internal_id,
                 confirmation_prompt=confirmation_prompt,
+                processing_profile_id=processing_profile_id,
                 expires_at=expires_at,
                 created_at=now,
                 updated_at=now,

--- a/src/family_assistant/storage/repositories/confirmation_requests.py
+++ b/src/family_assistant/storage/repositories/confirmation_requests.py
@@ -29,6 +29,8 @@ class ConfirmationRequestRow(TypedDict):
     source_message_internal_id: int | None
     confirmation_prompt: str
     processing_profile_id: str | None
+    origin_interface_type: str | None
+    origin_conversation_id: str | None
     expires_at: datetime
     created_at: datetime
     updated_at: datetime
@@ -53,6 +55,8 @@ class ConfirmationRequestsRepository(BaseRepository):
         confirmation_prompt: str,
         expires_at: datetime,
         processing_profile_id: str | None = None,
+        origin_interface_type: str | None = None,
+        origin_conversation_id: str | None = None,
     ) -> ConfirmationRequestRow:
         """Create a pending confirmation request."""
         if expires_at.tzinfo is None:
@@ -71,6 +75,8 @@ class ConfirmationRequestsRepository(BaseRepository):
                 source_message_internal_id=source_message_internal_id,
                 confirmation_prompt=confirmation_prompt,
                 processing_profile_id=processing_profile_id,
+                origin_interface_type=origin_interface_type,
+                origin_conversation_id=origin_conversation_id,
                 expires_at=expires_at,
                 created_at=now,
                 updated_at=now,

--- a/src/family_assistant/storage/repositories/events.py
+++ b/src/family_assistant/storage/repositories/events.py
@@ -158,6 +158,8 @@ class EventsRepository(BaseRepository):
         condition_script: str | None = None,
         one_time: bool = False,
         enabled: bool = True,
+        processing_profile_id: str | None = None,
+        created_by_user_id: str | None = None,
     ) -> int:
         """
         Create a new event listener.
@@ -193,6 +195,8 @@ class EventsRepository(BaseRepository):
                     interface_type=interface_type,
                     one_time=one_time,
                     enabled=enabled,
+                    processing_profile_id=processing_profile_id,
+                    created_by_user_id=created_by_user_id,
                     created_at=datetime.now(UTC),
                     daily_executions=0,
                 )
@@ -387,6 +391,8 @@ class EventsRepository(BaseRepository):
         one_time: bool,
         enabled: bool,
         condition_script: str | None = None,
+        processing_profile_id: str | None = None,
+        created_by_user_id: str | None = None,
     ) -> bool:
         """
         Update an event listener.
@@ -401,6 +407,9 @@ class EventsRepository(BaseRepository):
             one_time: Whether listener should auto-disable after first trigger
             enabled: Whether the listener is enabled
             condition_script: Optional Python script for complex matching
+            processing_profile_id: When set, re-stamp the creating profile so the
+                updated script executes under the updating profile's tools.
+            created_by_user_id: When set, re-stamp the creating user.
 
         Returns:
             True if updated successfully, False if not found or unauthorized
@@ -426,6 +435,13 @@ class EventsRepository(BaseRepository):
         # Only update action_config if provided
         if action_config is not None:
             update_values["action_config"] = action_config
+
+        # Re-stamp creator provenance when the updating profile/user is supplied,
+        # so the updated script executes under the updating profile's tools.
+        if processing_profile_id is not None:
+            update_values["processing_profile_id"] = processing_profile_id
+        if created_by_user_id is not None:
+            update_values["created_by_user_id"] = created_by_user_id
 
         # Always update condition_script (can be None to clear it)
         update_values["condition_script"] = condition_script

--- a/src/family_assistant/storage/repositories/schedule_automations.py
+++ b/src/family_assistant/storage/repositories/schedule_automations.py
@@ -35,6 +35,8 @@ def _build_script_payload(
     interface_type: str,
     automation_id: str,
     task_name: str,
+    processing_profile_id: str | None = None,
+    created_by_user_id: str | None = None,
 ) -> ScriptExecutionPayload:
     """Build a ScriptExecutionPayload from action_config, supporting both inline and stored scripts."""
     payload = ScriptExecutionPayload(
@@ -45,6 +47,10 @@ def _build_script_payload(
         task_name=action_config.get("task_name", task_name),
         config=dict(action_config),
     )
+    if processing_profile_id is not None:
+        payload["processing_profile_id"] = processing_profile_id
+    if created_by_user_id is not None:
+        payload["created_by_user_id"] = created_by_user_id
     script_name = action_config.get("script_name")
     if script_name:
         payload["script_name"] = script_name
@@ -86,6 +92,8 @@ class ScheduleAutomationsRepository(BaseRepository):
             action_type=row["action_type"],
             action_config=row["action_config"],
             enabled=row["enabled"],
+            processing_profile_id=row.get("processing_profile_id"),
+            created_by_user_id=row.get("created_by_user_id"),
             created_at=created_at,
             last_execution_at=normalize_datetime(row["last_execution_at"]),
             execution_count=row["execution_count"],
@@ -153,6 +161,8 @@ class ScheduleAutomationsRepository(BaseRepository):
         enabled: bool = True,
         *,
         timezone: ZoneInfo,
+        processing_profile_id: str | None = None,
+        created_by_user_id: str | None = None,
     ) -> int:
         """
         Create a schedule automation and schedule first task instance.
@@ -196,6 +206,8 @@ class ScheduleAutomationsRepository(BaseRepository):
                     conversation_id=conversation_id,
                     interface_type=interface_type,
                     enabled=enabled,
+                    processing_profile_id=processing_profile_id,
+                    created_by_user_id=created_by_user_id,
                     created_at=datetime.now(UTC),
                     execution_count=0,
                 )
@@ -234,6 +246,8 @@ class ScheduleAutomationsRepository(BaseRepository):
                     interface_type=interface_type,
                     automation_id=str(automation_id),
                     task_name=name,
+                    processing_profile_id=processing_profile_id,
+                    created_by_user_id=created_by_user_id,
                 )
 
             # Note: We do NOT pass recurrence_rule here because recurrence
@@ -472,6 +486,8 @@ class ScheduleAutomationsRepository(BaseRepository):
                     interface_type=automation["interface_type"],
                     automation_id=str(automation_id),
                     task_name=automation["name"],
+                    processing_profile_id=automation.get("processing_profile_id"),
+                    created_by_user_id=automation.get("created_by_user_id"),
                 )
 
             await enqueue_task(
@@ -533,6 +549,8 @@ class ScheduleAutomationsRepository(BaseRepository):
         enabled: bool | None | object = _UNSET,
         *,
         timezone: ZoneInfo,
+        processing_profile_id: str | None | object = _UNSET,
+        created_by_user_id: str | None | object = _UNSET,
     ) -> bool:
         """
         Update automation configuration, synchronizing task queue as needed.
@@ -574,6 +592,16 @@ class ScheduleAutomationsRepository(BaseRepository):
 
         if isinstance(enabled, bool):
             update_values["enabled"] = enabled
+
+        # Re-stamp creator provenance when supplied so the updated script
+        # executes under the updating profile's tools. Mutate ``existing`` too so
+        # the resynced task payload below carries the new profile.
+        if isinstance(processing_profile_id, str):
+            update_values["processing_profile_id"] = processing_profile_id
+            existing["processing_profile_id"] = processing_profile_id
+        if isinstance(created_by_user_id, str):
+            update_values["created_by_user_id"] = created_by_user_id
+            existing["created_by_user_id"] = created_by_user_id
 
         recurrence_changing = isinstance(recurrence_rule, str)
         if recurrence_changing:
@@ -824,6 +852,8 @@ class ScheduleAutomationsRepository(BaseRepository):
                 interface_type=automation["interface_type"],
                 automation_id=str(automation_id),
                 task_name=final_name,
+                processing_profile_id=automation.get("processing_profile_id"),
+                created_by_user_id=automation.get("created_by_user_id"),
             )
 
         await enqueue_task(
@@ -929,6 +959,8 @@ class ScheduleAutomationsRepository(BaseRepository):
                     interface_type=automation["interface_type"],
                     automation_id=str(automation_id),
                     task_name=automation["name"],
+                    processing_profile_id=automation.get("processing_profile_id"),
+                    created_by_user_id=automation.get("created_by_user_id"),
                 )
 
             # Note: We do NOT pass recurrence_rule here because recurrence

--- a/src/family_assistant/storage/repositories/schedule_automations.py
+++ b/src/family_assistant/storage/repositories/schedule_automations.py
@@ -596,6 +596,13 @@ class ScheduleAutomationsRepository(BaseRepository):
         # Re-stamp creator provenance when supplied so the updated script
         # executes under the updating profile's tools. Mutate ``existing`` too so
         # the resynced task payload below carries the new profile.
+        provenance_changing = (
+            isinstance(processing_profile_id, str)
+            and processing_profile_id != existing["processing_profile_id"]
+        ) or (
+            isinstance(created_by_user_id, str)
+            and created_by_user_id != existing["created_by_user_id"]
+        )
         if isinstance(processing_profile_id, str):
             update_values["processing_profile_id"] = processing_profile_id
             existing["processing_profile_id"] = processing_profile_id
@@ -630,6 +637,10 @@ class ScheduleAutomationsRepository(BaseRepository):
             or action_config_changing
             or enabled_changing
             or name_affects_task
+            # Re-stamping provenance must rebuild the pending task too, otherwise
+            # the already-enqueued payload keeps the old profile/user until it
+            # fires once under the wrong profile.
+            or provenance_changing
         )
 
         if needs_task_sync:

--- a/src/family_assistant/storage/schedule_automations.py
+++ b/src/family_assistant/storage/schedule_automations.py
@@ -59,6 +59,11 @@ schedule_automations_table = Table(
     ),
     # Management fields
     Column("enabled", Boolean, nullable=False, server_default="true"),
+    # Creator provenance: the processing profile and user that created this
+    # automation. Scripts are validated and executed under this profile so that
+    # validation and execution agree (see docs/design/automation_provenance.md).
+    Column("processing_profile_id", String(255), nullable=True),
+    Column("created_by_user_id", String(255), nullable=True),
     Column(
         "created_at",
         DateTime(timezone=True),

--- a/src/family_assistant/storage/types.py
+++ b/src/family_assistant/storage/types.py
@@ -56,6 +56,8 @@ class EventListenerDict(TypedDict):
     interface_type: str  # InterfaceType value
     one_time: bool
     enabled: bool
+    processing_profile_id: str | None
+    created_by_user_id: str | None
     created_at: datetime
     daily_executions: int
     daily_reset_at: datetime | None
@@ -75,6 +77,8 @@ class ScheduleAutomationDict(TypedDict):
     action_type: str  # EventActionType value
     action_config: ActionConfig
     enabled: bool
+    processing_profile_id: str | None
+    created_by_user_id: str | None
     created_at: datetime
     last_execution_at: datetime | None
     execution_count: int

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -1796,10 +1796,13 @@ async def handle_script_execution(
         tools_provider = processing_service.tools_provider
         # Re-point the execution context at the resolved profile so tool policy,
         # visibility grants and note labels all reflect the creating profile.
+        # The owner also becomes the acting user, so anything the script itself
+        # creates (e.g. via create_automation) inherits the same owner.
         exec_context = replace(
             exec_context,
             processing_service=processing_service,
             processing_profile_id=processing_service.service_config.id,
+            user_id=payload.get("created_by_user_id") or exec_context.user_id,
             tools_provider=tools_provider,
             visibility_grants=(
                 set(processing_service.service_config.visibility_grants)

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -1804,6 +1804,12 @@ async def handle_script_execution(
             processing_profile_id=processing_service.service_config.id,
             user_id=payload.get("created_by_user_id") or exec_context.user_id,
             tools_provider=tools_provider,
+            # Carry the resolved profile's infrastructure backends so tools that
+            # read them use the creating profile's clients, not the worker
+            # default's (mirrors _build_confirmation_execution_context).
+            home_assistant_client=processing_service.home_assistant_client,
+            attachment_registry=processing_service.attachment_registry,
+            camera_backend=processing_service.camera_backend,
             visibility_grants=(
                 set(processing_service.service_config.visibility_grants)
                 if processing_service.service_config.visibility_grants
@@ -2138,18 +2144,24 @@ def _get_processing_tools_provider(exec_context: ToolExecutionContext) -> ToolsP
 def _resolve_confirmation_processing_service(
     exec_context: ToolExecutionContext,
     source_row: MessageHistoryRow | None,
+    recorded_profile_id: str | None = None,
 ) -> ProcessingService:
-    """Resolve the local processing service that originally created the confirmation."""
+    """Resolve the local processing service that originally created the confirmation.
+
+    Prefers the profile recorded on the confirmation request itself, falling back
+    to the source message's profile. Script-originated confirmations have no
+    source message row, so the recorded profile is what keeps the deferred
+    execution on the automation's creating profile.
+    """
     default_processing_service = exec_context.processing_service
     if default_processing_service is None:
         raise RuntimeError("Confirmation execution requires a processing service")
 
-    profile_id = (
-        str(source_row["processing_profile_id"])
-        if source_row is not None
-        and source_row.get("processing_profile_id") is not None
-        else None
-    )
+    profile_id = recorded_profile_id
+    if profile_id is None and source_row is not None:
+        source_profile = source_row.get("processing_profile_id")
+        if source_profile is not None:
+            profile_id = str(source_profile)
     if profile_id is None or profile_id == default_processing_service.service_config.id:
         return default_processing_service
 
@@ -2313,6 +2325,7 @@ async def handle_confirmation_tool_execution(
         processing_service = _resolve_confirmation_processing_service(
             exec_context,
             source_row,
+            request.get("processing_profile_id"),
         )
         execution_context = await _build_confirmation_execution_context(
             exec_context,

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -57,6 +57,9 @@ if TYPE_CHECKING:
 # handle_index_email is now a method of EmailIndexer and registered in __main__.py
 from family_assistant.processing import ProcessingService
 from family_assistant.processing.utils import get_file_extension_from_mime_type
+from family_assistant.services.deferred_tool_confirmation import (
+    create_deferred_tool_confirmation,
+)
 from family_assistant.services.notification_targets import notify_conversation
 from family_assistant.services.notifier import MESSAGE_CATEGORY, NotificationMetadata
 from family_assistant.storage.context import DatabaseContext, get_db_context
@@ -64,7 +67,12 @@ from family_assistant.storage.message_history import message_history_table
 from family_assistant.storage.tasks import enqueue_task, get_task_event
 from family_assistant.tools import ToolExecutionContext
 from family_assistant.tools.stored_scripts import AUTOMATION_RUNTIME_GLOBALS
-from family_assistant.tools.types import ConfirmationOutcome, ToolResult
+from family_assistant.tools.types import (
+    ConfirmationOutcome,
+    RequestConfirmationCallback,
+    ToolArguments,
+    ToolResult,
+)
 from family_assistant.utils.clock import Clock, SystemClock
 
 logger = logging.getLogger(__name__)
@@ -1648,6 +1656,52 @@ def _resolve_script_execution_service(
     return cast("ProcessingService", candidate)
 
 
+def build_script_confirmation_callback(
+    created_by_user_id: str | None,
+) -> RequestConfirmationCallback:
+    """Build the confirmation callback used while executing an automation script.
+
+    Scripts run in the task worker with no interactive channel, so a confirm-gated
+    tool call is deferred to a durable confirmation addressed to the automation's
+    owner. The tool runs later via the confirmation_tool_execution task once the
+    user approves. Legacy automations with no recorded owner cannot be approved,
+    so the tool is reported as not run.
+    """
+
+    async def _script_confirmation_callback(
+        interface_type: str,
+        conversation_id: str,
+        turn_id: str | None,
+        tool_name: str,
+        call_id: str,
+        tool_args: ToolArguments,
+        timeout_seconds: float,
+        context: ToolExecutionContext,
+    ) -> ConfirmationOutcome:
+        _ = interface_type
+        _ = conversation_id
+        _ = turn_id
+        if created_by_user_id is None:
+            return ConfirmationOutcome(
+                kind="failed",
+                result=(
+                    "This automation has no recorded owner, so the confirm-gated "
+                    f"tool '{tool_name}' cannot be approved and was not run."
+                ),
+            )
+        return await create_deferred_tool_confirmation(
+            context=context,
+            tool_name=tool_name,
+            call_id=call_id,
+            tool_args=tool_args,
+            timeout_seconds=timeout_seconds,
+            target_user_id=created_by_user_id,
+            source_prefix="From an automation — approve to run:",
+        )
+
+    return _script_confirmation_callback
+
+
 async def handle_script_execution(
     exec_context: ToolExecutionContext,
     payload: ScriptExecutionPayload,
@@ -1754,6 +1808,9 @@ async def handle_script_execution(
             ),
             default_note_visibility_labels=(
                 processing_service.service_config.default_note_visibility_labels
+            ),
+            request_confirmation_callback=build_script_confirmation_callback(
+                payload.get("created_by_user_id")
             ),
         )
         logger.debug(
@@ -2375,4 +2432,5 @@ __all__ = [
     "handle_script_execution",
     "handle_confirmation_tool_execution",
     "handle_reindex_document",
+    "build_script_confirmation_callback",
 ]  # Export class and relevant handlers

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -1990,16 +1990,26 @@ async def _build_confirmation_execution_context(
     source_row: MessageHistoryRow | None,
     processing_service: ProcessingService,
 ) -> ToolExecutionContext:
-    """Reconstruct the best available context for deferred tool execution."""
+    """Reconstruct the best available context for deferred tool execution.
+
+    Prefers the source message's interface/conversation; confirmations created
+    without one (automation scripts) instead carry the origin recorded on the
+    request itself, so approved tools act in the requesting conversation rather
+    than the worker's placeholder context.
+    """
     interface_type = (
         str(source_row["interface_type"])
         if source_row is not None
-        else request["resolved_via_interface"] or exec_context.interface_type
+        else (
+            request["origin_interface_type"]
+            or request["resolved_via_interface"]
+            or exec_context.interface_type
+        )
     )
     conversation_id = (
         str(source_row["conversation_id"])
         if source_row is not None
-        else exec_context.conversation_id
+        else request["origin_conversation_id"] or exec_context.conversation_id
     )
     turn_id = (
         str(source_row["turn_id"])

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -62,6 +62,7 @@ from family_assistant.services.deferred_tool_confirmation import (
 )
 from family_assistant.services.notification_targets import notify_conversation
 from family_assistant.services.notifier import MESSAGE_CATEGORY, NotificationMetadata
+from family_assistant.services.user_identity import UserIdentityResolver
 from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.storage.message_history import message_history_table
 from family_assistant.storage.tasks import enqueue_task, get_task_event
@@ -1617,9 +1618,15 @@ def _resolve_script_execution_service(
 
     Scripts run under the profile that created the automation so that the tool
     set used at validation time matches the tool set available at execution
-    time. Falls back to the default processing service (with a warning) when the
-    creating profile is unknown (legacy automations created before provenance
-    was tracked) or is no longer registered.
+    time. Legacy automations created before provenance was tracked have no
+    recorded profile and fall back to the default processing service.
+
+    An automation explicitly stamped with a non-default profile that can no
+    longer be resolved (e.g. the profile was renamed/removed) is **not**
+    downgraded to the default: the script was validated and stamped for specific
+    tools/visibility, so running it under a different policy could change its
+    capabilities or data access. Such cases raise so the task fails loudly
+    rather than executing under the wrong profile.
     """
     default_service = exec_context.processing_service
     if (
@@ -1630,28 +1637,26 @@ def _resolve_script_execution_service(
         return default_service
 
     registry = default_service.processing_services_registry
-    fallback_reason: str | None = None
+    unresolvable_reason: str | None = None
     candidate: object | None = None
     if registry is None:
-        fallback_reason = "no processing services registry is available"
+        unresolvable_reason = "no processing services registry is available"
     else:
         candidate = registry.get(processing_profile_id)
         if candidate is None:
-            fallback_reason = "the profile is no longer registered"
+            unresolvable_reason = "the profile is no longer registered"
         elif getattr(candidate, "kind", None) != "local" or not hasattr(
             candidate, "tools_provider"
         ):
-            fallback_reason = "the profile is not a local profile"
+            unresolvable_reason = "the profile is not a local profile"
 
-    if fallback_reason is not None:
-        logger.warning(
-            "Script created under profile '%s' cannot be resolved (%s); falling "
-            "back to default profile '%s'",
-            processing_profile_id,
-            fallback_reason,
-            default_service.service_config.id,
+    if unresolvable_reason is not None:
+        raise RuntimeError(
+            f"Automation script is stamped with profile '{processing_profile_id}' "
+            f"but it cannot be resolved ({unresolvable_reason}); refusing to "
+            "downgrade to the default profile and run with different tools or "
+            "visibility than the script was validated against."
         )
-        return default_service
 
     return cast("ProcessingService", candidate)
 
@@ -2002,12 +2007,11 @@ async def _build_confirmation_execution_context(
         else exec_context.turn_id
     )
     user_name = exec_context.user_name or str(request["target_user_id"])
-    processing_profile_id = (
-        str(source_row["processing_profile_id"])
-        if source_row is not None
-        and source_row.get("processing_profile_id") is not None
-        else exec_context.processing_profile_id
-    )
+    # The profile id must match the service actually used (already resolved from
+    # the confirmation's recorded profile or the source message), so tools that
+    # read processing_profile_id directly (history filtering, automation
+    # stamping) see the same profile their provider belongs to.
+    processing_profile_id = processing_service.service_config.id
     subconversation_id = (
         str(source_row["subconversation_id"])
         if source_row is not None and source_row.get("subconversation_id") is not None
@@ -2192,6 +2196,44 @@ def _resolve_confirmation_processing_service(
     return cast("ProcessingService", candidate)
 
 
+def _resolve_confirmation_result_delivery(
+    context: ToolExecutionContext,
+    request: ConfirmationRequestRow,
+    source_row: MessageHistoryRow | None,
+) -> tuple[ChatInterface, str, str | None] | None:
+    """Pick where to deliver a confirmation result message.
+
+    Chat/email confirmations thread the result back to the originating
+    conversation (replying to the source message). Automation-originated
+    confirmations have no source message, so the result is delivered to the
+    target user's primary Telegram chat instead (mirroring how the pending
+    confirmation was delivered). Returns ``(chat_interface, conversation_id,
+    reply_to_interface_id)`` or None when no deliverable target exists.
+    """
+    if source_row is not None:
+        if context.chat_interface is None:
+            return None
+        reply_to_interface_id = (
+            str(source_row["interface_message_id"])
+            if source_row.get("interface_message_id") is not None
+            else None
+        )
+        return context.chat_interface, context.conversation_id, reply_to_interface_id
+
+    processing_service = context.processing_service
+    if processing_service is None or context.chat_interfaces is None:
+        return None
+    telegram_interface = context.chat_interfaces.get("telegram")
+    if telegram_interface is None:
+        return None
+    telegram_user_id = UserIdentityResolver(
+        processing_service.app_config
+    ).get_primary_telegram_user_id(request["target_user_id"])
+    if telegram_user_id is None:
+        return None
+    return telegram_interface, str(telegram_user_id), None
+
+
 async def _notify_confirmation_execution_result(
     context: ToolExecutionContext,
     request: ConfirmationRequestRow,
@@ -2201,25 +2243,16 @@ async def _notify_confirmation_execution_result(
     succeeded: bool = True,
 ) -> None:
     """Send a deterministic result notification when no live waiter consumes it."""
-    if context.chat_interface is None:
+    delivery = _resolve_confirmation_result_delivery(context, request, source_row)
+    if delivery is None:
         logger.info(
-            "Confirmation %s completed without a chat interface for notification",
+            "Confirmation %s completed without a deliverable notification target; "
+            "skipping result notification",
             request["id"],
         )
         return
 
-    if source_row is None:
-        logger.info(
-            "Confirmation %s completed without a source message; skipping result notification",
-            request["id"],
-        )
-        return
-
-    reply_to_interface_id = (
-        str(source_row["interface_message_id"])
-        if source_row.get("interface_message_id") is not None
-        else None
-    )
+    chat_interface, delivery_conversation_id, reply_to_interface_id = delivery
 
     try:
         result_text = _tool_result_text(result)
@@ -2241,8 +2274,8 @@ async def _notify_confirmation_execution_result(
                 f"Tool: {request['tool_name']}\n\n"
                 f"Error:\n{result_text}"
             )
-        sent_message_id = await context.chat_interface.send_message(
-            conversation_id=context.conversation_id,
+        sent_message_id = await chat_interface.send_message(
+            conversation_id=delivery_conversation_id,
             text=message,
             reply_to_interface_id=reply_to_interface_id,
             attachment_ids=attachment_ids,

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -119,6 +119,10 @@ class ScriptExecutionPayload(TypedDict, total=False):
     automation_id: str | int
     automation_type: str
     task_name: str
+    # Creator provenance: scripts run under the profile (and on behalf of the
+    # user) that created the automation, so validation and execution agree.
+    processing_profile_id: str
+    created_by_user_id: str
 
 
 class SystemEventCleanupPayload(TypedDict, total=False):
@@ -1597,6 +1601,53 @@ async def _process_script_wake_llm(
     )
 
 
+def _resolve_script_execution_service(
+    exec_context: ToolExecutionContext,
+    processing_profile_id: str | None,
+) -> ProcessingService | None:
+    """Resolve the processing service a script should execute under.
+
+    Scripts run under the profile that created the automation so that the tool
+    set used at validation time matches the tool set available at execution
+    time. Falls back to the default processing service (with a warning) when the
+    creating profile is unknown (legacy automations created before provenance
+    was tracked) or is no longer registered.
+    """
+    default_service = exec_context.processing_service
+    if (
+        default_service is None
+        or processing_profile_id is None
+        or processing_profile_id == default_service.service_config.id
+    ):
+        return default_service
+
+    registry = default_service.processing_services_registry
+    fallback_reason: str | None = None
+    candidate: object | None = None
+    if registry is None:
+        fallback_reason = "no processing services registry is available"
+    else:
+        candidate = registry.get(processing_profile_id)
+        if candidate is None:
+            fallback_reason = "the profile is no longer registered"
+        elif getattr(candidate, "kind", None) != "local" or not hasattr(
+            candidate, "tools_provider"
+        ):
+            fallback_reason = "the profile is not a local profile"
+
+    if fallback_reason is not None:
+        logger.warning(
+            "Script created under profile '%s' cannot be resolved (%s); falling "
+            "back to default profile '%s'",
+            processing_profile_id,
+            fallback_reason,
+            default_service.service_config.id,
+        )
+        return default_service
+
+    return cast("ProcessingService", candidate)
+
+
 async def handle_script_execution(
     exec_context: ToolExecutionContext,
     payload: ScriptExecutionPayload,
@@ -1605,8 +1656,12 @@ async def handle_script_execution(
     Task handler for executing scripts triggered by events.
 
     Executes user-defined scripts in response to events from Home Assistant,
-    document indexing, and other sources. Scripts run with restricted tool access
-    based on the event_handler processing profile.
+    document indexing, and other sources. Scripts run under the processing
+    profile that created the automation (see
+    docs/design/automation_provenance.md), so the tools available at execution
+    time match those used to validate the script at creation time. Legacy
+    automations without a recorded profile fall back to the task worker's
+    default profile.
 
     Args:
         exec_context: Execution context providing access to tools and services
@@ -1675,13 +1730,32 @@ async def handle_script_execution(
             f"Starting scheduled script execution in conversation {conversation_id}"
         )
 
-    # Get the event_handler processing service if available
-    processing_service = exec_context.processing_service
+    # Resolve the processing profile the script was created under so that the
+    # tools available here match those used to validate the script at creation
+    # time. Legacy automations (no recorded profile) fall back to the default.
+    processing_service = _resolve_script_execution_service(
+        exec_context, payload.get("processing_profile_id")
+    )
     tools_provider = None
 
     if processing_service and hasattr(processing_service, "tools_provider"):
-        # Use the event_handler profile's tools if available
         tools_provider = processing_service.tools_provider
+        # Re-point the execution context at the resolved profile so tool policy,
+        # visibility grants and note labels all reflect the creating profile.
+        exec_context = replace(
+            exec_context,
+            processing_service=processing_service,
+            processing_profile_id=processing_service.service_config.id,
+            tools_provider=tools_provider,
+            visibility_grants=(
+                set(processing_service.service_config.visibility_grants)
+                if processing_service.service_config.visibility_grants
+                else None
+            ),
+            default_note_visibility_labels=(
+                processing_service.service_config.default_note_visibility_labels
+            ),
+        )
         logger.debug(
             f"Using tools from processing service for script execution: {processing_service.service_config.id}"
         )

--- a/src/family_assistant/tools/automations.py
+++ b/src/family_assistant/tools/automations.py
@@ -364,6 +364,47 @@ def _validate_automation_type(automation_type: str) -> AutomationType:
     return automation_type  # type: ignore[return-value]
 
 
+async def _validate_inline_script_code(
+    exec_context: ToolExecutionContext,
+    script_code: str,
+) -> str | None:
+    """Validate inline automation script code against the creating profile's tools.
+
+    The automation will execute under the profile that created it, so the script
+    is validated against that same profile's tool set (the creator's
+    ``tools_provider``). Returns an error message if validation fails, or None if
+    the script is valid.
+    """
+    tools_provider = None
+    if exec_context.tools_provider:
+        tools_provider = exec_context.tools_provider
+    elif (
+        exec_context.processing_service
+        and exec_context.processing_service.tools_provider
+    ):
+        tools_provider = exec_context.processing_service.tools_provider
+
+    tool_definitions = None
+    if tools_provider:
+        tool_definitions = await tools_provider.get_tool_definitions()
+
+    input_names = [
+        "event",
+        "conversation_id",
+        "listener_id",
+        "listener_name",
+    ]
+    validator = ScriptValidator(tool_definitions=tool_definitions)
+    validation = validator.validate(
+        script_code,
+        input_names=input_names,
+        include_tools_api=tools_provider is not None,
+    )
+    if not validation.is_valid:
+        return f"Script validation failed: {validation.error_message}"
+    return None
+
+
 # Tool Implementations
 async def create_automation_tool(
     exec_context: ToolExecutionContext,
@@ -405,38 +446,13 @@ async def create_automation_tool(
                     text=f"Error: {script_error}", data={"error": script_error}
                 )
             if action_config.get("script_code"):
-                # Validate inline script code
-                tool_definitions = None
-                tools_provider = None
-                if (
-                    hasattr(exec_context, "tools_provider")
-                    and exec_context.tools_provider
-                ):
-                    tools_provider = exec_context.tools_provider
-                elif (
-                    exec_context.processing_service
-                    and hasattr(exec_context.processing_service, "tools_provider")
-                    and exec_context.processing_service.tools_provider
-                ):
-                    tools_provider = exec_context.processing_service.tools_provider
-                if tools_provider:
-                    tool_definitions = await tools_provider.get_tool_definitions()
-                input_names = [
-                    "event",
-                    "conversation_id",
-                    "listener_id",
-                    "listener_name",
-                ]
-                validator = ScriptValidator(tool_definitions=tool_definitions)
-                validation = validator.validate(
-                    action_config["script_code"],
-                    input_names=input_names,
-                    include_tools_api=tools_provider is not None,
+                validation_error = await _validate_inline_script_code(
+                    exec_context, action_config["script_code"]
                 )
-                if not validation.is_valid:
-                    error_msg = f"Script validation failed: {validation.error_message}"
+                if validation_error:
                     return ToolResult(
-                        text=f"Error: {error_msg}", data={"error": error_msg}
+                        text=f"Error: {validation_error}",
+                        data={"error": validation_error},
                     )
             # Note: the "neither script_code nor script_name" case is already
             # rejected by validate_script_action_config above.
@@ -475,6 +491,8 @@ async def create_automation_tool(
                 interface_type=exec_context.interface_type,
                 description=description,
                 condition_script=condition_script,
+                processing_profile_id=exec_context.processing_profile_id,
+                created_by_user_id=exec_context.user_id,
             )
 
             # Return structured data with human-readable text
@@ -504,6 +522,8 @@ async def create_automation_tool(
                 interface_type=exec_context.interface_type,
                 description=description,
                 timezone=exec_context.timezone,
+                processing_profile_id=exec_context.processing_profile_id,
+                created_by_user_id=exec_context.user_id,
             )
 
             # Get the automation to show next scheduled time
@@ -772,6 +792,26 @@ async def update_automation_tool(
             error_msg = f"Automation {automation_id} not found"
             return ToolResult(text=f"Error: {error_msg}", data={"error": error_msg})
 
+        # When the action_config (and therefore the script) is being changed,
+        # validate the new inline script against the updating profile's tools and
+        # re-stamp creator provenance, so the updated script is validated and
+        # executed under the same (updating) profile.
+        restamp_profile_id: str | None = None
+        restamp_user_id: str | None = None
+        if action_config is not None:
+            restamp_profile_id = exec_context.processing_profile_id
+            restamp_user_id = exec_context.user_id
+            script_code = action_config.get("script_code")
+            if script_code:
+                validation_error = await _validate_inline_script_code(
+                    exec_context, script_code
+                )
+                if validation_error:
+                    return ToolResult(
+                        text=f"Error: {validation_error}",
+                        data={"error": validation_error},
+                    )
+
         if automation_type == "event":
             # Update event automation - merge with existing values
             # Note: source_id cannot be changed for event listeners
@@ -810,6 +850,8 @@ async def update_automation_tool(
                 one_time=existing.one_time or False,
                 enabled=existing.enabled,
                 condition_script=condition_script,
+                processing_profile_id=restamp_profile_id,
+                created_by_user_id=restamp_user_id,
             )
 
         else:  # schedule
@@ -829,6 +871,10 @@ async def update_automation_tool(
                 update_kwargs["recurrence_rule"] = recurrence_rule
             if action_config is not None:
                 update_kwargs["action_config"] = action_config
+                if restamp_profile_id is not None:
+                    update_kwargs["processing_profile_id"] = restamp_profile_id
+                if restamp_user_id is not None:
+                    update_kwargs["created_by_user_id"] = restamp_user_id
             if description is not None:
                 update_kwargs["description"] = description
 

--- a/src/family_assistant/tools/automations.py
+++ b/src/family_assistant/tools/automations.py
@@ -364,7 +364,7 @@ def _validate_automation_type(automation_type: str) -> AutomationType:
     return automation_type  # type: ignore[return-value]
 
 
-async def _validate_inline_script_code(
+async def validate_inline_script_code(
     exec_context: ToolExecutionContext,
     script_code: str,
 ) -> str | None:
@@ -446,7 +446,7 @@ async def create_automation_tool(
                     text=f"Error: {script_error}", data={"error": script_error}
                 )
             if action_config.get("script_code"):
-                validation_error = await _validate_inline_script_code(
+                validation_error = await validate_inline_script_code(
                     exec_context, action_config["script_code"]
                 )
                 if validation_error:
@@ -803,7 +803,7 @@ async def update_automation_tool(
             restamp_user_id = exec_context.user_id
             script_code = action_config.get("script_code")
             if script_code:
-                validation_error = await _validate_inline_script_code(
+                validation_error = await validate_inline_script_code(
                     exec_context, script_code
                 )
                 if validation_error:

--- a/src/family_assistant/tools/automations.py
+++ b/src/family_assistant/tools/automations.py
@@ -799,25 +799,35 @@ async def update_automation_tool(
             error_msg = f"Automation {automation_id} not found"
             return ToolResult(text=f"Error: {error_msg}", data={"error": error_msg})
 
-        # When the action_config (and therefore the script) is being changed,
-        # validate the new inline script against the updating profile's tools and
-        # re-stamp creator provenance, so the updated script is validated and
-        # executed under the same (updating) profile.
+        # When a script automation's action_config (and therefore its script) is
+        # being changed, validate the new config and inline script against the
+        # updating profile's tools and re-stamp creator provenance, so the
+        # updated script is validated and executed under the same (updating)
+        # profile. wake_llm action_config edits are not scripts and skip the
+        # script validators.
         restamp_profile_id: str | None = None
         restamp_user_id: str | None = None
         if action_config is not None:
             restamp_profile_id = exec_context.processing_profile_id
             restamp_user_id = exec_context.user_id
-            script_code = action_config.get("script_code")
-            if script_code:
-                validation_error = await validate_inline_script_code(
-                    exec_context, script_code
+            if existing.action_type == "script":
+                script_error = await validate_script_action_config(
+                    exec_context.db_context, action_config
                 )
-                if validation_error:
+                if script_error:
                     return ToolResult(
-                        text=f"Error: {validation_error}",
-                        data={"error": validation_error},
+                        text=f"Error: {script_error}", data={"error": script_error}
                     )
+                script_code = action_config.get("script_code")
+                if script_code:
+                    validation_error = await validate_inline_script_code(
+                        exec_context, script_code
+                    )
+                    if validation_error:
+                        return ToolResult(
+                            text=f"Error: {validation_error}",
+                            data={"error": validation_error},
+                        )
 
         if automation_type == "event":
             # Update event automation - merge with existing values

--- a/src/family_assistant/tools/automations.py
+++ b/src/family_assistant/tools/automations.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from family_assistant.storage.models import Automation
     from family_assistant.storage.repositories.automations import AutomationType
     from family_assistant.storage.types import ActionConfig
+    from family_assistant.tools.infrastructure import ToolsProvider
     from family_assistant.tools.types import ToolExecutionContext
 
 logger = logging.getLogger(__name__)
@@ -364,26 +365,16 @@ def _validate_automation_type(automation_type: str) -> AutomationType:
     return automation_type  # type: ignore[return-value]
 
 
-async def validate_inline_script_code(
-    exec_context: ToolExecutionContext,
+async def validate_inline_script_code_with_provider(
+    tools_provider: ToolsProvider | None,
     script_code: str,
 ) -> str | None:
-    """Validate inline automation script code against the creating profile's tools.
+    """Validate inline automation script code against a profile's tool set.
 
     The automation will execute under the profile that created it, so the script
-    is validated against that same profile's tool set (the creator's
-    ``tools_provider``). Returns an error message if validation fails, or None if
-    the script is valid.
+    is validated against that same profile's ``tools_provider``. Returns an error
+    message if validation fails, or None if the script is valid.
     """
-    tools_provider = None
-    if exec_context.tools_provider:
-        tools_provider = exec_context.tools_provider
-    elif (
-        exec_context.processing_service
-        and exec_context.processing_service.tools_provider
-    ):
-        tools_provider = exec_context.processing_service.tools_provider
-
     tool_definitions = None
     if tools_provider:
         tool_definitions = await tools_provider.get_tool_definitions()
@@ -403,6 +394,22 @@ async def validate_inline_script_code(
     if not validation.is_valid:
         return f"Script validation failed: {validation.error_message}"
     return None
+
+
+async def validate_inline_script_code(
+    exec_context: ToolExecutionContext,
+    script_code: str,
+) -> str | None:
+    """Validate inline automation script code against the creating profile's tools."""
+    tools_provider = None
+    if exec_context.tools_provider:
+        tools_provider = exec_context.tools_provider
+    elif (
+        exec_context.processing_service
+        and exec_context.processing_service.tools_provider
+    ):
+        tools_provider = exec_context.processing_service.tools_provider
+    return await validate_inline_script_code_with_provider(tools_provider, script_code)
 
 
 # Tool Implementations

--- a/src/family_assistant/tools/automations.py
+++ b/src/family_assistant/tools/automations.py
@@ -7,7 +7,10 @@ from datetime import UTC
 from typing import TYPE_CHECKING, Any, cast
 
 from family_assistant.scripting.validator import ScriptValidator
-from family_assistant.tools.stored_scripts import validate_script_action_config
+from family_assistant.tools.stored_scripts import (
+    AUTOMATION_RUNTIME_GLOBALS,
+    validate_script_action_config,
+)
 from family_assistant.tools.types import ToolDefinition, ToolResult
 
 if TYPE_CHECKING:
@@ -365,26 +368,15 @@ def _validate_automation_type(automation_type: str) -> AutomationType:
     return automation_type  # type: ignore[return-value]
 
 
-async def validate_inline_script_code_with_provider(
+async def _validate_script_code_with_provider(
     tools_provider: ToolsProvider | None,
     script_code: str,
+    input_names: list[str],
 ) -> str | None:
-    """Validate inline automation script code against a profile's tool set.
-
-    The automation will execute under the profile that created it, so the script
-    is validated against that same profile's ``tools_provider``. Returns an error
-    message if validation fails, or None if the script is valid.
-    """
     tool_definitions = None
     if tools_provider:
         tool_definitions = await tools_provider.get_tool_definitions()
 
-    input_names = [
-        "event",
-        "conversation_id",
-        "listener_id",
-        "listener_name",
-    ]
     validator = ScriptValidator(tool_definitions=tool_definitions)
     validation = validator.validate(
         script_code,
@@ -396,11 +388,66 @@ async def validate_inline_script_code_with_provider(
     return None
 
 
-async def validate_inline_script_code(
-    exec_context: ToolExecutionContext,
-    script_code: str,
+async def validate_action_scripts_with_provider(
+    db_context: DatabaseContext,
+    tools_provider: ToolsProvider | None,
+    # ast-grep-ignore: no-dict-any - action config has varying keys per action type
+    action_config: dict[str, Any],
 ) -> str | None:
-    """Validate inline automation script code against the creating profile's tools."""
+    """Validate a script action_config's code against a profile's tool set.
+
+    The automation will execute under the profile that created it, so the script
+    is validated against that same profile's ``tools_provider``. Inline
+    ``script_code`` is validated directly with the automation runtime globals.
+    ``script_name`` configs load the referenced stored script and validate its
+    code too: stored scripts are global and were only validated against whatever
+    profile saved them, so the creating profile may lack tools the script uses.
+    Assumes structural validation (``validate_script_action_config``) already
+    passed. Returns an error message, or None if valid.
+    """
+    script_code = action_config.get("script_code")
+    if script_code:
+        return await _validate_script_code_with_provider(
+            tools_provider,
+            script_code,
+            input_names=sorted(AUTOMATION_RUNTIME_GLOBALS),
+        )
+
+    script_name = action_config.get("script_name")
+    if not script_name:
+        return None
+    stored = await db_context.scripts.get_by_name(script_name)
+    if stored is None:
+        return f"Stored script '{script_name}' not found"
+
+    # The script sees the automation runtime globals plus its declared schema
+    # parameters and whatever parameters the automation supplies.
+    input_names: set[str] = set(AUTOMATION_RUNTIME_GLOBALS)
+    schema = stored.parameters_schema or {}
+    if isinstance(schema.get("properties"), dict):
+        input_names.update(k for k in schema["properties"] if isinstance(k, str))
+    if isinstance(schema.get("required"), list):
+        input_names.update(k for k in schema["required"] if isinstance(k, str))
+    parameters = action_config.get("parameters")
+    if isinstance(parameters, dict):
+        input_names.update(k for k in parameters if isinstance(k, str))
+
+    error = await _validate_script_code_with_provider(
+        tools_provider,
+        stored.script_code,
+        input_names=sorted(input_names),
+    )
+    if error:
+        return f"Stored script '{script_name}': {error}"
+    return None
+
+
+async def validate_action_scripts(
+    exec_context: ToolExecutionContext,
+    # ast-grep-ignore: no-dict-any - action config has varying keys per action type
+    action_config: dict[str, Any],
+) -> str | None:
+    """Validate a script action_config against the creating profile's tools."""
     tools_provider = None
     if exec_context.tools_provider:
         tools_provider = exec_context.tools_provider
@@ -409,7 +456,9 @@ async def validate_inline_script_code(
         and exec_context.processing_service.tools_provider
     ):
         tools_provider = exec_context.processing_service.tools_provider
-    return await validate_inline_script_code_with_provider(tools_provider, script_code)
+    return await validate_action_scripts_with_provider(
+        exec_context.db_context, tools_provider, action_config
+    )
 
 
 # Tool Implementations
@@ -452,15 +501,14 @@ async def create_automation_tool(
                 return ToolResult(
                     text=f"Error: {script_error}", data={"error": script_error}
                 )
-            if action_config.get("script_code"):
-                validation_error = await validate_inline_script_code(
-                    exec_context, action_config["script_code"]
+            validation_error = await validate_action_scripts(
+                exec_context, action_config
+            )
+            if validation_error:
+                return ToolResult(
+                    text=f"Error: {validation_error}",
+                    data={"error": validation_error},
                 )
-                if validation_error:
-                    return ToolResult(
-                        text=f"Error: {validation_error}",
-                        data={"error": validation_error},
-                    )
             # Note: the "neither script_code nor script_name" case is already
             # rejected by validate_script_action_config above.
 
@@ -800,7 +848,7 @@ async def update_automation_tool(
             return ToolResult(text=f"Error: {error_msg}", data={"error": error_msg})
 
         # When a script automation's action_config (and therefore its script) is
-        # being changed, validate the new config and inline script against the
+        # being changed, validate the new config and its script against the
         # updating profile's tools and re-stamp creator provenance, so the
         # updated script is validated and executed under the same (updating)
         # profile. wake_llm action_config edits are not scripts and skip the
@@ -818,16 +866,14 @@ async def update_automation_tool(
                     return ToolResult(
                         text=f"Error: {script_error}", data={"error": script_error}
                     )
-                script_code = action_config.get("script_code")
-                if script_code:
-                    validation_error = await validate_inline_script_code(
-                        exec_context, script_code
+                validation_error = await validate_action_scripts(
+                    exec_context, action_config
+                )
+                if validation_error:
+                    return ToolResult(
+                        text=f"Error: {validation_error}",
+                        data={"error": validation_error},
                     )
-                    if validation_error:
-                        return ToolResult(
-                            text=f"Error: {validation_error}",
-                            data={"error": validation_error},
-                        )
 
         if automation_type == "event":
             # Update event automation - merge with existing values

--- a/src/family_assistant/tools/tasks.py
+++ b/src/family_assistant/tools/tasks.py
@@ -17,7 +17,7 @@ from sqlalchemy import select, update
 
 from family_assistant import storage
 from family_assistant.actions import ActionType, execute_action
-from family_assistant.tools.automations import validate_inline_script_code
+from family_assistant.tools.automations import validate_action_scripts
 from family_assistant.tools.stored_scripts import validate_script_action_config
 from family_assistant.utils.clock import SystemClock
 
@@ -714,12 +714,9 @@ async def schedule_action_tool(
         )
         if script_error:
             return f"Error: {script_error}"
-        if action_config.get("script_code"):
-            validation_error = await validate_inline_script_code(
-                exec_context, action_config["script_code"]
-            )
-            if validation_error:
-                return f"Error: {validation_error}"
+        validation_error = await validate_action_scripts(exec_context, action_config)
+        if validation_error:
+            return f"Error: {validation_error}"
 
     # Parse and validate time
     clock = exec_context.clock or SystemClock()

--- a/src/family_assistant/tools/tasks.py
+++ b/src/family_assistant/tools/tasks.py
@@ -17,6 +17,7 @@ from sqlalchemy import select, update
 
 from family_assistant import storage
 from family_assistant.actions import ActionType, execute_action
+from family_assistant.tools.automations import validate_inline_script_code
 from family_assistant.tools.stored_scripts import validate_script_action_config
 from family_assistant.utils.clock import SystemClock
 
@@ -713,6 +714,12 @@ async def schedule_action_tool(
         )
         if script_error:
             return f"Error: {script_error}"
+        if action_config.get("script_code"):
+            validation_error = await validate_inline_script_code(
+                exec_context, action_config["script_code"]
+            )
+            if validation_error:
+                return f"Error: {validation_error}"
 
     # Parse and validate time
     clock = exec_context.clock or SystemClock()
@@ -740,6 +747,8 @@ async def schedule_action_tool(
             user_name=exec_context.user_name,  # Pass user_name
             context={"scheduled_via": "schedule_action tool"},
             scheduled_at=scheduled_dt,
+            processing_profile_id=exec_context.processing_profile_id,
+            created_by_user_id=exec_context.user_id,
         )
 
         return f"OK. {action_type} action scheduled for {schedule_time}"

--- a/src/family_assistant/web/routers/automations_api.py
+++ b/src/family_assistant/web/routers/automations_api.py
@@ -450,6 +450,23 @@ async def update_automation(
     if not existing:
         raise HTTPException(status_code=404, detail="Automation not found")
 
+    # When the action_config (and therefore the script) changes, validate it
+    # against the acting profile's tools before it is persisted and re-stamped,
+    # so an invalid script is rejected at the boundary rather than failing later
+    # at execution time (matches the create path).
+    if request.action_config is not _UNSET and request.action_config is not None:
+        new_action_config = cast("dict[str, Any]", request.action_config)
+        script_error = await validate_script_action_config(db, new_action_config)
+        if script_error:
+            raise HTTPException(status_code=400, detail=script_error)
+        inline_script = new_action_config.get("script_code")
+        if inline_script:
+            validation_error = await validate_inline_script_code_with_provider(
+                processing_service.tools_provider, inline_script
+            )
+            if validation_error:
+                raise HTTPException(status_code=400, detail=validation_error)
+
     # Check name uniqueness if name is being changed
     if (
         request.name is not _UNSET

--- a/src/family_assistant/web/routers/automations_api.py
+++ b/src/family_assistant/web/routers/automations_api.py
@@ -14,6 +14,9 @@ from family_assistant.storage.types import (
     ListenerExecutionStatsDict,
     ScheduleExecutionStatsDict,
 )
+from family_assistant.tools.automations import (
+    validate_inline_script_code_with_provider,
+)
 from family_assistant.tools.stored_scripts import validate_script_action_config
 from family_assistant.web.dependencies import (
     get_current_user,
@@ -269,6 +272,15 @@ async def create_event_automation(
         script_error = await validate_script_action_config(db, request.action_config)
         if script_error:
             raise HTTPException(status_code=400, detail=script_error)
+        # Validate the inline script against the (acting) profile's tools, the
+        # same profile this automation is stamped with and will execute under.
+        inline_script = (request.action_config or {}).get("script_code")
+        if inline_script:
+            validation_error = await validate_inline_script_code_with_provider(
+                processing_service.tools_provider, inline_script
+            )
+            if validation_error:
+                raise HTTPException(status_code=400, detail=validation_error)
 
     # Check name uniqueness
     is_available, error_msg = await db.automations.check_name_available(
@@ -341,6 +353,15 @@ async def create_schedule_automation(
         script_error = await validate_script_action_config(db, request.action_config)
         if script_error:
             raise HTTPException(status_code=400, detail=script_error)
+        # Validate the inline script against the (acting) profile's tools, the
+        # same profile this automation is stamped with and will execute under.
+        inline_script = (request.action_config or {}).get("script_code")
+        if inline_script:
+            validation_error = await validate_inline_script_code_with_provider(
+                processing_service.tools_provider, inline_script
+            )
+            if validation_error:
+                raise HTTPException(status_code=400, detail=validation_error)
 
     # Check name uniqueness
     is_available, error_msg = await db.automations.check_name_available(

--- a/src/family_assistant/web/routers/automations_api.py
+++ b/src/family_assistant/web/routers/automations_api.py
@@ -450,11 +450,17 @@ async def update_automation(
     if not existing:
         raise HTTPException(status_code=404, detail="Automation not found")
 
-    # When the action_config (and therefore the script) changes, validate it
-    # against the acting profile's tools before it is persisted and re-stamped,
-    # so an invalid script is rejected at the boundary rather than failing later
-    # at execution time (matches the create path).
-    if request.action_config is not _UNSET and request.action_config is not None:
+    # When a script automation's action_config (and therefore its script)
+    # changes, validate it against the acting profile's tools before it is
+    # persisted and re-stamped, so an invalid script is rejected at the boundary
+    # rather than failing later at execution time (matches the create path).
+    # wake_llm action_config edits (e.g. {"context": ...}) are not scripts and
+    # must not go through the script validator.
+    if (
+        existing.action_type == "script"
+        and request.action_config is not _UNSET
+        and request.action_config is not None
+    ):
         new_action_config = cast("dict[str, Any]", request.action_config)
         script_error = await validate_script_action_config(db, new_action_config)
         if script_error:

--- a/src/family_assistant/web/routers/automations_api.py
+++ b/src/family_assistant/web/routers/automations_api.py
@@ -15,7 +15,11 @@ from family_assistant.storage.types import (
     ScheduleExecutionStatsDict,
 )
 from family_assistant.tools.stored_scripts import validate_script_action_config
-from family_assistant.web.dependencies import get_db, get_processing_service
+from family_assistant.web.dependencies import (
+    get_current_user,
+    get_db,
+    get_processing_service,
+)
 
 if TYPE_CHECKING:
     from family_assistant.storage.types import ActionConfig
@@ -240,6 +244,8 @@ async def get_automation(
 async def create_event_automation(
     request: CreateEventAutomationRequest,
     db: Annotated[DatabaseContext, Depends(get_db)],
+    processing_service: Annotated[ProcessingService, Depends(get_processing_service)],
+    current_user: Annotated[dict, Depends(get_current_user)],
 ) -> AutomationResponse:
     """Create a new event automation."""
     # Validate source_id
@@ -285,6 +291,8 @@ async def create_event_automation(
             condition_script=request.condition_script,
             one_time=request.one_time,
             enabled=request.enabled,
+            processing_profile_id=processing_service.service_config.id,
+            created_by_user_id=str(current_user["user_identifier"]),
         )
 
         # Fetch the created automation
@@ -317,6 +325,7 @@ async def create_schedule_automation(
     request: CreateScheduleAutomationRequest,
     db: Annotated[DatabaseContext, Depends(get_db)],
     processing_service: Annotated[ProcessingService, Depends(get_processing_service)],
+    current_user: Annotated[dict, Depends(get_current_user)],
 ) -> AutomationResponse:
     """Create a new schedule automation."""
     # Validate action_type
@@ -352,6 +361,8 @@ async def create_schedule_automation(
             description=request.description,
             enabled=request.enabled,
             timezone=processing_service.service_config.timezone,
+            processing_profile_id=processing_service.service_config.id,
+            created_by_user_id=str(current_user["user_identifier"]),
         )
 
         # Fetch the created automation
@@ -387,6 +398,7 @@ async def update_automation(
     request_body: Annotated[dict[str, Any], Body(...)],
     db: Annotated[DatabaseContext, Depends(get_db)],
     processing_service: Annotated[ProcessingService, Depends(get_processing_service)],
+    current_user: Annotated[dict, Depends(get_current_user)],
 ) -> AutomationResponse:
     """Update an existing automation."""
     # Validate automation_type
@@ -484,6 +496,18 @@ async def update_automation(
                     if request.condition_script is not _UNSET
                     else existing.condition_script,
                 ),
+                # Re-stamp creator provenance when the script/action changes so
+                # the updated script executes under the updater's profile.
+                processing_profile_id=(
+                    processing_service.service_config.id
+                    if request.action_config is not _UNSET
+                    else None
+                ),
+                created_by_user_id=(
+                    str(current_user["user_identifier"])
+                    if request.action_config is not _UNSET
+                    else None
+                ),
             )
         else:  # schedule
             # Update schedule automation
@@ -502,6 +526,18 @@ async def update_automation(
                 action_config=request.action_config,
                 enabled=request.enabled,
                 timezone=processing_service.service_config.timezone,
+                # Re-stamp creator provenance when the script/action changes so
+                # the updated script executes under the updater's profile.
+                processing_profile_id=(
+                    processing_service.service_config.id
+                    if request.action_config is not _UNSET
+                    else _UNSET
+                ),
+                created_by_user_id=(
+                    str(current_user["user_identifier"])
+                    if request.action_config is not _UNSET
+                    else _UNSET
+                ),
             )
 
         if not success:

--- a/src/family_assistant/web/routers/automations_api.py
+++ b/src/family_assistant/web/routers/automations_api.py
@@ -15,7 +15,7 @@ from family_assistant.storage.types import (
     ScheduleExecutionStatsDict,
 )
 from family_assistant.tools.automations import (
-    validate_inline_script_code_with_provider,
+    validate_action_scripts_with_provider,
 )
 from family_assistant.tools.stored_scripts import validate_script_action_config
 from family_assistant.web.dependencies import (
@@ -272,15 +272,14 @@ async def create_event_automation(
         script_error = await validate_script_action_config(db, request.action_config)
         if script_error:
             raise HTTPException(status_code=400, detail=script_error)
-        # Validate the inline script against the (acting) profile's tools, the
-        # same profile this automation is stamped with and will execute under.
-        inline_script = (request.action_config or {}).get("script_code")
-        if inline_script:
-            validation_error = await validate_inline_script_code_with_provider(
-                processing_service.tools_provider, inline_script
-            )
-            if validation_error:
-                raise HTTPException(status_code=400, detail=validation_error)
+        # Validate the inline or stored script against the (acting) profile's
+        # tools, the same profile this automation is stamped with and will
+        # execute under.
+        validation_error = await validate_action_scripts_with_provider(
+            db, processing_service.tools_provider, request.action_config or {}
+        )
+        if validation_error:
+            raise HTTPException(status_code=400, detail=validation_error)
 
     # Check name uniqueness
     is_available, error_msg = await db.automations.check_name_available(
@@ -353,15 +352,14 @@ async def create_schedule_automation(
         script_error = await validate_script_action_config(db, request.action_config)
         if script_error:
             raise HTTPException(status_code=400, detail=script_error)
-        # Validate the inline script against the (acting) profile's tools, the
-        # same profile this automation is stamped with and will execute under.
-        inline_script = (request.action_config or {}).get("script_code")
-        if inline_script:
-            validation_error = await validate_inline_script_code_with_provider(
-                processing_service.tools_provider, inline_script
-            )
-            if validation_error:
-                raise HTTPException(status_code=400, detail=validation_error)
+        # Validate the inline or stored script against the (acting) profile's
+        # tools, the same profile this automation is stamped with and will
+        # execute under.
+        validation_error = await validate_action_scripts_with_provider(
+            db, processing_service.tools_provider, request.action_config or {}
+        )
+        if validation_error:
+            raise HTTPException(status_code=400, detail=validation_error)
 
     # Check name uniqueness
     is_available, error_msg = await db.automations.check_name_available(
@@ -465,13 +463,11 @@ async def update_automation(
         script_error = await validate_script_action_config(db, new_action_config)
         if script_error:
             raise HTTPException(status_code=400, detail=script_error)
-        inline_script = new_action_config.get("script_code")
-        if inline_script:
-            validation_error = await validate_inline_script_code_with_provider(
-                processing_service.tools_provider, inline_script
-            )
-            if validation_error:
-                raise HTTPException(status_code=400, detail=validation_error)
+        validation_error = await validate_action_scripts_with_provider(
+            db, processing_service.tools_provider, new_action_config
+        )
+        if validation_error:
+            raise HTTPException(status_code=400, detail=validation_error)
 
     # Check name uniqueness if name is being changed
     if (

--- a/tests/functional/automations/test_automations_crud.py
+++ b/tests/functional/automations/test_automations_crud.py
@@ -225,6 +225,81 @@ async def test_update_automation_revalidates_script(db_engine: AsyncEngine) -> N
 
 
 @pytest.mark.asyncio
+async def test_update_automation_rejects_missing_stored_script(
+    db_engine: AsyncEngine,
+) -> None:
+    """Updating a script automation to reference a nonexistent stored script is
+    rejected at the boundary instead of failing later at execution time."""
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        exec_context = _exec_context_with_profile(
+            db_ctx,
+            conversation_id="stored_script_conv",
+            processing_profile_id="automation_creation",
+            user_id="user-789",
+        )
+        created = await create_automation_tool(
+            exec_context=exec_context,
+            name="Stored Script Update",
+            automation_type="event",
+            trigger_config={"event_source": "home_assistant", "event_filter": {}},
+            action_type="script",
+            action_config={"script_code": "x = 1\n"},
+        )
+        created_data = created.get_data()
+        assert isinstance(created_data, dict)
+        automation_id = int(created_data["id"])
+
+        result = await update_automation_tool(
+            exec_context=exec_context,
+            automation_id=automation_id,
+            automation_type="event",
+            action_config={"script_name": "does-not-exist"},
+        )
+
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "error" in data
+    assert "does-not-exist" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_wake_llm_automation_skips_script_validation(
+    db_engine: AsyncEngine,
+) -> None:
+    """Updating a wake_llm automation's action_config is not routed through the
+    script validator (which would reject it for having no script fields)."""
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        exec_context = _exec_context_with_profile(
+            db_ctx,
+            conversation_id="wake_llm_update_conv",
+            processing_profile_id="automation_creation",
+            user_id="user-789",
+        )
+        created = await create_automation_tool(
+            exec_context=exec_context,
+            name="Wake LLM Update",
+            automation_type="event",
+            trigger_config={"event_source": "home_assistant", "event_filter": {}},
+            action_type="wake_llm",
+            action_config={"context": "Original context"},
+        )
+        created_data = created.get_data()
+        assert isinstance(created_data, dict)
+        automation_id = int(created_data["id"])
+
+        result = await update_automation_tool(
+            exec_context=exec_context,
+            automation_id=automation_id,
+            automation_type="event",
+            action_config={"context": "Updated context"},
+        )
+
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert data.get("success") is True
+
+
+@pytest.mark.asyncio
 async def test_create_automation_cross_type_name_uniqueness(
     db_engine: AsyncEngine,
 ) -> None:

--- a/tests/functional/automations/test_automations_crud.py
+++ b/tests/functional/automations/test_automations_crud.py
@@ -1,11 +1,14 @@
 """CRUD operations for automations (create, list, get, update, delete)."""
 
+from typing import TYPE_CHECKING, cast
 from zoneinfo import ZoneInfo
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from family_assistant.storage.context import DatabaseContext
+from family_assistant.storage.tasks import tasks_table
 from family_assistant.tools.automations import (
     create_automation_tool,
     delete_automation_tool,
@@ -16,6 +19,9 @@ from family_assistant.tools.automations import (
     update_automation_tool,
 )
 from family_assistant.tools.types import ToolExecutionContext
+
+if TYPE_CHECKING:
+    from family_assistant.storage.types import ActionConfig
 
 
 @pytest.mark.asyncio
@@ -1358,3 +1364,47 @@ async def test_update_event_automation_preserves_condition_script(
         == "event.get('old_state') != event.get('new_state')"
     )
     assert result_data["description"] == "Updated description"
+
+
+@pytest.mark.asyncio
+async def test_schedule_provenance_change_rebuilds_pending_task(
+    db_engine: AsyncEngine,
+) -> None:
+    """Re-stamping a schedule automation's provenance (even with an unchanged
+    action_config) rebuilds the pending task so the next run uses the new
+    profile, not the stale one."""
+    action_config = cast("ActionConfig", {"script_code": "x = 1\n"})
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        automation_id = await db_ctx.schedule_automations.create(
+            name="Provenance Resync",
+            recurrence_rule="FREQ=DAILY;BYHOUR=7;BYMINUTE=0",
+            action_type="script",
+            action_config=action_config,
+            conversation_id="resync_conv",
+            timezone=ZoneInfo("UTC"),
+            processing_profile_id="profile_a",
+            created_by_user_id="user-a",
+        )
+
+        # Update with the identical action_config but a new owning profile/user.
+        updated = await db_ctx.schedule_automations.update(
+            automation_id=automation_id,
+            conversation_id="resync_conv",
+            action_config=cast("ActionConfig", dict(action_config)),
+            timezone=ZoneInfo("UTC"),
+            processing_profile_id="profile_b",
+            created_by_user_id="user-b",
+        )
+        assert updated is True
+
+        rows = await db_ctx.fetch_all(
+            select(tasks_table).where(
+                (tasks_table.c.task_type == "script_execution")
+                & (tasks_table.c.status == "pending")
+                & (tasks_table.c.task_id.like(f"sched_auto_{automation_id}_%"))
+            )
+        )
+        assert len(rows) == 1
+        payload = rows[0]["payload"]
+        assert payload["processing_profile_id"] == "profile_b"
+        assert payload["created_by_user_id"] == "user-b"

--- a/tests/functional/automations/test_automations_crud.py
+++ b/tests/functional/automations/test_automations_crud.py
@@ -97,6 +97,127 @@ async def test_create_schedule_automation_basic(db_engine: AsyncEngine) -> None:
     assert "Next run:" in result.get_text()
 
 
+def _exec_context_with_profile(
+    db_ctx: DatabaseContext,
+    *,
+    conversation_id: str,
+    processing_profile_id: str | None,
+    user_id: str | None,
+) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        interface_type="web",
+        conversation_id=conversation_id,
+        user_name="test_user",
+        turn_id="test_turn",
+        db_context=db_ctx,
+        processing_service=None,
+        clock=None,
+        home_assistant_client=None,
+        event_sources=None,
+        attachment_registry=None,
+        camera_backend=None,
+        timezone=ZoneInfo("UTC"),
+        processing_profile_id=processing_profile_id,
+        user_id=user_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_event_automation_records_creator_provenance(
+    db_engine: AsyncEngine,
+) -> None:
+    """Creating an event automation records the creating profile and user."""
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        exec_context = _exec_context_with_profile(
+            db_ctx,
+            conversation_id="prov_event_conv",
+            processing_profile_id="automation_creation",
+            user_id="user-123",
+        )
+        result = await create_automation_tool(
+            exec_context=exec_context,
+            name="Provenance Event",
+            automation_type="event",
+            trigger_config={"event_source": "home_assistant", "event_filter": {}},
+            action_type="script",
+            action_config={"script_code": "x = 1\n"},
+        )
+        created_data = result.get_data()
+        assert isinstance(created_data, dict)
+        listener_id = int(created_data["id"])
+
+        listener = await db_ctx.events.get_event_listener_by_id(listener_id)
+        assert listener is not None
+        assert listener["processing_profile_id"] == "automation_creation"
+        assert listener["created_by_user_id"] == "user-123"
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_automation_records_creator_provenance(
+    db_engine: AsyncEngine,
+) -> None:
+    """Creating a schedule automation records the creating profile and user."""
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        exec_context = _exec_context_with_profile(
+            db_ctx,
+            conversation_id="prov_sched_conv",
+            processing_profile_id="automation_creation",
+            user_id="user-456",
+        )
+        result = await create_automation_tool(
+            exec_context=exec_context,
+            name="Provenance Schedule",
+            automation_type="schedule",
+            trigger_config={"recurrence_rule": "FREQ=DAILY;BYHOUR=7;BYMINUTE=0"},
+            action_type="script",
+            action_config={"script_code": "x = 1\n"},
+        )
+        created_data = result.get_data()
+        assert isinstance(created_data, dict)
+        automation_id = int(created_data["id"])
+
+        automation = await db_ctx.schedule_automations.get_by_id(automation_id)
+        assert automation is not None
+        assert automation["processing_profile_id"] == "automation_creation"
+        assert automation["created_by_user_id"] == "user-456"
+
+
+@pytest.mark.asyncio
+async def test_update_automation_revalidates_script(db_engine: AsyncEngine) -> None:
+    """Updating an automation re-validates the new inline script."""
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        exec_context = _exec_context_with_profile(
+            db_ctx,
+            conversation_id="revalidate_conv",
+            processing_profile_id="automation_creation",
+            user_id="user-789",
+        )
+        created = await create_automation_tool(
+            exec_context=exec_context,
+            name="Revalidate Script",
+            automation_type="event",
+            trigger_config={"event_source": "home_assistant", "event_filter": {}},
+            action_type="script",
+            action_config={"script_code": "x = 1\n"},
+        )
+        created_data = created.get_data()
+        assert isinstance(created_data, dict)
+        automation_id = int(created_data["id"])
+
+        # Updating with a syntactically invalid script is rejected by validation.
+        result = await update_automation_tool(
+            exec_context=exec_context,
+            automation_id=automation_id,
+            automation_type="event",
+            action_config={"script_code": "def broken(:\n"},
+        )
+
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "error" in data
+    assert "validation failed" in data["error"].lower()
+
+
 @pytest.mark.asyncio
 async def test_create_automation_cross_type_name_uniqueness(
     db_engine: AsyncEngine,

--- a/tests/functional/automations/test_automations_execution.py
+++ b/tests/functional/automations/test_automations_execution.py
@@ -16,7 +16,11 @@ from family_assistant.interfaces import ChatInterface
 from family_assistant.processing import ProcessingService, ProcessingServiceConfig
 from family_assistant.scripting.errors import ScriptError
 from family_assistant.storage.context import DatabaseContext, get_db_context
-from family_assistant.task_worker import TaskWorker, handle_script_execution
+from family_assistant.task_worker import (
+    TaskWorker,
+    build_script_confirmation_callback,
+    handle_script_execution,
+)
 from family_assistant.tools import (
     AVAILABLE_FUNCTIONS as local_tool_implementations,
 )
@@ -197,6 +201,78 @@ add_or_update_note(title="Legacy {test_run_id}", content="should not be written"
         notes = await db_ctx.notes.get_all(visibility_grants=None)
         matching = [n for n in notes if f"Legacy {test_run_id}" in n.title]
         assert len(matching) == 0
+
+
+@pytest.mark.asyncio
+async def test_script_confirm_gated_tool_defers_to_durable_confirmation(
+    db_engine: AsyncEngine,
+) -> None:
+    """A confirm-gated tool called from a script creates a durable confirmation
+    addressed to the automation's owner rather than running immediately."""
+    default_service = _make_processing_service(
+        profile_id="event_handler",
+        tools_provider=await _provider_without_note_tool(),
+    )
+    callback = build_script_confirmation_callback("owner-user")
+
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        exec_context = _build_script_exec_context(
+            db_ctx=db_ctx,
+            conversation_id="confirm_conv",
+            processing_service=default_service,
+        )
+        outcome = await callback(
+            interface_type="web",
+            conversation_id="confirm_conv",
+            turn_id="test_turn",
+            tool_name="delete_calendar_event",
+            call_id="call-1",
+            tool_args={"event_id": "evt-123"},
+            timeout_seconds=3600.0,
+            context=exec_context,
+        )
+
+        assert outcome.kind == "completed"
+        assert isinstance(outcome.result, str)
+        assert "hasn't run yet" in outcome.result
+
+        pending = await db_ctx.confirmation_requests.list_pending_for_user("owner-user")
+        assert len(pending) == 1
+        assert pending[0]["tool_name"] == "delete_calendar_event"
+
+
+@pytest.mark.asyncio
+async def test_script_confirm_gated_tool_without_owner_is_not_run(
+    db_engine: AsyncEngine,
+) -> None:
+    """A confirm-gated tool in a legacy automation with no recorded owner cannot
+    be approved, so it is reported as not run and no confirmation is created."""
+    default_service = _make_processing_service(
+        profile_id="event_handler",
+        tools_provider=await _provider_without_note_tool(),
+    )
+    callback = build_script_confirmation_callback(None)
+
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        exec_context = _build_script_exec_context(
+            db_ctx=db_ctx,
+            conversation_id="confirm_legacy_conv",
+            processing_service=default_service,
+        )
+        outcome = await callback(
+            interface_type="web",
+            conversation_id="confirm_legacy_conv",
+            turn_id="test_turn",
+            tool_name="delete_calendar_event",
+            call_id="call-1",
+            tool_args={"event_id": "evt-123"},
+            timeout_seconds=3600.0,
+            context=exec_context,
+        )
+
+    assert outcome.kind == "failed"
+    assert isinstance(outcome.result, str)
+    assert "no recorded owner" in outcome.result
 
 
 @pytest.mark.asyncio

--- a/tests/functional/automations/test_automations_execution.py
+++ b/tests/functional/automations/test_automations_execution.py
@@ -14,6 +14,7 @@ from family_assistant.delegation_security import DelegationSecurityLevel
 from family_assistant.events.processor import EventProcessor
 from family_assistant.interfaces import ChatInterface
 from family_assistant.processing import ProcessingService, ProcessingServiceConfig
+from family_assistant.scripting.errors import ScriptError
 from family_assistant.storage.context import DatabaseContext, get_db_context
 from family_assistant.task_worker import TaskWorker, handle_script_execution
 from family_assistant.tools import (
@@ -32,6 +33,170 @@ from family_assistant.tools.automations import (
 from family_assistant.tools.types import ToolExecutionContext
 from tests.helpers import wait_for_tasks_to_complete
 from tests.mocks.mock_llm import LLMOutput, RuleBasedMockLLMClient
+
+
+def _make_processing_service(
+    *,
+    profile_id: str,
+    tools_provider: CompositeToolsProvider,
+    registry: dict[str, ProcessingService] | None = None,
+) -> ProcessingService:
+    """Build a minimal local ProcessingService for profile-resolution tests."""
+    return ProcessingService(
+        llm_client=RuleBasedMockLLMClient(
+            rules=[], default_response=LLMOutput(content="N/A")
+        ),
+        tools_provider=tools_provider,
+        service_config=ProcessingServiceConfig(
+            id=profile_id,
+            prompts={"system_prompt": profile_id},
+            timezone=ZoneInfo("UTC"),
+            max_history_messages=1,
+            history_max_age_hours=1,
+            tools_config=ToolsConfig(),
+            delegation_security_level=DelegationSecurityLevel.BLOCKED,
+        ),
+        app_config=AppConfig(),
+        context_providers=[],
+        server_url=None,
+        processing_services_registry=registry,
+    )
+
+
+async def _provider_with_note_tool() -> CompositeToolsProvider:
+    provider = CompositeToolsProvider(
+        providers=[
+            LocalToolsProvider(
+                definitions=NOTE_TOOLS_DEFINITION,
+                implementations={
+                    "add_or_update_note": local_tool_implementations[
+                        "add_or_update_note"
+                    ],
+                },
+            )
+        ]
+    )
+    await provider.get_tool_definitions()
+    return provider
+
+
+async def _provider_without_note_tool() -> CompositeToolsProvider:
+    provider = CompositeToolsProvider(
+        providers=[LocalToolsProvider(definitions=[], implementations={})]
+    )
+    await provider.get_tool_definitions()
+    return provider
+
+
+def _build_script_exec_context(
+    *,
+    db_ctx: DatabaseContext,
+    conversation_id: str,
+    processing_service: ProcessingService,
+) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        interface_type="web",
+        conversation_id=conversation_id,
+        user_name="test_user",
+        turn_id="test_turn",
+        db_context=db_ctx,
+        processing_service=processing_service,
+        clock=None,
+        home_assistant_client=None,
+        event_sources=None,
+        attachment_registry=None,
+        camera_backend=None,
+        timezone=ZoneInfo("UTC"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_script_executes_under_creating_profile(db_engine: AsyncEngine) -> None:
+    """A script runs with the tools of the profile that created the automation,
+    not the task worker's default profile."""
+    test_run_id = uuid.uuid4()
+
+    # Creating profile has the note tool; the worker's default profile does not.
+    creator_service = _make_processing_service(
+        profile_id="creator_profile",
+        tools_provider=await _provider_with_note_tool(),
+    )
+    default_service = _make_processing_service(
+        profile_id="event_handler",
+        tools_provider=await _provider_without_note_tool(),
+        registry={"creator_profile": creator_service},
+    )
+
+    script_code = f"""
+add_or_update_note(title="Provenance {test_run_id}", content="written by script")
+"""
+
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        exec_context = _build_script_exec_context(
+            db_ctx=db_ctx,
+            conversation_id=f"prov_{test_run_id}",
+            processing_service=default_service,
+        )
+        await handle_script_execution(
+            exec_context,
+            {
+                "script_code": script_code,
+                "conversation_id": f"prov_{test_run_id}",
+                "processing_profile_id": "creator_profile",
+                "config": {},
+            },
+        )
+
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        notes = await db_ctx.notes.get_all(visibility_grants=None)
+        matching = [n for n in notes if f"Provenance {test_run_id}" in n.title]
+        assert len(matching) == 1
+
+
+@pytest.mark.asyncio
+async def test_script_falls_back_to_default_profile_for_legacy_automation(
+    db_engine: AsyncEngine,
+) -> None:
+    """A legacy automation with no recorded profile falls back to the default
+    profile, whose tools are then enforced (here, the note tool is unavailable)."""
+    test_run_id = uuid.uuid4()
+
+    creator_service = _make_processing_service(
+        profile_id="creator_profile",
+        tools_provider=await _provider_with_note_tool(),
+    )
+    default_service = _make_processing_service(
+        profile_id="event_handler",
+        tools_provider=await _provider_without_note_tool(),
+        registry={"creator_profile": creator_service},
+    )
+
+    script_code = f"""
+add_or_update_note(title="Legacy {test_run_id}", content="should not be written")
+"""
+
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        exec_context = _build_script_exec_context(
+            db_ctx=db_ctx,
+            conversation_id=f"legacy_{test_run_id}",
+            processing_service=default_service,
+        )
+        # No processing_profile_id -> falls back to the default profile, which
+        # does not expose add_or_update_note, so the script raises.
+        with pytest.raises(ScriptError):
+            await handle_script_execution(
+                exec_context,
+                {
+                    "script_code": script_code,
+                    "conversation_id": f"legacy_{test_run_id}",
+                    "config": {},
+                },
+            )
+
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        notes = await db_ctx.notes.get_all(visibility_grants=None)
+        matching = [n for n in notes if f"Legacy {test_run_id}" in n.title]
+        assert len(matching) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/functional/automations/test_automations_execution.py
+++ b/tests/functional/automations/test_automations_execution.py
@@ -274,9 +274,12 @@ async def test_script_confirm_gated_tool_defers_to_durable_confirmation(
         pending = await db_ctx.confirmation_requests.list_pending_for_user("owner-user")
         assert len(pending) == 1
         assert pending[0]["tool_name"] == "delete_calendar_event"
-        # The confirmation records the creating profile so the deferred
-        # execution runs under it rather than the worker's default profile.
+        # The confirmation records the creating profile and origin conversation
+        # so the deferred execution runs under the same profile and acts in the
+        # requesting conversation rather than the worker's placeholder context.
         assert pending[0]["processing_profile_id"] == "creator_profile"
+        assert pending[0]["origin_interface_type"] == "web"
+        assert pending[0]["origin_conversation_id"] == "confirm_conv"
 
 
 @pytest.mark.asyncio

--- a/tests/functional/automations/test_automations_execution.py
+++ b/tests/functional/automations/test_automations_execution.py
@@ -97,6 +97,7 @@ def _build_script_exec_context(
     db_ctx: DatabaseContext,
     conversation_id: str,
     processing_service: ProcessingService,
+    processing_profile_id: str | None = None,
 ) -> ToolExecutionContext:
     return ToolExecutionContext(
         interface_type="web",
@@ -111,6 +112,7 @@ def _build_script_exec_context(
         attachment_registry=None,
         camera_backend=None,
         timezone=ZoneInfo("UTC"),
+        processing_profile_id=processing_profile_id,
     )
 
 
@@ -220,6 +222,7 @@ async def test_script_confirm_gated_tool_defers_to_durable_confirmation(
             db_ctx=db_ctx,
             conversation_id="confirm_conv",
             processing_service=default_service,
+            processing_profile_id="creator_profile",
         )
         outcome = await callback(
             interface_type="web",
@@ -239,6 +242,9 @@ async def test_script_confirm_gated_tool_defers_to_durable_confirmation(
         pending = await db_ctx.confirmation_requests.list_pending_for_user("owner-user")
         assert len(pending) == 1
         assert pending[0]["tool_name"] == "delete_calendar_event"
+        # The confirmation records the creating profile so the deferred
+        # execution runs under it rather than the worker's default profile.
+        assert pending[0]["processing_profile_id"] == "creator_profile"
 
 
 @pytest.mark.asyncio

--- a/tests/functional/automations/test_automations_execution.py
+++ b/tests/functional/automations/test_automations_execution.py
@@ -7,8 +7,10 @@ from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from family_assistant.actions import ActionType, execute_action
 from family_assistant.config_models import AppConfig, ToolsConfig
 from family_assistant.delegation_security import DelegationSecurityLevel
 from family_assistant.events.processor import EventProcessor
@@ -16,6 +18,7 @@ from family_assistant.interfaces import ChatInterface
 from family_assistant.processing import ProcessingService, ProcessingServiceConfig
 from family_assistant.scripting.errors import ScriptError
 from family_assistant.storage.context import DatabaseContext, get_db_context
+from family_assistant.storage.tasks import tasks_table
 from family_assistant.task_worker import (
     TaskWorker,
     build_script_confirmation_callback,
@@ -235,6 +238,105 @@ async def test_script_with_unresolvable_stamped_profile_fails(
                     "config": {},
                 },
             )
+
+
+@pytest.mark.asyncio
+async def test_create_automation_validates_stored_script_against_profile(
+    db_engine: AsyncEngine,
+) -> None:
+    """An automation referencing a stored script that uses tools unavailable to
+    the creating profile is rejected at creation, since the automation will
+    execute under that profile."""
+    limited_service = _make_processing_service(
+        profile_id="limited_profile",
+        tools_provider=await _provider_without_note_tool(),
+    )
+
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        await db_ctx.scripts.save(
+            name="note-writer",
+            description="Writes a note",
+            script_code='add_or_update_note(title="t", content="c")\n',
+        )
+        exec_context = _build_script_exec_context(
+            db_ctx=db_ctx,
+            conversation_id="stored_profile_conv",
+            processing_service=limited_service,
+        )
+        result = await create_automation_tool(
+            exec_context=exec_context,
+            name="Stored Script Profile Check",
+            automation_type="event",
+            trigger_config={"event_source": "home_assistant", "event_filter": {}},
+            action_type="script",
+            action_config={"script_name": "note-writer"},
+        )
+
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "error" in data
+    assert "note-writer" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_automation_accepts_stored_script_matching_profile(
+    db_engine: AsyncEngine,
+) -> None:
+    """The same stored script is accepted when the creating profile has the
+    tools it uses."""
+    capable_service = _make_processing_service(
+        profile_id="capable_profile",
+        tools_provider=await _provider_with_note_tool(),
+    )
+
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        await db_ctx.scripts.save(
+            name="note-writer",
+            description="Writes a note",
+            script_code='add_or_update_note(title="t", content="c")\n',
+        )
+        exec_context = _build_script_exec_context(
+            db_ctx=db_ctx,
+            conversation_id="stored_profile_ok_conv",
+            processing_service=capable_service,
+        )
+        result = await create_automation_tool(
+            exec_context=exec_context,
+            name="Stored Script Profile OK",
+            automation_type="event",
+            trigger_config={"event_source": "home_assistant", "event_filter": {}},
+            action_type="script",
+            action_config={"script_name": "note-writer"},
+        )
+
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "id" in data
+
+
+@pytest.mark.asyncio
+async def test_execute_action_script_payload_includes_interface(
+    db_engine: AsyncEngine,
+) -> None:
+    """Queued script actions carry the interface type, so contexts built from
+    the payload (and any deferred confirmations they create) record the real
+    origin interface instead of the worker's 'unknown_interface' default."""
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        await execute_action(
+            db_ctx=db_ctx,
+            action_type=ActionType.SCRIPT,
+            action_config={"script_code": "x = 1\n"},
+            conversation_id="iface_conv",
+            interface_type="telegram",
+        )
+
+        rows = await db_ctx.fetch_all(
+            select(tasks_table).where(tasks_table.c.task_type == "script_execution")
+        )
+        assert len(rows) == 1
+        payload = rows[0]["payload"]
+        assert payload["interface_type"] == "telegram"
+        assert payload["conversation_id"] == "iface_conv"
 
 
 @pytest.mark.asyncio

--- a/tests/functional/automations/test_automations_execution.py
+++ b/tests/functional/automations/test_automations_execution.py
@@ -206,6 +206,38 @@ add_or_update_note(title="Legacy {test_run_id}", content="should not be written"
 
 
 @pytest.mark.asyncio
+async def test_script_with_unresolvable_stamped_profile_fails(
+    db_engine: AsyncEngine,
+) -> None:
+    """An automation explicitly stamped with a non-default profile that is no
+    longer registered fails rather than silently downgrading to the default
+    profile (which would run with different tools/visibility)."""
+    test_run_id = uuid.uuid4()
+    default_service = _make_processing_service(
+        profile_id="event_handler",
+        tools_provider=await _provider_without_note_tool(),
+        registry={},
+    )
+
+    async with DatabaseContext(engine=db_engine) as db_ctx:
+        exec_context = _build_script_exec_context(
+            db_ctx=db_ctx,
+            conversation_id=f"missing_{test_run_id}",
+            processing_service=default_service,
+        )
+        with pytest.raises(RuntimeError, match="cannot be resolved"):
+            await handle_script_execution(
+                exec_context,
+                {
+                    "script_code": "x = 1\n",
+                    "conversation_id": f"missing_{test_run_id}",
+                    "processing_profile_id": "removed_profile",
+                    "config": {},
+                },
+            )
+
+
+@pytest.mark.asyncio
 async def test_script_confirm_gated_tool_defers_to_durable_confirmation(
     db_engine: AsyncEngine,
 ) -> None:

--- a/tests/functional/web/api/test_automations_crud_api.py
+++ b/tests/functional/web/api/test_automations_crud_api.py
@@ -74,6 +74,27 @@ class TestEventAutomationsAPI:
         assert data["condition_script"] is None
         assert data["match_conditions"] == automation_data["match_conditions"]
 
+    async def test_create_event_automation_rejects_invalid_inline_script(
+        self, api_test_client: AsyncClient
+    ) -> None:
+        """An inline script with a syntax error is rejected at creation, so the
+        validation/execution-profile guarantee holds for the API route too."""
+        automation_data = {
+            "name": "Invalid Inline Script",
+            "source_id": "indexing",
+            "action_type": "script",
+            "match_conditions": {"document_type": "pdf"},
+            "action_config": {"script_code": "def broken(:\n"},
+            "conversation_id": "test_api",
+        }
+
+        response = await api_test_client.post(
+            "/api/automations/event", json=automation_data
+        )
+
+        assert response.status_code == 400
+        assert "validation failed" in response.json()["detail"].lower()
+
     async def test_create_event_automation_records_creator_provenance(
         self, api_test_client: AsyncClient, api_db_context: DatabaseContext
     ) -> None:

--- a/tests/functional/web/api/test_automations_crud_api.py
+++ b/tests/functional/web/api/test_automations_crud_api.py
@@ -292,6 +292,32 @@ class TestEventAutomationsAPI:
         # Verify condition_script was cleared
         assert not cleared_data["condition_script"]
 
+    async def test_update_event_automation_rejects_invalid_inline_script(
+        self, api_test_client: AsyncClient
+    ) -> None:
+        """A PATCH that swaps in an invalid inline script is rejected before it is
+        persisted/re-stamped, just like the create path."""
+        create_response = await api_test_client.post(
+            "/api/automations/event",
+            json={
+                "name": "Update Invalid Script",
+                "source_id": "indexing",
+                "action_type": "script",
+                "match_conditions": {"document_type": "pdf"},
+                "action_config": {"script_code": "x = 1\n"},
+                "conversation_id": "test_api",
+            },
+        )
+        assert create_response.status_code == 200
+        automation_id = create_response.json()["id"]
+
+        update_response = await api_test_client.patch(
+            f"/api/automations/event/{automation_id}?conversation_id=test_api",
+            json={"action_config": {"script_code": "def broken(:\n"}},
+        )
+        assert update_response.status_code == 400
+        assert "validation failed" in update_response.json()["detail"].lower()
+
     async def test_delete_event_automation(self, api_test_client: AsyncClient) -> None:
         """Test deleting an event automation."""
         # Create an event automation

--- a/tests/functional/web/api/test_automations_crud_api.py
+++ b/tests/functional/web/api/test_automations_crud_api.py
@@ -318,6 +318,33 @@ class TestEventAutomationsAPI:
         assert update_response.status_code == 400
         assert "validation failed" in update_response.json()["detail"].lower()
 
+    async def test_update_wake_llm_action_config_is_not_script_validated(
+        self, api_test_client: AsyncClient
+    ) -> None:
+        """A PATCH that edits a wake_llm automation's context must not be routed
+        through the script validator (which would reject it for having no
+        script_code/script_name)."""
+        create_response = await api_test_client.post(
+            "/api/automations/event",
+            json={
+                "name": "Wake LLM Context Edit",
+                "source_id": "indexing",
+                "action_type": "wake_llm",
+                "match_conditions": {"document_type": "pdf"},
+                "action_config": {"context": "Original context"},
+                "conversation_id": "test_api",
+            },
+        )
+        assert create_response.status_code == 200
+        automation_id = create_response.json()["id"]
+
+        update_response = await api_test_client.patch(
+            f"/api/automations/event/{automation_id}?conversation_id=test_api",
+            json={"action_config": {"context": "Updated context"}},
+        )
+        assert update_response.status_code == 200
+        assert update_response.json()["action_config"] == {"context": "Updated context"}
+
     async def test_delete_event_automation(self, api_test_client: AsyncClient) -> None:
         """Test deleting an event automation."""
         # Create an event automation

--- a/tests/functional/web/api/test_automations_crud_api.py
+++ b/tests/functional/web/api/test_automations_crud_api.py
@@ -74,6 +74,31 @@ class TestEventAutomationsAPI:
         assert data["condition_script"] is None
         assert data["match_conditions"] == automation_data["match_conditions"]
 
+    async def test_create_event_automation_records_creator_provenance(
+        self, api_test_client: AsyncClient, api_db_context: DatabaseContext
+    ) -> None:
+        """Web-created automations record the acting profile and user, so their
+        scripts execute under the same authority."""
+        automation_data = {
+            "name": "Provenance Web Event",
+            "source_id": "indexing",
+            "action_type": "script",
+            "match_conditions": {"document_type": "pdf"},
+            "action_config": {"script_code": "print('processed')"},
+            "conversation_id": "test_api",
+        }
+
+        response = await api_test_client.post(
+            "/api/automations/event", json=automation_data
+        )
+
+        assert response.status_code == 200
+        listener_id = int(response.json()["id"])
+        listener = await api_db_context.events.get_event_listener_by_id(listener_id)
+        assert listener is not None
+        assert listener["processing_profile_id"] is not None
+        assert listener["created_by_user_id"] == "test_user"
+
     async def test_create_event_automation_validates_source_id(
         self, api_test_client: AsyncClient
     ) -> None:


### PR DESCRIPTION
Scripts in automations were validated against the creating profile's tool
set but executed under the task worker's default profile, so a script could
pass validation and then fail (or behave differently) at runtime because the
available tools differed.

Capture the creating profile and user on event_listeners and
schedule_automations, thread them through the script_execution task payload,
and resolve the profile at execution time in handle_script_execution (mirroring
the reminder-profile switch in handle_llm_callback). Validation already uses
the creating profile's tools provider, so the two now agree by construction.
update_automation re-validates changed inline scripts and re-stamps provenance
with the updating profile. Legacy automations with no recorded profile fall
back to the default profile with a warning.

wake_llm actions are unchanged and continue to run under the restricted
event_handler profile.

https://claude.ai/code/session_01LopXHha4SQnS6nEi2LUAkg