### PR TITLE
Enable ruff preview via config for editor-hook/CI consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ repos:
     hooks:
       - id: ruff-check
         name: ruff-check
-        entry: ruff check --fix --preview
+        entry: ruff check --fix
         language: system
         types: [python]
       - id: ruff-format
         name: ruff-format
-        entry: ruff format --preview
+        entry: ruff format
         language: system
         types: [python]
   - repo: local

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -495,15 +495,17 @@ that conflict with these tools**:
 
 ### Python Formatting
 
-- **Tool**: `ruff format --preview`
-- **Configuration**: Automatic formatting with preview features enabled
+- **Tool**: `ruff format`
+- **Configuration**: Automatic formatting with preview features enabled (`preview = true` in
+  `[tool.ruff]`)
 - **What it handles**: Indentation, spacing, line breaks, import ordering, quote consistency
 - **Important**: Do NOT flag Python style issues that ruff would automatically fix
 
 ### Python Linting
 
-- **Tool**: `ruff check --fix --preview --ignore=E501`
-- **Configuration**: Auto-fixes enabled, line length (E501) ignored
+- **Tool**: `ruff check --fix --ignore=E501`
+- **Configuration**: Auto-fixes enabled, preview features enabled (`preview = true` in
+  `[tool.ruff]`), line length (E501) ignored
 - **What it handles**: Code style violations, unused imports, common errors
 - **Important**: The reviewer should focus on logic and design issues, not style
 
@@ -523,7 +525,7 @@ that conflict with these tools**:
 
 The project uses pre-commit hooks that run these formatters automatically:
 
-- Python files: `ruff check --fix --preview` and `ruff format --preview`
+- Python files: `ruff check --fix` and `ruff format` (preview enabled via `pyproject.toml`)
 - Markdown files: `mdformat --wrap 100`
 
 ### Review Focus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ shell = "scripts/format-and-lint.sh --fast"
 [tool.poe.tasks.format]
 help = "Format code (ruff format + mdformat)"
 shell = """
-${VIRTUAL_ENV:-.venv}/bin/ruff format --preview src tests && \
+${VIRTUAL_ENV:-.venv}/bin/ruff format src tests && \
 if command -v ${VIRTUAL_ENV:-.venv}/bin/mdformat >/dev/null 2>&1; then \
     find . -name "*.md" \
         -not -path "./.venv/*" \
@@ -370,6 +370,10 @@ strict = false
 
 [tool.ruff]
 extend-exclude = ["alembic/**", "docs/**", ".ast-grep/tests/**"]
+# Enable preview mode here (not via the --preview CLI flag) so every ruff
+# invocation honours it, including the format-on-edit hook plugin which cannot
+# pass CLI flags. This keeps the editor hook consistent with CI and pre-commit.
+preview = true
 
 [tool.ruff.lint]
 select = [

--- a/scripts/format-and-lint.sh
+++ b/scripts/format-and-lint.sh
@@ -95,11 +95,11 @@ if [ ${#PYTHON_FILES[@]} -gt 0 ]; then
     # Ruff check
     echo -n "${BLUE}  ▸ Running ruff check...${NC}"
     timer_start
-    if ! "${VIRTUAL_ENV:-.venv}"/bin/ruff check --fix --preview --ignore=E501 "${PYTHON_FILES[@]}" 2>&1; then
+    if ! "${VIRTUAL_ENV:-.venv}"/bin/ruff check --fix --ignore=E501 "${PYTHON_FILES[@]}" 2>&1; then
         timer_end
         echo ""
         echo "${YELLOW}💡 Showing suggested fixes (including unsafe ones):${NC}"
-        "${VIRTUAL_ENV:-.venv}"/bin/ruff check --unsafe-fixes --diff --preview --ignore=E501 "${PYTHON_FILES[@]}"
+        "${VIRTUAL_ENV:-.venv}"/bin/ruff check --unsafe-fixes --diff --ignore=E501 "${PYTHON_FILES[@]}"
         echo ""
         echo "${RED}❌ ruff check failed. Fix the issues above and try again. Use ruff check --fix --unsafe-fixes to apply.${NC}"
         HAS_ERRORS=1
@@ -112,7 +112,7 @@ if [ ${#PYTHON_FILES[@]} -gt 0 ]; then
     if [ $HAS_ERRORS -eq 0 ]; then
         echo -n "${BLUE}  ▸ Running ruff format...${NC}"
         timer_start
-        if ! "${VIRTUAL_ENV:-.venv}"/bin/ruff format --preview "${PYTHON_FILES[@]}" 2>&1; then
+        if ! "${VIRTUAL_ENV:-.venv}"/bin/ruff format "${PYTHON_FILES[@]}" 2>&1; then
             timer_end
             echo ""
             echo "${RED}❌ ruff format failed${NC}"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -297,11 +297,11 @@ if [ $SKIP_LINT -eq 0 ]; then
     # Ruff check
     echo -n "${BLUE}  ▸ Running ruff check...${NC}"
     timer_start
-    if ! "${VIRTUAL_ENV:-.venv}"/bin/ruff check --fix --preview --ignore=E501 src tests 2>&1; then
+    if ! "${VIRTUAL_ENV:-.venv}"/bin/ruff check --fix --ignore=E501 src tests 2>&1; then
         timer_end
         echo ""
         echo "${YELLOW}💡 Showing suggested fixes (including unsafe ones):${NC}"
-        "${VIRTUAL_ENV:-.venv}"/bin/ruff check --unsafe-fixes --diff --preview --ignore=E501 src tests
+        "${VIRTUAL_ENV:-.venv}"/bin/ruff check --unsafe-fixes --diff --ignore=E501 src tests
         echo ""
         echo "${RED}❌ ruff check failed. Fix the issues above and try again. Use ruff check --fix --unsafe-fixes to apply.${NC}"
         exit 1
@@ -312,7 +312,7 @@ if [ $SKIP_LINT -eq 0 ]; then
     # Ruff format
     echo -n "${BLUE}  ▸ Running ruff format...${NC}"
     timer_start
-    if ! "${VIRTUAL_ENV:-.venv}"/bin/ruff format --preview src tests 2>&1; then
+    if ! "${VIRTUAL_ENV:-.venv}"/bin/ruff format src tests 2>&1; then
         timer_end
         echo ""
         echo "${RED}❌ ruff format failed${NC}"


### PR DESCRIPTION
The format-on-edit hook (format-and-lint plugin) runs ruff without the
--preview CLI flag, while every project-controlled invocation (poe
format/lint, scripts/format-and-lint.sh, scripts/run-tests.sh, and
pre-commit) passed --preview explicitly. This caused files formatted by
the editor hook to differ from what CI and pre-commit expect.

Move preview into [tool.ruff] (preview = true) so every ruff invocation
honours it, including the hook which cannot pass CLI flags. Remove the
now-redundant --preview flags so pyproject.toml is the single source of
truth, and update REVIEW_GUIDELINES.md accordingly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FJP9VkX4KMTd39E2jnH5ra