### PR TITLE
[codex] Fix delegated profile rows in web chat

### DIFF
--- a/src/family_assistant/storage/repositories/message_history.py
+++ b/src/family_assistant/storage/repositories/message_history.py
@@ -1549,6 +1549,7 @@ class MessageHistoryRepository(BaseRepository):
         before: datetime | None = None,
         after: datetime | None = None,
         limit: int = 50,
+        include_subconversations: bool = True,
     ) -> tuple[list[MessageHistoryRow], bool, bool]:
         """
         Get messages for a conversation with timestamp-based pagination.
@@ -1558,30 +1559,34 @@ class MessageHistoryRepository(BaseRepository):
             before: Get messages before this timestamp (for loading earlier)
             after: Get messages after this timestamp (for loading newer)
             limit: Maximum number of messages to return
+            include_subconversations: Include delegated subconversation rows
 
         Returns:
             Tuple of (messages, has_more_before, has_more_after)
         """
         conditions = [message_history_table.c.conversation_id == conversation_id]
+        if not include_subconversations:
+            conditions.append(message_history_table.c.subconversation_id.is_(None))
 
         # Add timestamp conditions
         if before:
             conditions.append(message_history_table.c.timestamp < before)
-            order = message_history_table.c.timestamp.desc()
+            timestamp_order = message_history_table.c.timestamp.desc()
+            internal_id_order = message_history_table.c.internal_id.desc()
         elif after:
             conditions.append(message_history_table.c.timestamp > after)
-            order = message_history_table.c.timestamp.asc()
+            timestamp_order = message_history_table.c.timestamp.asc()
+            internal_id_order = message_history_table.c.internal_id.asc()
         else:
             # Default: most recent messages
-            order = message_history_table.c.timestamp.desc()
+            timestamp_order = message_history_table.c.timestamp.desc()
+            internal_id_order = message_history_table.c.internal_id.desc()
 
         # Fetch one extra message to determine if there are more
         stmt = (
             select(message_history_table)
             .where(*conditions)
-            .order_by(
-                order, message_history_table.c.internal_id
-            )  # Add internal_id for stable sort
+            .order_by(timestamp_order, internal_id_order)
             .limit(limit + 1)
         )
 
@@ -1605,12 +1610,17 @@ class MessageHistoryRepository(BaseRepository):
             has_more_after = len(messages) > 0
         elif after:
             # Check if there are actually messages before the 'after' timestamp
+            before_conditions = [
+                message_history_table.c.conversation_id == conversation_id,
+                message_history_table.c.timestamp < after,
+            ]
+            if not include_subconversations:
+                before_conditions.append(
+                    message_history_table.c.subconversation_id.is_(None)
+                )
             check_before_stmt = (
                 select(message_history_table.c.internal_id)
-                .where(
-                    message_history_table.c.conversation_id == conversation_id,
-                    message_history_table.c.timestamp < after,
-                )
+                .where(*before_conditions)
                 .limit(1)
             )
             before_rows = await self._db.fetch_all(check_before_stmt)
@@ -1623,19 +1633,26 @@ class MessageHistoryRepository(BaseRepository):
 
         return messages, has_more_before, has_more_after
 
-    async def get_conversation_message_count(self, conversation_id: str) -> int:
+    async def get_conversation_message_count(
+        self, conversation_id: str, include_subconversations: bool = True
+    ) -> int:
         """
         Get the total number of messages in a conversation.
 
         Args:
             conversation_id: The conversation identifier
+            include_subconversations: Include delegated subconversation rows
 
         Returns:
             Total number of messages in the conversation
         """
+        conditions = [message_history_table.c.conversation_id == conversation_id]
+        if not include_subconversations:
+            conditions.append(message_history_table.c.subconversation_id.is_(None))
+
         stmt = select(
             func.count(message_history_table.c.internal_id).label("count")
-        ).where(message_history_table.c.conversation_id == conversation_id)
+        ).where(*conditions)
 
         row = await self._db.fetch_one(stmt)
         return row["count"] if row else 0
@@ -2024,6 +2041,7 @@ class MessageHistoryRepository(BaseRepository):
         conversation_id: str | None = None,
         date_from: datetime | None = None,
         date_to: datetime | None = None,
+        include_subconversations: bool = True,
     ) -> dict[tuple[str, str], list[MessageHistoryRow]]:
         """
         Retrieves all message history, grouped by (interface_type, conversation_id) and ordered by timestamp.
@@ -2033,6 +2051,7 @@ class MessageHistoryRepository(BaseRepository):
             conversation_id: Filter by conversation ID
             date_from: Filter messages after this date (inclusive)
             date_to: Filter messages before this date (inclusive)
+            include_subconversations: Include delegated subconversation rows
 
         Returns:
             Dictionary mapping (interface_type, conversation_id) tuples to lists of messages
@@ -2049,6 +2068,8 @@ class MessageHistoryRepository(BaseRepository):
             conditions.append(message_history_table.c.timestamp >= date_from)
         if date_to:
             conditions.append(message_history_table.c.timestamp <= date_to)
+        if not include_subconversations:
+            conditions.append(message_history_table.c.subconversation_id.is_(None))
 
         stmt = select(message_history_table)
         if conditions:
@@ -2083,6 +2104,7 @@ class MessageHistoryRepository(BaseRepository):
         conversation_id: str | None = None,
         date_from: datetime | None = None,
         date_to: datetime | None = None,
+        include_subconversations: bool = True,
     ) -> tuple[list[ConversationSummaryRow], int]:
         """
         Get conversation summaries with pagination, optimized for performance.
