### PR TITLE
[codex] Fix OTEL env auto-configuration

### DIFF
--- a/src/family_assistant/__init__.py
+++ b/src/family_assistant/__init__.py
@@ -3,11 +3,26 @@
 import logging.config
 import os
 
+from .otel_env import neutralize_otel_env
+
 # Configure logging as early as possible
 LOGGING_CONFIG = os.getenv("LOGGING_CONFIG", "logging.conf")
 if os.path.exists(LOGGING_CONFIG):
     logging.config.fileConfig(LOGGING_CONFIG, disable_existing_loggers=False)
 
-__version__ = "0.1.0"
+# Prevent the OTEL SDK from auto-configuring providers before our
+# setup_observability() runs.  This must happen before any submodule
+# import that calls trace.get_tracer() / metrics.get_meter() at module
+# level, because the OTEL API's get_*_provider() auto-discovers SDK
+# providers via entry points when OTEL_PYTHON_*_PROVIDER env vars are
+# set (e.g. by the Kubernetes OpenTelemetry Operator).  Without this,
+# the auto-discovered provider claims a Once guard that makes our
+# subsequent set_*_provider() call a silent no-op.
+#
+# App-owned OTEL env vars (OTEL_TRACES_EXPORTER, OTEL_METRICS_EXPORTER, ...)
+# are also cleared because opentelemetry-instrument / distros read them
+# to auto-configure exporters. Values are moved to _FA_OTEL_* so our
+# config_loader (which runs later via load_config()) can still read them.
+neutralize_otel_env()
 
-# You can optionally define __version__ here or import key components
+__version__ = "0.1.0"

--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -29,6 +29,7 @@ from pydantic import ValidationError
 
 from .config_models import AppConfig
 from .config_sources import deep_merge_dicts, load_yaml_file
+from .otel_env import neutralize_otel_env
 
 logger = logging.getLogger(__name__)
 
