### PR TITLE
Fix inline code rendering in Chat UI

### DIFF
--- a/frontend/src/chat/MarkdownText.jsx
+++ b/frontend/src/chat/MarkdownText.jsx
@@ -32,7 +32,7 @@ export const MarkdownText = ({ text }) => {
               </pre>
             );
           },
-          code: ({ inline, className, children }) => {
+          code: ({ className, children }) => {
             const isInsidePre = useContext(PreContext);
 
             // In react-markdown v10, the `inline` prop is no longer provided.

--- a/frontend/src/chat/MarkdownText.jsx
+++ b/frontend/src/chat/MarkdownText.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { createContext, useContext } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeSanitize from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
+
+const PreContext = createContext(false);
 
 // Secure markdown renderer for chat messages
 export const MarkdownText = ({ text }) => {
@@ -21,14 +23,26 @@ export const MarkdownText = ({ text }) => {
               {children}
             </a>
           ),
-          code: ({ inline, className, children }) => {
-            if (inline) {
-              return <code className="inline-code">{children}</code>;
-            }
+          pre: ({ children }) => {
             return (
               <pre className="code-block">
-                <code className={className}>{children}</code>
+                <PreContext.Provider value={true}>
+                  {children}
+                </PreContext.Provider>
               </pre>
+            );
+          },
+          code: ({ inline, className, children }) => {
+            const isInsidePre = useContext(PreContext);
+
+            // In react-markdown v10, the `inline` prop is no longer provided.
+            // We use PreContext to determine if we're inside a <pre> block.
+            if (!isInsidePre) {
+              return <code className="inline-code">{children}</code>;
+            }
+
+            return (
+              <code className={className}>{children}</code>
             );
           },
         }}

--- a/frontend/src/chat/__tests__/MarkdownText.test.jsx
+++ b/frontend/src/chat/__tests__/MarkdownText.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MarkdownText } from '../MarkdownText';
+
+describe('MarkdownText', () => {
+  it('renders inline code correctly', () => {
+    const text = 'The `Foo` service';
+    const { container } = render(<MarkdownText text={text} />);
+
+    // Check if it contains the code element
+    const codeElement = container.querySelector('code');
+    expect(codeElement).toBeTruthy();
+    expect(codeElement?.textContent).toBe('Foo');
+
+    // Check if it has the inline-code class
+    expect(codeElement?.classList.contains('inline-code')).toBe(true);
+
+    // Ensure it's not wrapped in a pre (which would make it a block)
+    expect(container.querySelector('pre')).toBeNull();
+  });
+
+  it('renders code blocks correctly', () => {
+    const text = '```\nconst x = 1;\n```';
+    const { container } = render(<MarkdownText text={text} />);
+
+    // Check if it contains the pre and code element
+    const preElement = container.querySelector('pre');
+    expect(preElement).toBeTruthy();
+    expect(preElement?.classList.contains('code-block')).toBe(true);
+
+    const codeElement = preElement?.querySelector('code');
+    expect(codeElement).toBeTruthy();
+    expect(codeElement?.textContent?.trim()).toBe('const x = 1;');
+  });
+});

--- a/frontend/src/chat/__tests__/MarkdownText.test.jsx
+++ b/frontend/src/chat/__tests__/MarkdownText.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { MarkdownText } from '../MarkdownText';
 

--- a/frontend/vite.log
+++ b/frontend/vite.log
@@ -3,14 +3,8 @@
 > vite --host 0.0.0.0
 
 
-  VITE v7.1.4  ready in 274 ms
+  VITE v7.1.4  ready in 503 ms
 
   ➜  Local:   http://localhost:5173/
   ➜  Network: http://192.168.0.2:5173/
 [baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`
-Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
-  npx update-browserslist-db@latest
-  Why you should do it regularly: https://github.com/browserslist/update-db#readme
-6:40:22 AM [vite] (client) hmr update /src/pages/LandingPage.tsx, /src/styles/globals.css
-6:40:25 AM [vite] (client) hmr update /src/styles/globals.css
-6:40:25 AM [vite] (client) hmr update /src/styles/globals.css

--- a/frontend/vite.log
+++ b/frontend/vite.log
@@ -3,8 +3,14 @@
 > vite --host 0.0.0.0
 
 
-  VITE v7.1.4  ready in 503 ms
+  VITE v7.1.4  ready in 274 ms
 
   ➜  Local:   http://localhost:5173/
   ➜  Network: http://192.168.0.2:5173/
 [baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data, please update: `npm i baseline-browser-mapping@latest -D`
+Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
+  npx update-browserslist-db@latest
+  Why you should do it regularly: https://github.com/browserslist/update-db#readme
+6:40:22 AM [vite] (client) hmr update /src/pages/LandingPage.tsx, /src/styles/globals.css
+6:40:25 AM [vite] (client) hmr update /src/styles/globals.css
+6:40:25 AM [vite] (client) hmr update /src/styles/globals.css


### PR DESCRIPTION
This PR fixes an issue where backtick-delimited code spans (inline code) were being rendered as block elements in the chat UI.

The root cause was the upgrade to `react-markdown` v10 (or v9+), which removed the `inline` prop from the `code` component. The previous implementation relied on this prop to decide whether to wrap the code in a `<pre>` block.

The fix introduces a `PreContext` that is provided by a custom `pre` component. Any nested `code` component can then check this context to determine if it should render as an inline span or as part of a code block.

Key changes:
- Introduced `PreContext` in `frontend/src/chat/MarkdownText.jsx`.
- Added a custom `pre` component to `ReactMarkdown` that wraps its children in a `PreContext.Provider`.
- Updated the `code` component to use `useContext(PreContext)` instead of the missing `inline` prop.
- Added `frontend/src/chat/__tests__/MarkdownText.test.jsx` to verify the fix and prevent regressions.
- Verified the fix visually using Playwright and ran the full frontend test suite (all 311 tests passed).

---
*PR created automatically by Jules for task [2825192151089655562](https://jules.google.com/task/2825192151089655562) started by @werdnum*