### PR TITLE
Instruct artist profile to use transform_image for reference images

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1043,7 +1043,7 @@ service_profiles:
 
           ## Working with Reference Images (`transform_image`)
 
-          Whenever the user provides one or more reference images, or wants a result that builds on, edits, or stays visually consistent with an existing image, you MUST use `transform_image` rather than `generate_image`. `generate_image` creates images purely from text and cannot see or preserve an existing image; only `transform_image` can edit or combine reference images.
+          Whenever the user provides one or more reference images, or wants a result that builds on, edits, or stays visually consistent with an existing image, prefer `transform_image` over `generate_image`. `generate_image` creates images purely from text and cannot see or preserve an existing image; only `transform_image` can edit or combine reference images.
 
           Use `transform_image` for requests such as:
           1. **Editing an existing image**: object removal/addition, background changes, retouching, recoloring, or fixing details in a provided image.
@@ -1053,6 +1053,8 @@ service_profiles:
           5. **Visual consistency**: when the user wants a new image to match the look, character, or subject of an image they shared (e.g. "draw this same character doing X").
 
           Pass the reference image(s) via `images` (preferred for one or more) and describe the desired change in `instruction`. Only fall back to `generate_image` when there is no reference image and the user wants something created entirely from a text description.
+
+          Note: for deterministic annotation of a provided image — drawing boxes, circles, arrows, or labels to point something out (e.g. "circle the bird", "highlight the error") — use `highlight_image` instead of `transform_image`. `transform_image` performs generative edits and is the wrong tool for precise markup.
 
           ## Video Generation Best Practices (Veo)
 
@@ -1065,7 +1067,7 @@ service_profiles:
           ## Workflow
           1. **Understand**: Clarify the user's vision. What is the subject? What is the mood?
           2. **Refine**: If the user's request is vague ("make a cat"), expand it into a high-quality prompt ("A fluffy Persian cat sitting on a velvet cushion in a sunlit Victorian room, photorealistic, 4k").
-          3. **Execute**: Use the appropriate tool. If a reference image is provided or visual continuity with an existing image is desired, use `transform_image`; for brand-new images from text, use `generate_image`; for video, use `generate_video`.
+          3. **Execute**: Use the appropriate tool. For generative edits of a reference image or visual continuity with an existing image, use `transform_image`; for deterministic annotation/markup of a provided image (boxes, circles, arrows, labels), use `highlight_image`; for brand-new images from text, use `generate_image`; for video, use `generate_video`.
           4. **Review**: Present the result. If using `generate_video`, note that it may take a few minutes.
 
           Current time: {current_time}
@@ -1552,3 +1554,4 @@ browser_handoff_config:
     - "browser_visual_profile"
 # Secrets (telegram_token, api_keys, database_url) are primarily from env.
 # Model, embedding_model, server_url, storage_paths are also top-level or env.
+

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1041,6 +1041,19 @@ service_profiles:
           Example Prompt Structure:
           "[Subject] [Action/Context], [Art Style], [Lighting], [Color Palette], [Camera Angle/Framing]"
 
+          ## Working with Reference Images (`transform_image`)
+
+          Whenever the user provides one or more reference images, or wants a result that builds on, edits, or stays visually consistent with an existing image, you MUST use `transform_image` rather than `generate_image`. `generate_image` creates images purely from text and cannot see or preserve an existing image; only `transform_image` can edit or combine reference images.
+
+          Use `transform_image` for requests such as:
+          1. **Editing an existing image**: object removal/addition, background changes, retouching, recoloring, or fixing details in a provided image.
+          2. **Style changes**: re-rendering a provided image in a new art style while keeping its composition or subject.
+          3. **Variations**: producing alternative versions of a provided image.
+          4. **Combining images**: merging elements from multiple reference images (put the primary image first in `images`).
+          5. **Visual consistency**: when the user wants a new image to match the look, character, or subject of an image they shared (e.g. "draw this same character doing X").
+
+          Pass the reference image(s) via `images` (preferred for one or more) and describe the desired change in `instruction`. Only fall back to `generate_image` when there is no reference image and the user wants something created entirely from a text description.
+
           ## Video Generation Best Practices (Veo)
 
           When using `generate_video`, follow these guidelines:
@@ -1052,7 +1065,7 @@ service_profiles:
           ## Workflow
           1. **Understand**: Clarify the user's vision. What is the subject? What is the mood?
           2. **Refine**: If the user's request is vague ("make a cat"), expand it into a high-quality prompt ("A fluffy Persian cat sitting on a velvet cushion in a sunlit Victorian room, photorealistic, 4k").
-          3. **Execute**: Use the appropriate tool (`generate_image`, `generate_video`, etc.).
+          3. **Execute**: Use the appropriate tool. If a reference image is provided or visual continuity with an existing image is desired, use `transform_image`; for brand-new images from text, use `generate_image`; for video, use `generate_video`.
           4. **Review**: Present the result. If using `generate_video`, note that it may take a few minutes.
 
           Current time: {current_time}

--- a/docs/user/image_tools.md
+++ b/docs/user/image_tools.md
@@ -175,11 +175,15 @@ with `/artist` or `/image`. This activates a profile optimized for creative imag
 - Enhanced prompt refinement
 - Access to video generation capabilities
 - Specialized knowledge of effective prompting techniques
+- Reference-image editing: when you attach an image (or ask for a result that builds on or stays
+  consistent with an existing image), the artist edits and combines those reference images instead
+  of generating something from scratch
 
 Example:
 
 - `/artist Create a detailed fantasy landscape with a magical forest and floating islands`
 - `/image Generate a professional product photo of a coffee mug`
+- `/artist` with a photo attached: "Put this same character on a beach at sunset"
 
 ## Examples
 


### PR DESCRIPTION
The artist profile already allowed transform_image but its system prompt
only documented generate_image and generate_video, so the model had no
guidance on when to edit/combine an existing image versus creating one
from text. Add a 'Working with Reference Images' section that directs the
artist to use transform_image whenever a reference image is provided or
visual continuity with an existing image is desired, and clarify tool
selection in the workflow. Update the user guide to match.