@@ -150,17 +151,24 @@ ENV_VAR_MAPPINGS: list[EnvVarMapping] = [
     EnvVarMapping(
         "BROWSER_HANDOFF_TIMEOUT", "browser_handoff_config.timeout_seconds", float
     ),
-    # OpenTelemetry
-    EnvVarMapping("OTEL_ENABLED", "otel.enabled", bool),
-    EnvVarMapping("OTEL_SERVICE_NAME", "otel.service_name"),
-    EnvVarMapping("OTEL_TRACES_EXPORTER", "otel.traces_exporter"),
-    EnvVarMapping("OTEL_METRICS_EXPORTER", "otel.metrics_exporter"),
-    EnvVarMapping("OTEL_EXPORTER_OTLP_ENDPOINT", "otel.otlp_endpoint"),
-    EnvVarMapping("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "otel.otlp_traces_endpoint"),
-    EnvVarMapping("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "otel.otlp_metrics_endpoint"),
-    EnvVarMapping("OTEL_LOG_CORRELATION", "otel.log_correlation", bool),
-    EnvVarMapping("OTEL_TRACES_SAMPLE_RATE", "otel.traces_sample_rate", float),
-    EnvVarMapping("OTEL_DEBUG_CONSOLE_EXPORTER", "otel.debug_console_exporter", bool),
+    # OpenTelemetry env vars are renamed to _FA_OTEL_* at startup
+    # (in __init__.py) to prevent the OTEL SDK from auto-configuring.
+    EnvVarMapping("_FA_OTEL_ENABLED", "otel.enabled", bool),
+    EnvVarMapping("_FA_OTEL_SERVICE_NAME", "otel.service_name"),
+    EnvVarMapping("_FA_OTEL_TRACES_EXPORTER", "otel.traces_exporter"),
+    EnvVarMapping("_FA_OTEL_METRICS_EXPORTER", "otel.metrics_exporter"),
+    EnvVarMapping("_FA_OTEL_EXPORTER_OTLP_ENDPOINT", "otel.otlp_endpoint"),
+    EnvVarMapping(
+        "_FA_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "otel.otlp_traces_endpoint"
+    ),
+    EnvVarMapping(
+        "_FA_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "otel.otlp_metrics_endpoint"
+    ),
+    EnvVarMapping("_FA_OTEL_LOG_CORRELATION", "otel.log_correlation", bool),
+    EnvVarMapping("_FA_OTEL_TRACES_SAMPLE_RATE", "otel.traces_sample_rate", float),
+    EnvVarMapping(
+        "_FA_OTEL_DEBUG_CONSOLE_EXPORTER", "otel.debug_console_exporter", bool
+    ),
 ]
 
 USER_IDENTITIES_FILE_ENV_VAR = "USER_IDENTITIES_FILE"
@@ -1029,6 +1037,7 @@ def load_config(
 
     if load_dotenv_file:
         load_dotenv()
+        neutralize_otel_env()
 
     apply_env_var_overrides(config_data)
     apply_user_identity_file(config_data)

--- a/src/family_assistant/otel_env.py
+++ b/src/family_assistant/otel_env.py
@@ -1,0 +1,35 @@
+"""Helpers for keeping app-managed OTel config out of SDK auto-config."""
+
+from __future__ import annotations
+
+import os
+
+APP_OTEL_ENV_VARS = frozenset(
+    {
+        "OTEL_ENABLED",
+        "OTEL_SERVICE_NAME",
+        "OTEL_TRACES_EXPORTER",
+        "OTEL_METRICS_EXPORTER",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        "OTEL_LOG_CORRELATION",
+        "OTEL_TRACES_SAMPLE_RATE",
+        "OTEL_DEBUG_CONSOLE_EXPORTER",
+    }
+)
+
+
+def neutralize_otel_env() -> None:
+    """Move app-owned OTel vars away from SDK auto-configuration."""
+    for key in list(os.environ):
+        if key.startswith("OTEL_PYTHON_"):
+            os.environ.pop(key)
+
+    for key in APP_OTEL_ENV_VARS:
+        if key not in os.environ:
+            continue
+        private_key = f"_FA_{key}"
+        if private_key not in os.environ:
+            os.environ[private_key] = os.environ[key]
+        os.environ.pop(key)

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -13,6 +13,8 @@ These tests verify the configuration loading hierarchy:
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 from typing import TYPE_CHECKING, Any
 from unittest import mock
 
@@ -40,6 +42,7 @@ from family_assistant.config_sources import (
     load_yaml_file,
 )
 from family_assistant.delegation_security import DelegationSecurityLevel
+from family_assistant.otel_env import neutralize_otel_env
 from family_assistant.tools.metadata import ToolDescriptor
 from family_assistant.tools.policy import PolicyEngine, ToolPolicyDecision
 
@@ -545,17 +548,70 @@ class TestApplyEnvVarOverrides:
         assert config["model"] == "original-model"
 
     def test_applies_otel_enabled_env_var(self) -> None:
-        """Test applying OTEL_ENABLED boolean env var."""
+        """Test applying the internally renamed OTEL_ENABLED boolean env var."""
         config: dict[str, Any] = {"otel": {}}
-        with mock.patch.dict(os.environ, {"OTEL_ENABLED": "true"}, clear=False):
+        with mock.patch.dict(os.environ, {"_FA_OTEL_ENABLED": "true"}, clear=False):
             apply_env_var_overrides(config)
         assert config["otel"]["enabled"] is True
 
-    def test_applies_otel_sample_rate_env_var(self) -> None:
-        """Test applying OTEL_TRACES_SAMPLE_RATE float env var."""
+    def test_package_import_renames_public_otel_env_vars(self) -> None:
+        """Import-time rewrite keeps OTel env vars away from SDK auto-config."""
+        code = (
+            "import os; import family_assistant; "
+            "print(os.environ.get('OTEL_METRICS_EXPORTER')); "
+            "print(os.environ.get('_FA_OTEL_METRICS_EXPORTER')); "
+            "print(os.environ.get('OTEL_PYTHON_METER_PROVIDER')); "
+            "print(os.environ.get('OTEL_EXPORTER_OTLP_HEADERS'))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            check=True,
+            env={
+                **os.environ,
+                "OTEL_METRICS_EXPORTER": "none",
+                "OTEL_PYTHON_METER_PROVIDER": "opentelemetry.sdk.metrics.MeterProvider",
+                "OTEL_EXPORTER_OTLP_HEADERS": "authorization=Bearer token",
+            },
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.splitlines() == [
+            "None",
+            "none",
+            "None",
+            "authorization=Bearer token",
+        ]
+
+    def test_dotenv_loaded_public_otel_env_vars_are_renamed(self) -> None:
+        """OTEL values loaded after package import are still applied to config."""
+        config: dict[str, Any] = {"otel": {}}
+        with mock.patch.dict(os.environ, {"OTEL_METRICS_EXPORTER": "none"}):
+            neutralize_otel_env()
+            apply_env_var_overrides(config)
+        assert "OTEL_METRICS_EXPORTER" not in os.environ
+        assert config["otel"]["metrics_exporter"] == "none"
+
+    def test_existing_internal_otel_env_var_wins_over_later_public_value(
+        self,
+    ) -> None:
+        """Real env overrides keep priority over later .env values."""
         config: dict[str, Any] = {"otel": {}}
         with mock.patch.dict(
-            os.environ, {"OTEL_TRACES_SAMPLE_RATE": "0.25"}, clear=False
+            os.environ,
+            {
+                "_FA_OTEL_METRICS_EXPORTER": "none",
+                "OTEL_METRICS_EXPORTER": "otlp-http",
+            },
+        ):
+            neutralize_otel_env()
+            apply_env_var_overrides(config)
+        assert config["otel"]["metrics_exporter"] == "none"
+
+    def test_applies_otel_sample_rate_env_var(self) -> None:
+        """Test applying _FA_OTEL_TRACES_SAMPLE_RATE float env var."""
+        config: dict[str, Any] = {"otel": {}}
+        with mock.patch.dict(
+            os.environ, {"_FA_OTEL_TRACES_SAMPLE_RATE": "0.25"}, clear=False
         ):
             apply_env_var_overrides(config)
         assert config["otel"]["traces_sample_rate"] == 0.25


### PR DESCRIPTION
## Summary
- Move public `OTEL_*` environment variables to internal `_FA_OTEL_*` names at package import time.
- Drop `OTEL_PYTHON_*` provider variables before the OpenTelemetry SDK can auto-configure global providers.
- Update config loading/tests to read the internal `_FA_OTEL_*` names.

## Why
The deployed pod is configured with `OTEL_METRICS_EXPORTER=none`, but it is still creating an OTLP HTTP metric exporter and logging repeated `404 page not found` failures. The likely failure mode is OTel auto-configuration claiming the global provider before `setup_observability()` can install the app's configured no-op meter provider.

## Validation
- `git diff --check --cached`
- `PYTHONPATH=src /home/gemini/work/family-assistant/.venv/bin/python -m py_compile src/family_assistant/__init__.py src/family_assistant/config_loader.py tests/unit/test_config_loader.py`
- Direct smoke check confirmed public `OTEL_METRICS_EXPORTER` is removed, `_FA_OTEL_METRICS_EXPORTER=none` is preserved, `OTEL_PYTHON_METER_PROVIDER` is removed, and config resolves `metrics_exporter: none`.

Full pytest is left to CI because the k8s-agent workspace PVC is full; local dev dependency setup hit `No space left on device`.