### PR TITLE
fix(ios): keep TestFlight build numbers monotonic after Xcode Cloud cutover

### DIFF
--- a/docs/design/ios_testflight_delivery.md
+++ b/docs/design/ios_testflight_delivery.md
@@ -43,12 +43,36 @@ on GitHub Actions).
 [`ios/FamilyAssistant/ci_scripts/ci_pre_xcodebuild.sh`](../../ios/FamilyAssistant/ci_scripts/ci_pre_xcodebuild.sh)
 — Xcode Cloud runs this automatically before each `xcodebuild` invocation. It stamps
 `CURRENT_PROJECT_VERSION` (the source of `CFBundleVersion`, since the target uses
-`GENERATE_INFOPLIST_FILE = YES`) with the monotonically increasing `CI_BUILD_NUMBER`, so every
-upload has a unique build number with no manual bumping. The edit happens in the ephemeral CI
-checkout only and is never committed.
+`GENERATE_INFOPLIST_FILE = YES`) with `BUILD_NUMBER_BASE + CI_BUILD_NUMBER`, so every upload has a
+unique, monotonically increasing build number with no manual bumping. The edit happens in the
+ephemeral CI checkout only and is never committed.
 
 The `ci_scripts` directory must sit next to the `.xcodeproj` and the script must be executable and
 not part of any build target.
+
+### Build-number base offset
+
+`CI_BUILD_NUMBER` is Xcode Cloud's own counter and starts at 1. Earlier builds, however, were
+uploaded by the now-retired manual script using the **git commit count** as the build number, and
+those reached ~4972 on TestFlight. A raw `CI_BUILD_NUMBER` stamp (9, 10, …) is numerically *below*
+those legacy uploads, so TestFlight treats every Xcode Cloud build as "older" and refuses to install
+it — and the cloud counter would take thousands of builds to climb back past 4972.
+
+`BUILD_NUMBER_BASE` (currently `10000`) offsets `CI_BUILD_NUMBER` past the legacy range, so the very
+next cloud build (e.g. `10000 + 9 = 10009`) is strictly greater than anything already uploaded while
+remaining monotonic forever. Only ever raise this base — never lower it — and only if some future
+legacy upload exceeds it (none should, now that manual uploads are retired). `MARKETING_VERSION`
+stays `1.0`; build numbers are compared within a marketing version, so bumping the marketing version
+later lets the counter reset freely.
+
+### Manual releases are retired
+
+[`ios/testflight-release.sh`](../../ios/testflight-release.sh) previously archived and uploaded to
+TestFlight using the git commit count as the build number. Running it alongside Xcode Cloud would
+mean two independent counters fighting for the same build-number sequence — whichever ran last would
+need to be highest, which no fixed offset can guarantee. The script therefore no longer uploads:
+invoking it without `--build-only` errors out and points at Xcode Cloud, and `--build-only` still
+archives and exports a local `.ipa` for on-device testing. **Xcode Cloud is the single uploader.**
 
 ## One-time console setup (manual)
 

--- a/ios/FamilyAssistant/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ios/FamilyAssistant/ci_scripts/ci_pre_xcodebuild.sh
@@ -7,6 +7,14 @@
 # increasing Xcode Cloud build number (CI_BUILD_NUMBER) so every TestFlight
 # upload is unique without anyone having to bump a counter by hand.
 #
+# BUILD_NUMBER_BASE offset: earlier builds were stamped with the git commit
+# count (via ios/testflight-release.sh) and reached ~4972 on TestFlight. Xcode
+# Cloud's CI_BUILD_NUMBER, by contrast, starts at 1, so a raw stamp produces
+# build numbers (9, 10, ...) that TestFlight treats as OLDER than the legacy
+# uploads and refuses to install. Adding a base that clears the legacy range
+# keeps every Xcode Cloud build strictly greater than anything already up
+# there while remaining monotonic (CI_BUILD_NUMBER only ever increases).
+#
 # The app target uses GENERATE_INFOPLIST_FILE = YES, so CFBundleVersion is
 # derived from the CURRENT_PROJECT_VERSION build setting at build time. We
 # rewrite that setting in the ephemeral CI checkout only -- this change is
@@ -30,7 +38,12 @@ if [ ! -f "$PROJECT_FILE" ]; then
   exit 1
 fi
 
