### PR TITLE
docs: design for Telegram Rich Messages (Bot API 10.1)

### DIFF
--- a/docs/design/telegram-rich-messages.md
+++ b/docs/design/telegram-rich-messages.md
@@ -1,0 +1,201 @@
+# Telegram Rich Messages
+
+## Status
+
+Proposed design for review. **Blocked on upstream library support** (see
+[Dependency Blocker](#dependency-blocker)).
+
+This design describes how Family Assistant could adopt Telegram's **Rich Messages** feature (Bot API
+10.1, released 2026-06-11) to render assistant replies as structured documents — section headings,
+tables, lists, collapsible detail sections, block/pull quotes, and code blocks — and to stream
+AI-generated replies into the chat as they are produced.
+
+It is intentionally scoped as a forward-looking design: the feature cannot be implemented today
+because `python-telegram-bot` does not yet expose the new API surface. The doc captures the target
+architecture so that implementation can start the moment the dependency is available, and so the
+prerequisite library upgrade (tracked separately) is justified.
+
+## Background
+
+Telegram Bot API 10.1 added "Rich Messages", a structured block model for bot messages. Unlike the
+existing `parse_mode` formatting (`MarkdownV2`/`HTML`), which produces a single styled text string
+constrained to inline entities, Rich Messages model a message as a tree of typed blocks.
+
+Key facts (verified against the Bot API changelog and reference, 2026-06-14):
+
+- **Not a Markdown parser.** Telegram's pipeline is a structured entity/block model. There is no
+  `parse_mode=GHFMD`. Content is built from `RichBlock*` objects, not a markdown string. The block
+  set maps cleanly onto GitHub-Flavored Markdown constructs (headings, tables, fenced code, lists,
+  quotes, dividers), which is why it is described as "document-grade" / GFM-like.
+- **New methods.** `sendRichMessage` and `sendRichMessageDraft` (streaming), plus a `rich_message`
+  parameter on `editMessageText`. These are separate from `sendMessage`.
+- **Block types** include: `RichBlockParagraph`, `RichBlockSectionHeading`, `RichBlockList` /
+  `RichBlockListItem`, `RichBlockTable` / `RichBlockTableCell`, `RichBlockPreformatted` (code),
+  `RichBlockBlockQuotation`, `RichBlockPullQuotation`, `RichBlockDivider`, `RichBlockDetails`
+  (collapsible), `RichBlockMathematicalExpression`, media blocks (`RichBlockPhoto`,
+  `RichBlockVideo`, `RichBlockAnimation`, `RichBlockAudio`, `RichBlockVoiceNote`), and
+  `RichBlockThinking`.
+- **Streaming.** `sendRichMessageDraft` lets a bot push partial content and update it live,
+  replacing the static "type indicator then one big block" experience.
+- **Message length.** The reference does not (as of this writing) state a numeric maximum for rich
+  messages, and we have not been able to confirm whether the classic 4096-character text limit is
+  raised. This must be re-verified before relying on "longer messages" as a benefit.
+
+## Dependency Blocker
+
+Rich Messages cannot be implemented until `python-telegram-bot` exposes the 10.1 surface.
+
+- We pin `python-telegram-bot[ext]>=21.0,<22.0` in `pyproject.toml`.
+- The latest released PTB (22.8) advertises support for **Bot API 10.0**, not 10.1. There is no PTB
+  release with `send_rich_message` yet.
+
+Adoption therefore requires two sequential upgrades:
+
+1. **PTB 21.x → 22.x** — clears the `<22.0` cap and reaches API 10.0 parity. Tracked as a separate
+   PR; it has standalone value and no dependency on Rich Messages.
+2. **PTB 22.x → the point release that adds 10.1 / Rich Messages** — a smaller bump once available.
+
+This doc assumes step 2 has landed before implementation begins.
+
+## Current State
+
+Assistant replies reach Telegram as a single markdown-derived string:
+
+- The LLM produces markdown-ish text. `convert_to_telegram_markdown()`
+  (`src/family_assistant/telegram/markdown_utils.py:37`) runs it through the `telegramify_markdown`
+  library to produce `MarkdownV2`, plus a post-processing fix for the library's `<`/`>` escaping bug
+  (`fix_telegramify_markdown_escaping`, `markdown_utils.py:13`).
+- `TelegramChatInterface.send_message()` (`src/family_assistant/telegram/interface.py:49`) maps the
+  `parse_mode` string to a `telegram.constants.ParseMode`, sends via `bot.send_message`, and on a
+  `BadRequest` "Can't parse entities" error retries once as plain text (`interface.py:115`) so
+  messages are never lost.
+- Long replies are split: `TELEGRAM_MAX_MESSAGE_LENGTH = 4000`
+  (`src/family_assistant/telegram/handler.py:71`), and `_send_message_chunks()` (`handler.py:299`)
+  breaks the text with `TextChunker` on natural boundaries. This produces multiple sequential
+  messages for long content such as the daily brief.
+- The transport abstraction is the `ChatInterface` protocol (`src/family_assistant/interfaces.py`),
+  implemented by `TelegramChatInterface` and the web `WebChatInterface` (which ignores
+  `parse_mode`).
+
+Limitations this design addresses:
+
+- Tables, headings, and collapsible sections degrade to flat text.
+- Long structured output is split mid-document into several chunks.
+- Replies appear only when complete; there is no progressive rendering.
+
+## Goals
+
+- Render assistant replies as native Telegram Rich Messages when the content is structured
+  (headings, tables, lists, code blocks, quotes, collapsible detail).
+- Stream long / slow replies progressively via `sendRichMessageDraft` + `editMessageText`.
+- Reuse the assistant's existing markdown output as the source of truth — no second authoring format
+  for the LLM to learn.
+- Preserve the existing `MarkdownV2` path and plain-text fallback as a graceful degradation when
+  rich rendering is unavailable or fails.
+- Keep the web interface unchanged in behaviour.
+
+## Non-Goals
+
+- Do not require the LLM to emit `RichBlock*` JSON. The LLM continues to produce markdown.
+- Do not remove the `MarkdownV2` path; it remains the fallback.
+- Do not build rich rendering for the web UI in this iteration (the React frontend already renders
+  markdown natively).
+- Do not implement media-heavy blocks (collage, slideshow, map) in v1.
+
+## Proposed Design
+
+### Overview
+
+Introduce a markdown → RichBlock conversion layer and an optional rich send path on the Telegram
+interface, selected by capability detection with fallback to the current `MarkdownV2` path.
+
+```
+LLM markdown
+   │
+   ├── (rich available) ──► markdown_to_rich_blocks() ──► sendRichMessage / draft+edit
+   │
+   └── (fallback)       ──► convert_to_telegram_markdown() ──► send_message (MarkdownV2)
+                                                                  └─► plain-text on parse error
+```
+
+### Components
+
+1. **`markdown_to_rich_blocks(text) -> list[RichBlock]`** (new, in `telegram/rich_messages.py`).
+   Parses the assistant's markdown into PTB `RichBlock*` objects. We already depend on
+   `telegramify_markdown`, which parses GFM (including tables, task lists, code blocks); the
+   converter walks that parse tree and emits blocks rather than a `MarkdownV2` string. Where
+   `telegramify_markdown` does not expose a usable tree, fall back to a small CommonMark/GFM parser
+   (e.g. `markdown-it-py`, already transitively available) — to be confirmed during spike.
+
+2. **`ChatInterface` extension.** Add an optional capability so callers can request rich rendering
+   without coupling to Telegram. Two options (decide at implementation):
+
+   - (a) A new optional method `send_rich_message(conversation_id, blocks, ...)` with a default
+     implementation that flattens to text and calls `send_message`.
+   - (b) Keep `send_message(text, ...)` as the single entry point and let the Telegram
+     implementation decide internally whether to render `text` as rich blocks.
+
+   **Recommendation: (b).** Callers keep passing markdown; only `TelegramChatInterface` changes.
+   This avoids touching every call site and keeps the web path identical. Rich rendering becomes an
+   internal detail of the Telegram transport, gated by config + capability detection.
+
+3. **Capability detection.** Probe whether the installed PTB / bot supports `send_rich_message`
+   (attribute check on `bot`) once at startup, store the result, and branch on it. If unavailable,
+   behaviour is byte-for-byte the current `MarkdownV2` path.
+
+4. **Streaming (phase 2).** For long replies, open a draft with `sendRichMessageDraft` and update it
+   via `editMessageText(rich_message=...)` as the assistant produces output. This requires the
+   processing layer to expose incremental output; today replies are returned whole. Streaming is
+   therefore split into its own phase and depends on incremental generation being available from
+   `ProcessingService`.
+
+### Fallback and error handling
+
+Mirror the existing robustness:
+
+- If `markdown_to_rich_blocks` raises, log and fall back to `convert_to_telegram_markdown` + the
+  current send path. Rich rendering must never lose a message (consistent with the No Silent
+  Failures / Fail-Fast-but-don't-lose-user-output principles in AGENTS.md).
+- If `sendRichMessage` returns a `BadRequest`, fall back to `MarkdownV2`, then to plain text — the
+  same ladder as `interface.py:115` today.
+
+### Message length
+
+If Rich Messages raise or remove the 4096-char limit, the `_send_message_chunks` splitting
+(`handler.py:299`) can be skipped for the rich path, sending structured content as a single coherent
+document. This is a benefit **contingent on verifying the new limit** — until verified, keep
+chunking as a safety net.
+
+## Milestones
+
+1. **Spike & verify** (no production code): confirm a PTB release with Rich Messages exists; read
+   the `RichBlock*` field docs and confirm the message-size limit; prototype
+   `markdown_to_rich_blocks` against representative assistant output (daily brief, a table, a code
+   block). Independently testable via unit tests on the converter.
+2. **Converter + Telegram rich send path** behind capability detection and config flag, with full
+   fallback ladder. Independently shippable; default off until validated.
+3. **Enable by default** once validated against real chats; update length handling to skip chunking
+   on the rich path if the limit allows.
+4. **Streaming** via `sendRichMessageDraft` once incremental generation is available from the
+   processing layer.
+
+## Testing
+
+- Unit tests for `markdown_to_rich_blocks`: headings, nested lists, tables, fenced code (with
+  language), block quotes, collapsible details, and special-character escaping.
+- Functional Telegram tests (`tests/functional/telegram/`) asserting: rich path used when capability
+  present; fallback to `MarkdownV2` when converter raises; fallback to plain text on `BadRequest`.
+- A capability-absent test pinning current behaviour to guard against regressions.
+
+## Documentation
+
+On user-visible rollout, update `docs/user/USER_GUIDE.md` and describe the capability in the system
+prompt (`prompts.yaml`) so the assistant knows its replies can include tables and collapsible
+sections in Telegram.
+
+## Open Questions
+
+- Does `telegramify_markdown` expose a parse tree we can reuse, or do we need a separate GFM parser?
+- What is the actual maximum size of a rich message, and is the 4096-char text limit changed?
+- Which PTB release adds `send_rich_message`, and what is its minimum Python / API version?
+- Streaming: what is the minimal incremental-output hook needed from `ProcessingService`?

--- a/docs/design/telegram-rich-messages.md
+++ b/docs/design/telegram-rich-messages.md
@@ -141,11 +141,19 @@ LLM markdown
 ### Components
 
 1. **Rich payload from markdown** (new, in `telegram/rich_messages.py`). Build an `InputRichMessage`
-   from the assistant's markdown. In the simplest case this is a thin wrapper that passes the
-   markdown straight through; a small normalization step may be needed to reconcile our GFM dialect
-   with whatever subset Telegram accepts (e.g. table or task-list syntax) — to be confirmed during
-   the spike. Note there is **no** `markdown_to_rich_blocks` block builder: `RichBlock*` is the
-   received representation, not the send input.
+   from the assistant's markdown. This is mostly pass-through, but it is **not** a blind wrapper —
+   the builder must normalize constructs whose rich-markdown meaning differs from plain text:
+
+   - **Image syntax → text.** In Telegram rich markdown, `![alt](url)` is a *media block*, so
+     passing it through would turn a text reply into a media send — which v1 explicitly excludes and
+     which may require media permissions or be rejected. The builder escapes or rewrites image
+     syntax (e.g. to a plain link `[alt](url)`) so image references stay textual until media blocks
+     are intentionally supported.
+   - **GFM dialect reconciliation.** A small normalization step may be needed to match the markdown
+     subset Telegram accepts (e.g. table or task-list syntax) — to be confirmed during the spike.
+
+   Note there is **no** `markdown_to_rich_blocks` block builder: `RichBlock*` is the received
+   representation, not the send input.
 
 2. **Route the real Telegram reply path through a rich-aware sender.** The main assistant reply path
    is **not** `TelegramChatInterface.send_message`; the handler sends replies directly via
@@ -166,9 +174,20 @@ LLM markdown
    rather than a `Message`), then **persist the finished reply with a normal `sendRichMessage`** —
    do not attempt to "finalize" the draft via `editMessageText`, as there is no opened draft message
    to edit and the preview disappears when it expires. Group/forum chats skip streaming and use the
-   non-draft path. This also requires the processing layer to expose incremental output (today
-   replies are returned whole), so streaming is split into its own phase and depends on incremental
-   generation from `ProcessingService`.
+   non-draft path.
+
+   **Stream parseable snapshots, not raw token prefixes.** Each draft update is parsed as a rich
+   message, but a raw token prefix is frequently invalid markdown while a code fence, table row,
+   link, or `<details>` block is half-written — sending those would fail the draft parse and defeat
+   streaming for exactly the structured replies this feature targets. The streamer therefore needs a
+   buffering/repair step that emits only syntactically valid snapshots: buffer until the in-progress
+   block closes, or temporarily close it (e.g. append a closing fence) so each emitted snapshot
+   parses, then send the next snapshot once more content arrives. Until such a snapshot is
+   available, show a placeholder/typing draft rather than a broken one.
+
+   This also requires the processing layer to expose incremental output (today replies are returned
+   whole), so streaming is split into its own phase and depends on incremental generation from
+   `ProcessingService`.
 
 ### Fallback and error handling
 

--- a/docs/design/telegram-rich-messages.md
+++ b/docs/design/telegram-rich-messages.md
@@ -17,29 +17,44 @@ prerequisite library upgrade (tracked separately) is justified.
 
 ## Background
 
-Telegram Bot API 10.1 added "Rich Messages", a structured block model for bot messages. Unlike the
-existing `parse_mode` formatting (`MarkdownV2`/`HTML`), which produces a single styled text string
-constrained to inline entities, Rich Messages model a message as a tree of typed blocks.
+Telegram Bot API 10.1 added "Rich Messages", a document-grade formatting model for bot messages.
+Unlike the existing `parse_mode` formatting (`MarkdownV2`/`HTML`), which produces a single styled
+text string constrained to inline entities, a rich message renders as a structured document with
+block-level structure (headings, tables, lists, dividers, collapsible sections).
 
 Key facts (verified against the Bot API changelog and reference, 2026-06-14):
 
-- **Not a Markdown parser.** Telegram's pipeline is a structured entity/block model. There is no
-  `parse_mode=GHFMD`. Content is built from `RichBlock*` objects, not a markdown string. The block
-  set maps cleanly onto GitHub-Flavored Markdown constructs (headings, tables, fenced code, lists,
-  quotes, dividers), which is why it is described as "document-grade" / GFM-like.
-- **New methods.** `sendRichMessage` and `sendRichMessageDraft` (streaming), plus a `rich_message`
-  parameter on `editMessageText`. These are separate from `sendMessage`.
-- **Block types** include: `RichBlockParagraph`, `RichBlockSectionHeading`, `RichBlockList` /
-  `RichBlockListItem`, `RichBlockTable` / `RichBlockTableCell`, `RichBlockPreformatted` (code),
-  `RichBlockBlockQuotation`, `RichBlockPullQuotation`, `RichBlockDivider`, `RichBlockDetails`
-  (collapsible), `RichBlockMathematicalExpression`, media blocks (`RichBlockPhoto`,
-  `RichBlockVideo`, `RichBlockAnimation`, `RichBlockAudio`, `RichBlockVoiceNote`), and
-  `RichBlockThinking`.
-- **Streaming.** `sendRichMessageDraft` lets a bot push partial content and update it live,
-  replacing the static "type indicator then one big block" experience.
+- **Send markdown/HTML, receive blocks.** This is the critical distinction. The bot **sends** a rich
+  message by passing an `InputRichMessage`, which carries the content as **markdown or HTML** (one
+  of the two) — there is no need to construct a block tree by hand. Telegram parses that input and
+  the **received** message exposes the structured `RichMessage` (a tree of `RichBlock*` objects) on
+  `Message.rich_message`. So `RichBlock*` is the *parsed/received* representation, not the send
+  input. (This corrects an earlier draft of this doc that proposed building `RichBlock*` objects to
+  send.) The accepted markdown is GitHub-Flavored-Markdown-like, which is what makes "send GFM and
+  get a document" accurate.
+- **New methods.** `sendRichMessage` (input: `InputRichMessage`) and `sendRichMessageDraft`
+  (streaming), plus a `rich_message` parameter on `editMessageText`. These are separate from
+  `sendMessage`.
+- **Received block types** (in `Message.rich_message`) include: `RichBlockParagraph`,
+  `RichBlockSectionHeading`, `RichBlockList` / `RichBlockListItem`, `RichBlockTable` /
+  `RichBlockTableCell`, `RichBlockPreformatted` (code), `RichBlockBlockQuotation`,
+  `RichBlockPullQuotation`, `RichBlockDivider`, `RichBlockDetails` (collapsible),
+  `RichBlockMathematicalExpression`, media blocks (`RichBlockPhoto`, `RichBlockVideo`,
+  `RichBlockAnimation`, `RichBlockAudio`, `RichBlockVoiceNote`), and `RichBlockThinking`.
+- **Streaming is draft-based and private-chat-only.** `sendRichMessageDraft` streams an ephemeral
+  preview (reported as a short-lived draft, on the order of ~30s, keyed by a `draft_id`) and is only
+  valid for a private chat. It returns a success flag, **not** a persisted `Message`; the finished
+  output must be committed with a normal `sendRichMessage`. There is no opened draft message object
+  to edit via `editMessageText`. Group and forum-topic chats must use the non-draft path.
 - **Message length.** The reference does not (as of this writing) state a numeric maximum for rich
   messages, and we have not been able to confirm whether the classic 4096-character text limit is
   raised. This must be re-verified before relying on "longer messages" as a benefit.
+
+> Note: the precise `InputRichMessage` field names (`markdown`/`html`) and the exact
+> `sendRichMessageDraft` contract (return type, draft lifetime, private-chat constraint) are taken
+> from the Bot API 10.1 reference and a code review of an earlier draft; they must be re-confirmed
+> against PTB's typed bindings during the spike, since the docs page is large and the
+> machine-readable spec mirrors had not caught up at time of writing.
 
 ## Dependency Blocker
 
@@ -87,7 +102,9 @@ Limitations this design addresses:
 
 - Render assistant replies as native Telegram Rich Messages when the content is structured
   (headings, tables, lists, code blocks, quotes, collapsible detail).
-- Stream long / slow replies progressively via `sendRichMessageDraft` + `editMessageText`.
+- In **private chats**, stream long / slow replies progressively via `sendRichMessageDraft`, then
+  commit the finished reply with `sendRichMessage`. Group and forum-topic chats use the non-draft
+  send path (no streaming).
 - Reuse the assistant's existing markdown output as the source of truth — no second authoring format
   for the LLM to learn.
 - Preserve the existing `MarkdownV2` path and plain-text fallback as a graceful degradation when
@@ -106,13 +123,16 @@ Limitations this design addresses:
 
 ### Overview
 
-Introduce a markdown → RichBlock conversion layer and an optional rich send path on the Telegram
-interface, selected by capability detection with fallback to the current `MarkdownV2` path.
+Because `sendRichMessage` accepts markdown/HTML directly (via `InputRichMessage`), the assistant's
+existing markdown output can be passed through almost unchanged — no block-construction layer is
+needed. The work is therefore mostly about routing: choosing the rich send path when available, and
+preserving the current `MarkdownV2` ladder as fallback.
 
 ```
 LLM markdown
    │
-   ├── (rich available) ──► markdown_to_rich_blocks() ──► sendRichMessage / draft+edit
+   ├── (rich available) ──► InputRichMessage(markdown=…) ──► sendRichMessage
+   │                                                          (private chat: draft-stream first)
    │
    └── (fallback)       ──► convert_to_telegram_markdown() ──► send_message (MarkdownV2)
                                                                   └─► plain-text on parse error
@@ -120,44 +140,51 @@ LLM markdown
 
 ### Components
 
-1. **`markdown_to_rich_blocks(text) -> list[RichBlock]`** (new, in `telegram/rich_messages.py`).
-   Parses the assistant's markdown into PTB `RichBlock*` objects. We already depend on
-   `telegramify_markdown`, which parses GFM (including tables, task lists, code blocks); the
-   converter walks that parse tree and emits blocks rather than a `MarkdownV2` string. Where
-   `telegramify_markdown` does not expose a usable tree, fall back to a small CommonMark/GFM parser
-   (e.g. `markdown-it-py`, already transitively available) — to be confirmed during spike.
+1. **Rich payload from markdown** (new, in `telegram/rich_messages.py`). Build an `InputRichMessage`
+   from the assistant's markdown. In the simplest case this is a thin wrapper that passes the
+   markdown straight through; a small normalization step may be needed to reconcile our GFM dialect
+   with whatever subset Telegram accepts (e.g. table or task-list syntax) — to be confirmed during
+   the spike. Note there is **no** `markdown_to_rich_blocks` block builder: `RichBlock*` is the
+   received representation, not the send input.
 
-2. **`ChatInterface` extension.** Add an optional capability so callers can request rich rendering
-   without coupling to Telegram. Two options (decide at implementation):
+2. **Route the real Telegram reply path through a rich-aware sender.** The main assistant reply path
+   is **not** `TelegramChatInterface.send_message`; the handler sends replies directly via
+   `_send_message_chunks()` → `context.bot.send_message` (`handler.py:299`, call sites around
+   `handler.py:807`+ and `handler.py:1328`+). A change confined to `TelegramChatInterface` would
+   therefore leave ordinary Telegram conversations on the old `MarkdownV2`/chunking path. Introduce
+   a single rich-aware send helper (e.g. `send_rich_or_fallback(bot, chat_id, markdown, …)`) and
+   call it from **both** the handler's reply path and `TelegramChatInterface.send_message`, so the
+   two send paths stay consistent. Callers keep passing markdown; the helper decides rich vs.
+   fallback. The web path (`WebChatInterface`) is untouched.
 
-   - (a) A new optional method `send_rich_message(conversation_id, blocks, ...)` with a default
-     implementation that flattens to text and calls `send_message`.
-   - (b) Keep `send_message(text, ...)` as the single entry point and let the Telegram
-     implementation decide internally whether to render `text` as rich blocks.
-
-   **Recommendation: (b).** Callers keep passing markdown; only `TelegramChatInterface` changes.
-   This avoids touching every call site and keeps the web path identical. Rich rendering becomes an
-   internal detail of the Telegram transport, gated by config + capability detection.
-
-3. **Capability detection.** Probe whether the installed PTB / bot supports `send_rich_message`
+3. **Capability detection.** Probe whether the installed PTB / bot exposes `send_rich_message`
    (attribute check on `bot`) once at startup, store the result, and branch on it. If unavailable,
    behaviour is byte-for-byte the current `MarkdownV2` path.
 
-4. **Streaming (phase 2).** For long replies, open a draft with `sendRichMessageDraft` and update it
-   via `editMessageText(rich_message=...)` as the assistant produces output. This requires the
-   processing layer to expose incremental output; today replies are returned whole. Streaming is
-   therefore split into its own phase and depends on incremental generation being available from
-   `ProcessingService`.
+4. **Streaming (phase 2, private chats only).** In a private chat, stream incremental output via
+   `sendRichMessageDraft` (an ephemeral ~30s preview keyed by `draft_id`, returning a success flag
+   rather than a `Message`), then **persist the finished reply with a normal `sendRichMessage`** —
+   do not attempt to "finalize" the draft via `editMessageText`, as there is no opened draft message
+   to edit and the preview disappears when it expires. Group/forum chats skip streaming and use the
+   non-draft path. This also requires the processing layer to expose incremental output (today
+   replies are returned whole), so streaming is split into its own phase and depends on incremental
+   generation from `ProcessingService`.
 
 ### Fallback and error handling
 
-Mirror the existing robustness:
+Mirror the existing robustness, but **fall back only for expected, specific errors** — do not wrap
+the whole rich path in a blanket `except`. While the feature is under development a broad catch
+would hide converter bugs or unexpected PTB/API shapes behind a silent MarkdownV2 reply, defeating
+tests and masking real defects (contrary to the Fail-Fast principle in AGENTS.md).
 
-- If `markdown_to_rich_blocks` raises, log and fall back to `convert_to_telegram_markdown` + the
-  current send path. Rich rendering must never lose a message (consistent with the No Silent
-  Failures / Fail-Fast-but-don't-lose-user-output principles in AGENTS.md).
-- If `sendRichMessage` returns a `BadRequest`, fall back to `MarkdownV2`, then to plain text — the
-  same ladder as `interface.py:115` today.
+- If `sendRichMessage` raises a `BadRequest` that indicates the input was rejected (e.g. an
+  unparseable-markup error), fall back to `MarkdownV2`, then to plain text — the same ladder as
+  `interface.py:115` today. This is a known, expected failure mode worth absorbing so a message is
+  never lost.
+- Any other exception (programming errors in the payload builder, unexpected API responses,
+  capability-probe inconsistencies) is allowed to propagate so it surfaces in tests and logs. Once
+  the path is validated and enabled by default, we can broaden the absorbed set if real-world
+  failure modes justify it.
 
 ### Message length
 
@@ -168,23 +195,27 @@ chunking as a safety net.
 
 ## Milestones
 
-1. **Spike & verify** (no production code): confirm a PTB release with Rich Messages exists; read
-   the `RichBlock*` field docs and confirm the message-size limit; prototype
-   `markdown_to_rich_blocks` against representative assistant output (daily brief, a table, a code
-   block). Independently testable via unit tests on the converter.
-2. **Converter + Telegram rich send path** behind capability detection and config flag, with full
+1. **Spike & verify** (no production code): confirm a PTB release with Rich Messages exists; confirm
+   the `InputRichMessage` field names (`markdown`/`html`), the `sendRichMessageDraft` contract
+   (return type, draft lifetime, private-chat constraint), and the message-size limit against PTB's
+   typed bindings; check that representative assistant output (daily brief, a table, a code block)
+   renders correctly when sent as markdown.
+2. **Rich send path** routed through the shared rich-aware sender (handler reply path +
+   `TelegramChatInterface`), behind capability detection and a config flag, with the narrowed
    fallback ladder. Independently shippable; default off until validated.
 3. **Enable by default** once validated against real chats; update length handling to skip chunking
    on the rich path if the limit allows.
-4. **Streaming** via `sendRichMessageDraft` once incremental generation is available from the
-   processing layer.
+4. **Streaming** (private chats) via `sendRichMessageDraft` + final `sendRichMessage`, once
+   incremental generation is available from the processing layer.
 
 ## Testing
 
-- Unit tests for `markdown_to_rich_blocks`: headings, nested lists, tables, fenced code (with
-  language), block quotes, collapsible details, and special-character escaping.
+- Unit tests for the markdown → `InputRichMessage` payload builder: headings, nested lists, tables,
+  fenced code (with language), block quotes, collapsible details, and special-character handling.
 - Functional Telegram tests (`tests/functional/telegram/`) asserting: rich path used when capability
-  present; fallback to `MarkdownV2` when converter raises; fallback to plain text on `BadRequest`.
+  present (via the shared sender on the handler reply path, not just the interface); fallback to
+  `MarkdownV2` then plain text on an input-rejected `BadRequest`; and that an unexpected error
+  propagates rather than being silently swallowed.
 - A capability-absent test pinning current behaviour to guard against regressions.
 
 ## Documentation
@@ -195,7 +226,11 @@ sections in Telegram.
 
 ## Open Questions
 
-- Does `telegramify_markdown` expose a parse tree we can reuse, or do we need a separate GFM parser?
+- What markdown dialect does `InputRichMessage` accept (GFM tables, task lists, headings), and how
+  much normalization of our output is required?
 - What is the actual maximum size of a rich message, and is the 4096-char text limit changed?
-- Which PTB release adds `send_rich_message`, and what is its minimum Python / API version?
+- What exactly does `sendRichMessageDraft` return, how long does the draft live, and is it strictly
+  private-chat-only?
+- Which PTB release adds `send_rich_message` / `InputRichMessage`, and what is its minimum Python /
+  API version?
 - Streaming: what is the minimal incremental-output hook needed from `ProcessingService`?

--- a/docs/design/telegram-rich-messages.md
+++ b/docs/design/telegram-rich-messages.md
@@ -45,9 +45,10 @@ Key facts (verified against the Bot API changelog and reference, 2026-06-14):
   valid for a private chat. It returns a success flag, **not** a persisted `Message`; the finished
   output must be committed with a normal `sendRichMessage`. There is no opened draft message object
   to edit via `editMessageText`. Group and forum-topic chats must use the non-draft path.
-- **Message length.** The reference does not (as of this writing) state a numeric maximum for rich
-  messages, and we have not been able to confirm whether the classic 4096-character text limit is
-  raised. This must be re-verified before relying on "longer messages" as a benefit.
+- **Message length.** Rich Messages have a hard cap of **32768 UTF-8 characters**
+  ([rich-message limits](https://core.telegram.org/bots/api#rich-message-limits)) — much larger than
+  the 4096-char plain-text limit, but still finite, so chunking is raised rather than removed (see
+  [Message length](#message-length)).
 
 > Note: the precise `InputRichMessage` field names (`markdown`/`html`) and the exact
 > `sendRichMessageDraft` contract (return type, draft lifetime, private-chat constraint) are taken
@@ -61,11 +62,12 @@ Rich Messages are **not hard-blocked** on a typed PTB release. The blocker is na
 earlier draft of this doc claimed: only the *typed bindings* (`send_rich_message`,
 `InputRichMessage`) are missing, not the ability to call the methods.
 
-- We currently pin `python-telegram-bot[ext]>=21.0,<22.0` in `pyproject.toml`. **The wrapper works
-  on this pin** — PTB 21.11.1 already exposes `Bot.do_api_request`/`api_kwargs` for raw Bot API
-  calls
+- We now pin `python-telegram-bot[ext]>=22.0,<23.0` (PR #912, merged). **The wrapper does not depend
+  on this** — `Bot.do_api_request`/`api_kwargs` for raw Bot API calls has existed since at least PTB
+  21.11.1
   ([21.11.1 docs](https://docs.python-telegram-bot.org/en/v21.11.1/telegram.bot.html#telegram.Bot.do_api_request)),
-  so the rich-message spike does **not** need the 22.x upgrade.
+  so the rich-message spike would have worked even on the old 21.x pin. The 22.x bump was
+  independent cleanup, not a prerequisite.
 - The latest released PTB (22.8) advertises support for **Bot API 10.0**, not 10.1; there is no
   typed `send_rich_message` yet.
 - PTB documents a
@@ -80,10 +82,10 @@ earlier draft of this doc claimed: only the *typed bindings* (`send_rich_message
 
 Recommended sequencing:
 
-1. **Implement behind a `do_api_request` wrapper** on the **current 21.x pin** (config-gated,
-   default off) once the send contract is confirmed in the spike — no upstream dependency.
-2. **PTB 21.x → 22.x** — independent cleanup (clears the `<22.0` cap, reaches API 10.0 parity).
-   Tracked as a separate PR; **not** a prerequisite for the wrapper.
+1. **PTB 21.x → 22.x** — ✅ done (PR #912, merged). Independent cleanup; was never a prerequisite for
+   the wrapper.
+2. **Implement behind a `do_api_request` wrapper** (config-gated, default off) once the send
+   contract is confirmed in the spike — no further upstream dependency.
 3. **Swap to native bindings** when PTB ships typed 10.1 support; the wrapper boundary localizes the
    change.
 
@@ -181,15 +183,28 @@ LLM markdown
    therefore leave ordinary Telegram conversations on the old `MarkdownV2`/chunking path. Introduce
    a single rich-aware send helper and call it from **both** the handler's reply path and
    `TelegramChatInterface.send_message`, so the two send paths stay consistent. The web path
-   (`WebChatInterface`) is untouched. The helper's contract has two subtleties that must not be
+   (`WebChatInterface`) is untouched. The helper's contract has several subtleties that must not be
    lost:
 
+   - **Route raw markdown *before* MarkdownV2 conversion.** On the handler path the reply is run
+     through `convert_to_telegram_markdown(final_llm_content_to_send)` *before*
+     `_send_message_chunks` (`handler.py:806`-`819`). Wiring the helper at the
+     `_send_message_chunks` boundary would hand it already-escaped MarkdownV2, not the raw GFM that
+     `sendRichMessage` expects — so enabling rich messages would silently still take the legacy
+     path. The helper must therefore receive the **raw** assistant markdown (plus rich intent) and
+     decide *before* conversion: rich path uses the raw markdown; only the fallback path runs
+     `convert_to_telegram_markdown`.
    - **Carry reply context.** The handler passes `reply_to_message_id` and a `ForceReply` markup on
      every assistant reply. `sendRichMessage` does **not** accept the legacy `reply_to_message_id`
      parameter — the Bot API exposes `reply_parameters` plus `reply_markup`. The helper signature
      must therefore accept reply/markup intent (e.g. `reply_to_message_id`, `reply_markup`) and
      translate `reply_to_message_id` → `reply_parameters` for the rich path, while the fallback path
      keeps using it as today. Threading and `ForceReply` must survive on the rich path.
+   - **Preserve attachment delivery.** `TelegramChatInterface.send_message` also owns
+     `attachment_ids` dispatch via `_send_attachments` (used by the communication tool and
+     task-worker callbacks). The shared contract must carry `attachment_ids` (or keep the existing
+     `_send_attachments` call around the helper) so replies that include generated/approved
+     attachments don't silently send text only.
    - **Respect the caller's parse-mode/rich intent — do not rich-render everything.**
      `TelegramChatInterface.send_message` is also used outside the assistant-reply path with
      `parse_mode=None` for *literal* text (e.g. the communication tool, confirmation-result
@@ -251,10 +266,13 @@ tests and masking real defects (contrary to the Fail-Fast principle in AGENTS.md
 
 ### Message length
 
-If Rich Messages raise or remove the 4096-char limit, the `_send_message_chunks` splitting
-(`handler.py:299`) can be skipped for the rich path, sending structured content as a single coherent
-document. This is a benefit **contingent on verifying the new limit** — until verified, keep
-chunking as a safety net.
+Rich Messages have a **higher but still finite cap: 32768 UTF-8 characters**
+([rich-message limits](https://core.telegram.org/bots/api#rich-message-limits)), versus 4096 for
+plain text. So the rich path can *raise* the chunking threshold from the current 4000 to (just
+under) 32768 and deliver a typical daily brief or document summary as a single coherent message —
+but it **cannot skip chunking entirely**. A reply above 32768 chars must still be split (rich-aware
+chunking) or it will be rejected, regressing content the existing 4000-char chunker delivers today.
+Keep chunking as the safety net at the rich limit.
 
 ## Milestones
 
@@ -296,7 +314,8 @@ sections in Telegram.
 
 - What markdown dialect does `InputRichMessage` accept (GFM tables, task lists, headings), and how
   much normalization of our output is required?
-- What is the actual maximum size of a rich message, and is the 4096-char text limit changed?
+- The rich-message cap is documented as 32768 UTF-8 chars; confirm whether it counts UTF-8 bytes,
+  UTF-16 units, or codepoints, since that affects where rich-aware chunking must split.
 - What exactly does `sendRichMessageDraft` return, how long does the draft live, and is it strictly
   private-chat-only?
 - Which PTB release adds `send_rich_message` / `InputRichMessage`, and what is its minimum Python /

--- a/docs/design/telegram-rich-messages.md
+++ b/docs/design/telegram-rich-messages.md
@@ -61,21 +61,29 @@ Rich Messages are **not hard-blocked** on a typed PTB release. The blocker is na
 earlier draft of this doc claimed: only the *typed bindings* (`send_rich_message`,
 `InputRichMessage`) are missing, not the ability to call the methods.
 
-- We pin `python-telegram-bot[ext]>=21.0,<22.0` in `pyproject.toml`.
+- We currently pin `python-telegram-bot[ext]>=21.0,<22.0` in `pyproject.toml`. **The wrapper works
+  on this pin** — PTB 21.11.1 already exposes `Bot.do_api_request`/`api_kwargs` for raw Bot API
+  calls
+  ([21.11.1 docs](https://docs.python-telegram-bot.org/en/v21.11.1/telegram.bot.html#telegram.Bot.do_api_request)),
+  so the rich-message spike does **not** need the 22.x upgrade.
 - The latest released PTB (22.8) advertises support for **Bot API 10.0**, not 10.1; there is no
   typed `send_rich_message` yet.
-- However, PTB documents a
+- PTB documents a
   [Bot API forward-compatibility path](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Bot-API-Forward-Compatibility#new-methods):
   new methods can be invoked via `Bot.do_api_request("sendRichMessage", ...)` with a
   JSON-serializable `rich_message` payload. So the rich send/draft calls can be prototyped now
-  behind a thin wrapper and swapped for native bindings when they land.
+  behind a thin wrapper and swapped for native bindings when they land. **`do_api_request` returns a
+  raw `dict` unless `return_type` is supplied**, so the wrapper must pass `return_type=Message` (or
+  deserialize the response itself) before returning — the handler reads `message_id` off every sent
+  assistant reply, so a payload-only wrapper would post the message and then crash when recording
+  history.
 
 Recommended sequencing:
 
-1. **PTB 21.x → 22.x** — clears the `<22.0` cap and reaches API 10.0 parity. Tracked as a separate
-   PR; standalone value, and the floor for the forward-compatible wrapper.
-2. **Implement behind a `do_api_request` wrapper** (capability/config-gated, default off) once the
-   send contract is confirmed in the spike — no need to wait for a typed release.
+1. **Implement behind a `do_api_request` wrapper** on the **current 21.x pin** (config-gated,
+   default off) once the send contract is confirmed in the spike — no upstream dependency.
+2. **PTB 21.x → 22.x** — independent cleanup (clears the `<22.0` cap, reaches API 10.0 parity).
+   Tracked as a separate PR; **not** a prerequisite for the wrapper.
 3. **Swap to native bindings** when PTB ships typed 10.1 support; the wrapper boundary localizes the
    change.
 
@@ -202,6 +210,12 @@ LLM markdown
    do not attempt to "finalize" the draft via `editMessageText`, as there is no opened draft message
    to edit and the preview disappears when it expires. Group/forum chats skip streaming and use the
    non-draft path.
+
+   **Allocate one stable non-zero `draft_id` per streamed reply.** The Bot API requires `draft_id`
+   to be non-zero, and updates that reuse the same id are animated into the existing preview. The
+   streamer must therefore allocate a single non-zero id when a reply begins and reuse it for every
+   draft update until the final `sendRichMessage`; using `0`, or changing the id between chunks, is
+   rejected or produces disconnected previews.
 
    **Stream parseable snapshots, not raw token prefixes.** Each draft update is parsed as a rich
    message, but a raw token prefix is frequently invalid markdown while a code fence, table row,

--- a/docs/design/telegram-rich-messages.md
+++ b/docs/design/telegram-rich-messages.md
@@ -2,18 +2,17 @@
 
 ## Status
 
-Proposed design for review. **Blocked on upstream library support** (see
-[Dependency Blocker](#dependency-blocker)).
+Proposed design for review. Implementable now behind a forward-compatibility wrapper; native PTB
+bindings are a later swap (see [Dependency Status](#dependency-status)).
 
 This design describes how Family Assistant could adopt Telegram's **Rich Messages** feature (Bot API
 10.1, released 2026-06-11) to render assistant replies as structured documents — section headings,
 tables, lists, collapsible detail sections, block/pull quotes, and code blocks — and to stream
 AI-generated replies into the chat as they are produced.
 
-It is intentionally scoped as a forward-looking design: the feature cannot be implemented today
-because `python-telegram-bot` does not yet expose the new API surface. The doc captures the target
-architecture so that implementation can start the moment the dependency is available, and so the
-prerequisite library upgrade (tracked separately) is justified.
+It is a forward-looking design: typed `python-telegram-bot` bindings for the new methods do not
+exist yet, but the methods can be invoked via PTB's `do_api_request` forward-compatibility path, so
+the doc captures the target architecture and a wrapper-based interim implementation.
 
 ## Background
 
@@ -56,21 +55,29 @@ Key facts (verified against the Bot API changelog and reference, 2026-06-14):
 > against PTB's typed bindings during the spike, since the docs page is large and the
 > machine-readable spec mirrors had not caught up at time of writing.
 
-## Dependency Blocker
+## Dependency Status
 
-Rich Messages cannot be implemented until `python-telegram-bot` exposes the 10.1 surface.
+Rich Messages are **not hard-blocked** on a typed PTB release. The blocker is narrower than an
+earlier draft of this doc claimed: only the *typed bindings* (`send_rich_message`,
+`InputRichMessage`) are missing, not the ability to call the methods.
 
 - We pin `python-telegram-bot[ext]>=21.0,<22.0` in `pyproject.toml`.
-- The latest released PTB (22.8) advertises support for **Bot API 10.0**, not 10.1. There is no PTB
-  release with `send_rich_message` yet.
+- The latest released PTB (22.8) advertises support for **Bot API 10.0**, not 10.1; there is no
+  typed `send_rich_message` yet.
+- However, PTB documents a
+  [Bot API forward-compatibility path](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Bot-API-Forward-Compatibility#new-methods):
+  new methods can be invoked via `Bot.do_api_request("sendRichMessage", ...)` with a
+  JSON-serializable `rich_message` payload. So the rich send/draft calls can be prototyped now
+  behind a thin wrapper and swapped for native bindings when they land.
 
-Adoption therefore requires two sequential upgrades:
+Recommended sequencing:
 
 1. **PTB 21.x → 22.x** — clears the `<22.0` cap and reaches API 10.0 parity. Tracked as a separate
-   PR; it has standalone value and no dependency on Rich Messages.
-2. **PTB 22.x → the point release that adds 10.1 / Rich Messages** — a smaller bump once available.
-
-This doc assumes step 2 has landed before implementation begins.
+   PR; standalone value, and the floor for the forward-compatible wrapper.
+2. **Implement behind a `do_api_request` wrapper** (capability/config-gated, default off) once the
+   send contract is confirmed in the spike — no need to wait for a typed release.
+3. **Swap to native bindings** when PTB ships typed 10.1 support; the wrapper boundary localizes the
+   change.
 
 ## Current State
 
@@ -144,11 +151,15 @@ LLM markdown
    from the assistant's markdown. This is mostly pass-through, but it is **not** a blind wrapper —
    the builder must normalize constructs whose rich-markdown meaning differs from plain text:
 
-   - **Image syntax → text.** In Telegram rich markdown, `![alt](url)` is a *media block*, so
+   - **Media syntax → text.** In Telegram rich markdown, `![alt](url)` is a *media block*, so
      passing it through would turn a text reply into a media send — which v1 explicitly excludes and
      which may require media permissions or be rejected. The builder escapes or rewrites image
      syntax (e.g. to a plain link `[alt](url)`) so image references stay textual until media blocks
-     are intentionally supported.
+     are intentionally supported. **This applies to rich HTML too:** Telegram rich markdown accepts
+     HTML, including media/structural tags such as `<img>`, `<video>`, `<audio>`, `<tg-map>`,
+     `<tg-collage>`, and `<tg-slideshow>`. Since assistant output (or quoted external content) can
+     contain these, the normalization step must escape/rewrite those tags as text as well, not just
+     the markdown image form.
    - **GFM dialect reconciliation.** A small normalization step may be needed to match the markdown
      subset Telegram accepts (e.g. table or task-list syntax) — to be confirmed during the spike.
 
@@ -160,14 +171,30 @@ LLM markdown
    `_send_message_chunks()` → `context.bot.send_message` (`handler.py:299`, call sites around
    `handler.py:807`+ and `handler.py:1328`+). A change confined to `TelegramChatInterface` would
    therefore leave ordinary Telegram conversations on the old `MarkdownV2`/chunking path. Introduce
-   a single rich-aware send helper (e.g. `send_rich_or_fallback(bot, chat_id, markdown, …)`) and
-   call it from **both** the handler's reply path and `TelegramChatInterface.send_message`, so the
-   two send paths stay consistent. Callers keep passing markdown; the helper decides rich vs.
-   fallback. The web path (`WebChatInterface`) is untouched.
+   a single rich-aware send helper and call it from **both** the handler's reply path and
+   `TelegramChatInterface.send_message`, so the two send paths stay consistent. The web path
+   (`WebChatInterface`) is untouched. The helper's contract has two subtleties that must not be
+   lost:
 
-3. **Capability detection.** Probe whether the installed PTB / bot exposes `send_rich_message`
-   (attribute check on `bot`) once at startup, store the result, and branch on it. If unavailable,
-   behaviour is byte-for-byte the current `MarkdownV2` path.
+   - **Carry reply context.** The handler passes `reply_to_message_id` and a `ForceReply` markup on
+     every assistant reply. `sendRichMessage` does **not** accept the legacy `reply_to_message_id`
+     parameter — the Bot API exposes `reply_parameters` plus `reply_markup`. The helper signature
+     must therefore accept reply/markup intent (e.g. `reply_to_message_id`, `reply_markup`) and
+     translate `reply_to_message_id` → `reply_parameters` for the rich path, while the fallback path
+     keeps using it as today. Threading and `ForceReply` must survive on the rich path.
+   - **Respect the caller's parse-mode/rich intent — do not rich-render everything.**
+     `TelegramChatInterface.send_message` is also used outside the assistant-reply path with
+     `parse_mode=None` for *literal* text (e.g. the communication tool, confirmation-result
+     notifications). If the helper treated every call as rich markdown, literal text containing `#`,
+     `*`, tables, or other rich syntax would be reformatted instead of sent verbatim. Rich rendering
+     applies **only** to Markdown-intent assistant replies; `parse_mode=None` is preserved as plain
+     text, and `parse_mode="MarkdownV2"/"HTML"` keeps current behaviour.
+
+3. **Capability/enablement gate.** Because the methods are reachable via `do_api_request` (see
+   [Dependency Status](#dependency-status)), "capability" is primarily a config flag plus an
+   optional one-time probe, not an attribute check on `bot`. When disabled (or if a probe fails),
+   behaviour is byte-for-byte the current `MarkdownV2` path. Once native `send_rich_message`
+   bindings land, the gate can additionally prefer them over the wrapper.
 
 4. **Streaming (phase 2, private chats only).** In a private chat, stream incremental output via
    `sendRichMessageDraft` (an ephemeral ~30s preview keyed by `draft_id`, returning a success flag
@@ -197,9 +224,12 @@ would hide converter bugs or unexpected PTB/API shapes behind a silent MarkdownV
 tests and masking real defects (contrary to the Fail-Fast principle in AGENTS.md).
 
 - If `sendRichMessage` raises a `BadRequest` that indicates the input was rejected (e.g. an
-  unparseable-markup error), fall back to `MarkdownV2`, then to plain text — the same ladder as
-  `interface.py:115` today. This is a known, expected failure mode worth absorbing so a message is
-  never lost.
+  unparseable-markup error), fall back to `MarkdownV2`, then to plain text. **Route the fallback
+  through the chunking path (`_send_message_chunks`), not the single-message `interface.py:115`
+  ladder.** A reply that fit the larger rich-message envelope (e.g. a ~10k-char daily brief) can
+  still exceed the legacy 4096-char text limit once it degrades to MarkdownV2/plain text; sending it
+  as one message would fail again instead of being delivered. Chunking on fallback keeps the message
+  deliverable.
 - Any other exception (programming errors in the payload builder, unexpected API responses,
   capability-probe inconsistencies) is allowed to propagate so it surfaces in tests and logs. Once
   the path is validated and enabled by default, we can broaden the absorbed set if real-world
@@ -214,14 +244,16 @@ chunking as a safety net.
 
 ## Milestones
 
-1. **Spike & verify** (no production code): confirm a PTB release with Rich Messages exists; confirm
-   the `InputRichMessage` field names (`markdown`/`html`), the `sendRichMessageDraft` contract
-   (return type, draft lifetime, private-chat constraint), and the message-size limit against PTB's
-   typed bindings; check that representative assistant output (daily brief, a table, a code block)
-   renders correctly when sent as markdown.
+1. **Spike & verify** (no production code): confirm the `sendRichMessage` request shape (the
+   `rich_message`/`InputRichMessage` `markdown`/`html` fields), the `sendRichMessageDraft` contract
+   (return type, draft lifetime, private-chat constraint), and the message-size limit — exercising
+   the methods via `do_api_request` against a test bot rather than waiting for typed bindings; check
+   that representative assistant output (daily brief, a table, a code block) renders correctly when
+   sent as markdown.
 2. **Rich send path** routed through the shared rich-aware sender (handler reply path +
-   `TelegramChatInterface`), behind capability detection and a config flag, with the narrowed
-   fallback ladder. Independently shippable; default off until validated.
+   `TelegramChatInterface`), implemented behind a `do_api_request` wrapper, gated by config, with
+   reply-context translation, plain-text passthrough, and the chunked fallback ladder. Independently
+   shippable; default off until validated.
 3. **Enable by default** once validated against real chats; update length handling to skip chunking
    on the rich path if the limit allows.
 4. **Streaming** (private chats) via `sendRichMessageDraft` + final `sendRichMessage`, once
@@ -231,11 +263,14 @@ chunking as a safety net.
 
 - Unit tests for the markdown → `InputRichMessage` payload builder: headings, nested lists, tables,
   fenced code (with language), block quotes, collapsible details, and special-character handling.
-- Functional Telegram tests (`tests/functional/telegram/`) asserting: rich path used when capability
-  present (via the shared sender on the handler reply path, not just the interface); fallback to
-  `MarkdownV2` then plain text on an input-rejected `BadRequest`; and that an unexpected error
-  propagates rather than being silently swallowed.
-- A capability-absent test pinning current behaviour to guard against regressions.
+- Functional Telegram tests (`tests/functional/telegram/`) asserting: rich path used when enabled
+  (via the shared sender on the handler reply path, not just the interface); reply threading and
+  `ForceReply` survive on the rich path (`reply_to_message_id` → `reply_parameters`);
+  `parse_mode=None` literal sends are **not** rich-rendered; a long reply that fails rich parse is
+  delivered via the **chunked** fallback rather than rejected; fallback to `MarkdownV2` then plain
+  text on an input-rejected `BadRequest`; and that an unexpected error propagates rather than being
+  silently swallowed.
+- A feature-disabled test pinning current behaviour to guard against regressions.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Adds a forward-looking design doc (`docs/design/telegram-rich-messages.md`) for adopting Telegram's
**Rich Messages** feature (Bot API 10.1, released 2026-06-11) to render assistant replies as
structured documents — section headings, tables, lists, collapsible detail sections, block/pull
quotes, and code blocks — and to stream AI-generated replies into the chat.

This is documentation only; no code changes.

## Why now / why a design doc

The feature **cannot be implemented today**: `python-telegram-bot` does not yet expose the 10.1 API
surface (latest release 22.8 supports Bot API 10.0). The doc captures the target architecture,
fallback ladder, and milestones so implementation can start the moment the dependency lands, and so
the prerequisite library upgrade is justified.

## Key points

- **Not a Markdown parse mode.** Rich Messages are a structured `RichBlock*` block tree, not
  `parse_mode=GHFMD`. The block set maps cleanly onto GFM constructs, so the assistant's existing
  markdown output remains the source of truth via a `markdown_to_rich_blocks()` converter.
- **Capability-gated with full fallback.** Recommends keeping `send_message(text, ...)` as the single
  caller entry point; only `TelegramChatInterface` changes internally, gated by capability detection,
  falling back to the current `MarkdownV2` → plain-text ladder. The web path is untouched.
- **Streaming** via `sendRichMessageDraft` + `editMessageText` is split into its own phase (depends
  on incremental output from the processing layer).
- **Open question flagged:** the new max message size / whether the 4096-char limit changes is
  unconfirmed; chunking stays as a safety net until verified.

## Dependency sequencing

1. PTB 21.x → 22.x (separate PR, standalone value, reaches API 10.0 parity).
2. PTB 22.x → the point release that adds Rich Messages (10.1) — then implement this design.

## Test plan

Docs-only change; `mdformat` pre-commit passes. No functional tests affected.

https://claude.ai/code/session_014jHkHHLzvcJ3wkn8rqgm5m

---
_Generated by [Claude Code](https://claude.ai/code/session_014jHkHHLzvcJ3wkn8rqgm5m)_