### PR TITLE
Clarify test failure responsibility and flaky test handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -712,7 +712,9 @@ Once you've implemented a change, you ALWAYS go through the following algorithm:
 3. Run all tests plausibly impacted by your change.
 4. Run `poe test` after major changes for final verification - this is what runs in CI and it runs
    all tests and linters. `poe test` is the gold standard, but it doesn't need to be run every
-   single time you push a small fix.
+   single time you push a small fix. CI runs the full suite on every push regardless, so it remains
+   the backstop that must pass before a PR can merge - skipping a local `poe test` defers
+   verification to CI, it does not skip it.
 
 When long-running verification commands such as `poe test` are active, do not provide play-by-play
 progress updates. Let the command run and report only when action is needed or when it finishes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -672,11 +672,11 @@ access, input validation, and defense-in-depth approaches.
 - IMPORTANT: You NEVER leave tests broken. We do not commit changes that cause tests to break. You
   NEVER make excuses like saying that test failures are 'unrelated' or 'separate issues'. You ALWAYS
   fix ALL test failures, even if you don't think you caused them.
-- **Assumption about test failures**: You are responsible for fixing all test failures, even if you
-  believe they are pre-existing. Since the project never commits with failing tests, any failure you
-  encounter should be treated as a result of your changes. If you suspect a test is flaky, you may
-  try re-running `poe test` to confirm, but you must ultimately resolve all failures before
-  committing.
+- **Assumption about test failures**: You are responsible for fixing test failures in or near the
+  code you changed, even if you believe they are pre-existing. The project does not commit with
+  failing tests, so treat a failure anywhere near your change as a result of your changes and
+  resolve it before committing. For flakiness in areas completely unrelated to your change, see the
+  flaky-test guidance under "Debugging and Change Verification" below.
 - **Hook bypassing**: NEVER attempt to bypass pre-commit hooks, PreToolUse hooks, or any other
   verification hooks (e.g., using `--no-verify`, `--no-gpg-sign`) without explicit permission from
   the user. These hooks exist to enforce quality standards and prevent broken code from being
@@ -709,15 +709,21 @@ Once you've implemented a change, you ALWAYS go through the following algorithm:
 
 1. Run scripts/format-and-lint.sh to check for linter errors.
 2. Make sure that you have tests covering the new functionality, and that they pass.
-3. Run a broad subset of tests related to your fixes.
-4. Run `poe test` for final verification - this is what runs in CI and it runs all tests and
-   linters.
+3. Run all tests plausibly impacted by your change.
+4. Run `poe test` after major changes for final verification - this is what runs in CI and it runs
+   all tests and linters. `poe test` is the gold standard, but it doesn't need to be run every
+   single time you push a small fix.
 
 When long-running verification commands such as `poe test` are active, do not provide play-by-play
 progress updates. Let the command run and report only when action is needed or when it finishes.
 
-You NEVER push new changes or make a PR if `poe test` does not pass. We do not merge PRs with
-failing tests or linter errors.
+Flaky tests can be addressed as follows: flakiness anywhere near the modified code should be
+addressed even if it expands the scope of the PR somewhat. Flakiness in areas completely unrelated
+to the modified code can be ignored if the test passes on rerun - though if it's persistent you can
+mark the test `@flaky` and/or file a GitHub issue for the flakiness.
+
+You NEVER push new changes or make a PR with failing tests or linter errors that are caused by your
+change. We do not merge PRs with failing tests or linter errors.
 
 ### Planning Guidelines
 


### PR DESCRIPTION
This PR refines the guidance in AGENTS.md regarding test failure responsibility and flaky test handling to be more nuanced and practical.

## Summary
Updated the testing and verification guidelines to distinguish between test failures that are the developer's responsibility (failures in or near changed code) versus flaky tests in unrelated areas, and clarified when `poe test` needs to be run versus when targeted test runs suffice.

## Key Changes
- **Test failure responsibility**: Narrowed the scope to failures "in or near the code you changed" rather than all failures, while maintaining the principle that the project doesn't commit with failing tests
- **Flaky test guidance**: Added explicit guidance for handling flaky tests, distinguishing between flakiness near the change (should be fixed) versus flakiness in unrelated areas (can be ignored if it passes on rerun, or marked `@flaky`)
- **Verification workflow**: Clarified that `poe test` is the gold standard but doesn't need to be run for every small fix—targeted test runs of impacted code are acceptable for incremental changes
- **PR requirements**: Updated the final requirement to specify that PRs should not have "failing tests or linter errors that are caused by your change" rather than an absolute prohibition

## Implementation Details
These changes make the testing guidelines more practical while maintaining code quality standards. The distinction between "near" and "unrelated" failures acknowledges that developers should focus on their changes while not being blocked by pre-existing flakiness in distant parts of the codebase.

https://claude.ai/code/session_011zcWMY35LtScHehGsMiov4