-echo "Stamping CURRENT_PROJECT_VERSION = ${CI_BUILD_NUMBER}"
+# Clears the legacy commit-count builds (peaked ~4972). Bump this only if a
+# newer legacy upload ever exceeds it; never lower it.
+BUILD_NUMBER_BASE=10000
+BUILD_NUMBER=$((BUILD_NUMBER_BASE + CI_BUILD_NUMBER))
+
+echo "Stamping CURRENT_PROJECT_VERSION = ${BUILD_NUMBER} (base ${BUILD_NUMBER_BASE} + CI_BUILD_NUMBER ${CI_BUILD_NUMBER})"
 /usr/bin/sed -i '' -E \
-  "s/CURRENT_PROJECT_VERSION = [^;]+;/CURRENT_PROJECT_VERSION = ${CI_BUILD_NUMBER};/g" \
+  "s/CURRENT_PROJECT_VERSION = [^;]+;/CURRENT_PROJECT_VERSION = ${BUILD_NUMBER};/g" \
   "$PROJECT_FILE"

--- a/ios/testflight-release.sh
+++ b/ios/testflight-release.sh
@@ -1,13 +1,24 @@
 #!/usr/bin/env bash
 #
-# Build the FamilyAssistant iOS app and upload it to TestFlight (App Store Connect).
+# Build the FamilyAssistant iOS app locally and export a signed .ipa for testing.
+#
+# TestFlight releases are produced by Xcode Cloud, NOT by this script. Xcode
+# Cloud is the single source of truth for TestFlight build numbers: its
+# ci_scripts/ci_pre_xcodebuild.sh stamps a monotonically increasing build
+# number derived from CI_BUILD_NUMBER. A second uploader (this script) using a
+# different counter would clash with that sequence and push "older" builds that
+# TestFlight refuses to install -- exactly the regression this retirement
+# prevents. Uploading from here is therefore disabled; this script now only
+# archives and exports an .ipa locally for on-device testing.
 #
 # Usage:
-#   ./ios/testflight-release.sh                 # pull origin/main, archive, upload
-#   ./ios/testflight-release.sh --no-pull       # build the current checkout as-is
-#   ./ios/testflight-release.sh --build-only    # archive + export .ipa, skip the upload
+#   ./ios/testflight-release.sh --build-only    # archive + export a local .ipa
+#   ./ios/testflight-release.sh --build-only --no-pull   # ... from the current checkout
 #
-# Authentication (App Store Connect API key):
+# To ship a TestFlight build, push to the branch Xcode Cloud watches and let the
+# cloud workflow build and upload it.
+#
+# Authentication (App Store Connect API key) -- optional, only for signing:
 #   ASC_KEY_ID      App Store Connect API key id      (no default)
 #   ASC_ISSUER_ID   App Store Connect API issuer id   (no default)
 #   ASC_KEY_PATH    Path to the AuthKey_<id>.p8 file  (default: ~/Downloads/AuthKey_<ASC_KEY_ID>.p8)
@@ -16,20 +27,20 @@
 #   next to this script (ios/.asc-release.env -- gitignored) of the form:
 #       ASC_KEY_ID=XXXXXXXXXX
 #       ASC_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-#   Get the values from App Store Connect -> Users and Access -> Integrations ->
-#   App Store Connect API. The issuer id is the UUID at the top of that page.
-#   The key must have the App Manager or Admin role -- a Developer-role key
-#   cannot create the distribution certificate cloud signing needs.
+#   When present they let automatic signing fetch profiles under
+#   -allowProvisioningUpdates on a host not signed into Xcode Accounts. They are
+#   no longer required, since this script does not upload.
 #   The .p8, key id, and issuer id are secrets and are never committed
 #   (the .gitignore here blocks *.p8 and .asc-release.env).
 #
 # Other overrides:
 #   SCHEME          Xcode scheme   (default: FamilyAssistant)
 #   CONFIGURATION   Build config   (default: Release)
-#   BUILD_NUMBER    CFBundleVersion to stamp (default: git commit count on HEAD)
+#   BUILD_NUMBER    CFBundleVersion to stamp (default: git commit count on HEAD;
+#                   cosmetic only here -- the real TestFlight number is assigned
+#                   by Xcode Cloud)
 #
-# Requires Xcode 15.4+ and an App Store Connect record for the bundle id
-# (dev.andrewgarrett.assistant) that this Apple team can publish to.
+# Requires Xcode 15.4+.
 
 set -euo pipefail
 
@@ -42,13 +53,13 @@ CONFIGURATION="${CONFIGURATION:-Release}"
 EXPORT_OPTIONS="$SCRIPT_DIR/ExportOptions.plist"
 
 DO_PULL=1
-DO_UPLOAD=1
+UPLOAD_REQUESTED=1
 for arg in "$@"; do
     case "$arg" in
         --no-pull)    DO_PULL=0 ;;