@@ -2094,6 +2116,7 @@ class MessageHistoryRepository(BaseRepository):
             conversation_id: Filter by specific conversation ID
             date_from: Filter conversations with messages after this date
             date_to: Filter conversations with messages before this date
+            include_subconversations: Include delegated subconversation rows
 
         Returns:
             Tuple of (summaries list, total count)
@@ -2118,6 +2141,9 @@ class MessageHistoryRepository(BaseRepository):
 
         if date_to:
             base_conditions.append(message_history_table.c.timestamp <= date_to)
+
+        if not include_subconversations:
+            base_conditions.append(message_history_table.c.subconversation_id.is_(None))
 
         # Subquery to get the latest message id and count per conversation
         # We get the max internal_id within the max timestamp to handle timestamp collisions
@@ -2171,6 +2197,11 @@ class MessageHistoryRepository(BaseRepository):
 
         if date_to:
             count_conditions.append(message_history_table.c.timestamp <= date_to)
+
+        if not include_subconversations:
+            count_conditions.append(
+                message_history_table.c.subconversation_id.is_(None)
+            )
 
         msg_count_subq = (
             select(

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -1557,6 +1557,7 @@ async def get_conversations(
         conversation_id=conversation_id,
         date_from=date_from_dt,
         date_to=date_to_dt,
+        include_subconversations=False,
     )
 
     # Filter the returned page to conversations the caller solely (canonically)
@@ -1640,7 +1641,9 @@ async def get_conversation_messages(
     if actual_limit is None:
         # Legacy behavior: get all messages
         history_by_chat = await db_context.message_history.get_all_grouped(
-            interface_type=None, conversation_id=conversation_id
+            interface_type=None,
+            conversation_id=conversation_id,
+            include_subconversations=False,
         )
 
         # Collect messages from all interfaces for this conversation ID
@@ -1667,6 +1670,7 @@ async def get_conversation_messages(
             before=before_dt,
             after=after_dt,
             limit=actual_limit,
+            include_subconversations=False,
         )
 
     # Convert to response format
@@ -1720,7 +1724,10 @@ async def get_conversation_messages(
 
     # Get total message count for the conversation
     total_message_count = (
-        await db_context.message_history.get_conversation_message_count(conversation_id)
+        await db_context.message_history.get_conversation_message_count(
+            conversation_id,
+            include_subconversations=False,
+        )
     )
 
     hub = _get_hub(request)

--- a/tests/functional/web/ui/test_conversation_messages.py
+++ b/tests/functional/web/ui/test_conversation_messages.py
@@ -5,8 +5,11 @@ from datetime import UTC, datetime
 
 import httpx
 import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from family_assistant.assistant import Assistant
+from family_assistant.llm.messages import AssistantMessage, UserMessage
+from family_assistant.storage.context import get_db_context
 from tests.helpers import wait_for_condition
 from tests.mocks.mock_llm import LLMOutput, RuleBasedMockLLMClient
 
@@ -101,6 +104,75 @@ async def test_get_conversation_messages_with_data(
         assert len(assistant_msgs) >= 1
         assert any("Hi there" in m["content"] for m in user_msgs)
         assert any("Hello! How can I help?" in m["content"] for m in assistant_msgs)
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_messages_excludes_delegated_subconversations(
+    web_only_assistant: Assistant,
+    db_engine: AsyncEngine,
+) -> None:
+    """Delegated profile rows should not render as main web chat messages."""
+    conv_id = f"test_conv_delegated_rows_{uuid.uuid4().hex[:8]}"
+    timestamp = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    async with get_db_context(db_engine) as db_context:
+        await db_context.message_history.add_message(
+            UserMessage(content="Main user request"),
+            interface_type="web",
+            conversation_id=conv_id,
+            timestamp=timestamp,
+            turn_id="main-turn",
+            processing_profile_id="default_assistant",
+            user_id="test_user",
+        )
+        await db_context.message_history.add_message(
+            UserMessage(content="Delegated prompt from model"),
+            interface_type="web",
+            conversation_id=conv_id,
+            timestamp=timestamp,
+            turn_id="delegated-turn",
+            processing_profile_id="browser",
+            subconversation_id="delegated-subconversation",
+        )
+        await db_context.message_history.add_message(
+            AssistantMessage(content="Delegated profile answer"),
+            interface_type="web",
+            conversation_id=conv_id,
+            timestamp=timestamp,
+            turn_id="delegated-turn",
+            processing_profile_id="browser",
+            subconversation_id="delegated-subconversation",
+        )
+        await db_context.message_history.add_message(
+            AssistantMessage(content="Main assistant answer"),
+            interface_type="web",
+            conversation_id=conv_id,
+            timestamp=timestamp,
+            turn_id="main-turn",
+            processing_profile_id="default_assistant",
+            user_id="test_user",
+        )
+
+    assert web_only_assistant.fastapi_app is not None
+    transport = httpx.ASGITransport(app=web_only_assistant.fastapi_app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        for query_string in ("", "?limit=0"):
+            response = await client.get(
+                f"/api/v1/chat/conversations/{conv_id}/messages{query_string}"
+            )
+            assert response.status_code == 200
+            data = response.json()
+
+            assert data["count"] == 2
+            assert data["total_messages"] == 2
+            assert [
+                (message["role"], message["content"]) for message in data["messages"]
+            ] == [
+                ("user", "Main user request"),
+                ("assistant", "Main assistant answer"),
+            ]
 
 
 @pytest.mark.asyncio

--- a/tests/functional/web/ui/test_conversations_list.py
+++ b/tests/functional/web/ui/test_conversations_list.py
@@ -1,5 +1,6 @@
 """Test /api/v1/chat/conversations endpoint for listing conversations."""
 
+import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 
@@ -100,6 +101,73 @@ async def test_get_conversations_with_data(
             assert conv["conversation_id"] in conv_ids
             assert conv["last_message"].startswith("Hello! This is response")
             assert "last_timestamp" in conv
+
+
+@pytest.mark.asyncio
+async def test_get_conversations_excludes_delegated_subconversations_from_summary(
+    web_only_assistant: Assistant,
+    db_engine: AsyncEngine,
+) -> None:
+    """Delegated rows should not drive sidebar previews or visible counts."""
+    conv_id = f"test_conv_delegated_summary_{uuid.uuid4().hex[:8]}"
+    timestamp = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    async with get_db_context(db_engine) as db_context:
+        await db_context.message_history.add_message(
+            UserMessage(content="Main user request"),
+            interface_type="web",
+            conversation_id=conv_id,
+            timestamp=timestamp,
+            turn_id="main-turn",
+            processing_profile_id="default_assistant",
+            user_id="test_user",
+        )
+        await db_context.message_history.add_message(
+            AssistantMessage(content="Main assistant answer"),
+            interface_type="web",
+            conversation_id=conv_id,
+            timestamp=timestamp,
+            turn_id="main-turn",
+            processing_profile_id="default_assistant",
+            user_id="test_user",
+        )
+        await db_context.message_history.add_message(
+            UserMessage(content="Delegated prompt from model"),
+            interface_type="web",
+            conversation_id=conv_id,
+            timestamp=timestamp,
+            turn_id="delegated-turn",
+            processing_profile_id="browser",
+            subconversation_id="delegated-subconversation",
+        )
+        await db_context.message_history.add_message(
+            AssistantMessage(content="Delegated profile answer"),
+            interface_type="web",
+            conversation_id=conv_id,
+            timestamp=timestamp,
+            turn_id="delegated-turn",
+            processing_profile_id="browser",
+            subconversation_id="delegated-subconversation",
+        )
+
+    assert web_only_assistant.fastapi_app is not None
+    transport = httpx.ASGITransport(app=web_only_assistant.fastapi_app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        response = await client.get(
+            f"/api/v1/chat/conversations?conversation_id={conv_id}"
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+    assert data["count"] == 1
+    assert len(data["conversations"]) == 1
+    conversation = data["conversations"][0]
+    assert conversation["conversation_id"] == conv_id
+    assert conversation["last_message"] == "Main assistant answer"
+    assert conversation["message_count"] == 2
+    assert conversation["last_timestamp"].startswith("2026-01-01T12:00:00")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Filter the web chat transcript endpoint to show only main-conversation rows (`subconversation_id IS NULL`).
- Apply the same main-conversation filter to conversation sidebar summaries, previews, and visible message counts.
- Preserve broad repository defaults for internal callers while letting web-facing endpoints opt out of delegated sub-conversation rows.
- Make paginated message ordering stable for equal timestamps by pairing descending timestamp ordering with descending internal IDs before reversing for display.
- Add regression coverage for delegated user/assistant rows sharing the same `conversation_id` and timestamp as the main chat.

## Why

Delegated profiles persist their own isolated rows using the parent `conversation_id` plus a generated `subconversation_id`. The web endpoints were querying by `conversation_id` only, so delegated prompts and delegated replies were rendered as normal main-chat messages. That also made model-to-delegated-profile prompts appear as user messages in the transcript and could affect ordering or sidebar previews.

## Validation

- `scripts/format-and-lint.sh src/family_assistant/storage/repositories/message_history.py src/family_assistant/web/routers/chat_api.py tests/functional/web/ui/test_conversation_messages.py tests/functional/web/ui/test_conversations_list.py`
- `pytest tests/functional/web/ui/test_conversation_messages.py tests/functional/web/ui/test_conversations_list.py -xq --db sqlite`
- `poe test` passed: pytest, frontend-tests, basedpyright, pylint, frontend-lint, frontend-typecheck