-        --build-only) DO_UPLOAD=0 ;;
+        --build-only) UPLOAD_REQUESTED=0 ;;
         -h|--help)
-            sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            sed -n '2,42p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -60,6 +71,25 @@ done
 
 if [[ ! -d "$PROJECT" ]]; then
     echo "ERROR: cannot find Xcode project at $PROJECT" >&2
+    exit 1
+fi
+
+# TestFlight uploads are retired -- Xcode Cloud owns the build-number sequence.
+# Uploading a second, differently-numbered build from here would clash with that
+# sequence and push builds TestFlight treats as "older". Refuse upfront and point
+# to the supported paths.
+if [[ "$UPLOAD_REQUESTED" -eq 1 ]]; then
+    cat >&2 <<'EOF'
+ERROR: this script no longer uploads to TestFlight.
+
+TestFlight builds are produced by Xcode Cloud, which owns the build-number
+sequence (ios/FamilyAssistant/ci_scripts/ci_pre_xcodebuild.sh stamps it from
+CI_BUILD_NUMBER). A second uploader using a different counter would regress
+that sequence and push builds TestFlight refuses to install.
+
+To ship a TestFlight build:  push to the branch Xcode Cloud watches.
+To build a local .ipa to test on a device:  re-run with --build-only.
+EOF
     exit 1
 fi
 
@@ -78,15 +108,17 @@ fi
 
 echo "Building from commit: $(git -C "$REPO_ROOT" log --oneline -1)"
 
-# --- 2. Pick a monotonic build number -------------------------------------
-# TestFlight rejects a re-used build number for the same marketing version, so
-# default to the commit count on HEAD (always increases as work lands).
+# --- 2. Pick a build number -----------------------------------------------
+# Cosmetic for a local --build-only .ipa; the authoritative TestFlight build
+# number is assigned by Xcode Cloud, not here. Default to the commit count on
+# HEAD so a locally-installed test build still carries a sensible version.
 BUILD_NUMBER="${BUILD_NUMBER:-$(git -C "$REPO_ROOT" rev-list --count HEAD)}"
 echo "Using build number (CFBundleVersion): $BUILD_NUMBER"
 
-# --- 3. Resolve App Store Connect API credentials -------------------------
+# --- 3. Resolve App Store Connect API credentials (optional) --------------
 # Load identifiers from an untracked, gitignored env file if present so no key
-# id / issuer id is ever committed to the repo.
+# id / issuer id is ever committed to the repo. These are no longer required
+# (no upload happens); when present they let automatic signing fetch profiles.
 CREDS_FILE="$SCRIPT_DIR/.asc-release.env"
 if [[ -f "$CREDS_FILE" ]]; then
     # shellcheck source=/dev/null
@@ -97,28 +129,10 @@ ASC_KEY_ID="${ASC_KEY_ID:-}"
 ASC_ISSUER_ID="${ASC_ISSUER_ID:-}"
 ASC_KEY_PATH="${ASC_KEY_PATH:-$HOME/Downloads/AuthKey_${ASC_KEY_ID}.p8}"
 
-if [[ "$DO_UPLOAD" -eq 1 ]]; then
-    if [[ -z "$ASC_KEY_ID" || -z "$ASC_ISSUER_ID" ]]; then
-        echo "ERROR: ASC_KEY_ID and ASC_ISSUER_ID must be set." >&2
-        echo "       Export them, or create $CREDS_FILE (gitignored) with:" >&2
-        echo "         ASC_KEY_ID=XXXXXXXXXX" >&2
-        echo "         ASC_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" >&2
-        echo "       (App Store Connect -> Users and Access -> Integrations -> App Store Connect API)" >&2
-        echo "       Or run with --build-only to skip the upload." >&2
-        exit 1
-    fi
-    if [[ ! -f "$ASC_KEY_PATH" ]]; then
-        echo "ERROR: API key not found at $ASC_KEY_PATH" >&2
-        echo "       Set ASC_KEY_PATH to your AuthKey_${ASC_KEY_ID}.p8, or download it from App Store Connect." >&2
-        exit 1
-    fi
-fi
-
-# Authentication flags shared by the archive and export steps. Automatic
-# signing under -allowProvisioningUpdates needs an App Store Connect key on a
-# host that is not already signed into Xcode Accounts, so the archive step
-# needs them too -- not just the export/upload. Populated whenever a key is
-# available (always so for an upload; best-effort for --build-only).
+# Authentication flags for the archive/export steps. Automatic signing under
+# -allowProvisioningUpdates needs an App Store Connect key on a host that is not
+# already signed into Xcode Accounts. Populated best-effort whenever a key is
+# available; signing falls back to local Xcode Accounts otherwise.
 ASC_AUTH_ARGS=()
 if [[ -n "$ASC_KEY_ID" && -n "$ASC_ISSUER_ID" && -f "$ASC_KEY_PATH" ]]; then
     ASC_AUTH_ARGS=(
@@ -147,18 +161,13 @@ xcodebuild \
     CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
     archive
 
-# --- 5. Export (+ upload to TestFlight when destination=upload) -----------
-if [[ "$DO_UPLOAD" -eq 1 ]]; then
-    echo "Exporting and uploading to TestFlight..."
-else
-    echo "Exporting .ipa only (--build-only); skipping upload..."
-    # destination=upload in ExportOptions.plist would still try to upload, so
-    # build a temporary export-to-disk plist for the build-only path.
-    EXPORT_OPTIONS="$BUILD_ROOT/ExportOptions.build-only.plist"
-    /usr/libexec/PlistBuddy -c "Print" "$SCRIPT_DIR/ExportOptions.plist" >/dev/null
-    cp "$SCRIPT_DIR/ExportOptions.plist" "$EXPORT_OPTIONS"
-    /usr/libexec/PlistBuddy -c "Set :destination export" "$EXPORT_OPTIONS"
-fi
+# --- 5. Export the .ipa to disk -------------------------------------------
+echo "Exporting .ipa to disk..."
+# destination=upload in ExportOptions.plist would try to upload, so build a
+# temporary export-to-disk plist regardless of the committed setting.
+EXPORT_OPTIONS="$BUILD_ROOT/ExportOptions.build-only.plist"
+cp "$SCRIPT_DIR/ExportOptions.plist" "$EXPORT_OPTIONS"
+/usr/libexec/PlistBuddy -c "Set :destination export" "$EXPORT_OPTIONS"
 
 xcodebuild \
     -exportArchive \
@@ -169,9 +178,5 @@ xcodebuild \
     "${ASC_AUTH_ARGS[@]}"
 
 echo
-if [[ "$DO_UPLOAD" -eq 1 ]]; then
-    echo "Done. Build $BUILD_NUMBER uploaded to App Store Connect."
-    echo "It will appear in TestFlight after Apple finishes processing (a few minutes)."
-else
-    echo "Done. Exported .ipa is in: $EXPORT_PATH"
-fi
+echo "Done. Exported .ipa is in: $EXPORT_PATH"
+echo "TestFlight uploads are handled by Xcode Cloud, not this script."


### PR DESCRIPTION
## Problem

iOS auto-builds in TestFlight reset from build **4947** back to **9** and stopped installing — TestFlight treats the new builds as "older" and never supersedes the existing ones.

## Root cause

Two build-number schemes collided:

- **Legacy / manual** (`ios/testflight-release.sh`): stamped `CFBundleVersion` from `git rev-list --count HEAD` — the commit count. Those uploads peaked at **~4972** on TestFlight.
- **Xcode Cloud auto-builds** (`ci_pre_xcodebuild.sh`, added later): stamps the version from **`CI_BUILD_NUMBER`**, Xcode Cloud's own counter that starts at 1 (now ~9).

`CFBundleVersion` is compared numerically within a marketing version, so `9 < 4972` → every auto-build looks older and won't install. The cloud counter would take thousands of builds to climb back past 4972.

## Fix

- **`ci_pre_xcodebuild.sh`**: offset by `BUILD_NUMBER_BASE = 10000`, so the version is `10000 + CI_BUILD_NUMBER`. Next auto-build is **10009** — clears the legacy range (max 4972) with margin and stays monotonic forever since `CI_BUILD_NUMBER` only increases.
- **`testflight-release.sh`**: **retire the manual upload path.** Two independent counters can't be kept monotonic against each other with fixed offsets (whichever ran last must be highest — impossible to guarantee statically). Xcode Cloud is now the single uploader. The script refuses to upload (errors out pointing at Xcode Cloud) and keeps `--build-only` for producing a local `.ipa` for on-device testing.
- **`docs/design/ios_testflight_delivery.md`**: records the offset rationale and the manual-path retirement.

## Notes

- `MARKETING_VERSION` stays `1.0`. Build numbers are compared within a marketing version, so a future marketing-version bump can reset the counter freely.
- Confirmed highest legacy TestFlight build with the maintainer: **4972**.

## Testing

- `bash -n` clean on both scripts.
- `testflight-release.sh` (no args) now exits 1 with the Xcode Cloud guidance; `--help` exits 0.
- `ci_pre_xcodebuild.sh` simulated: `CI_BUILD_NUMBER=9` → stamps `10009`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)