### PR TITLE
Add PWA manifest and service worker paths to public routes

### DIFF
--- a/src/family_assistant/web/auth.py
+++ b/src/family_assistant/web/auth.py
@@ -58,6 +58,9 @@ PUBLIC_PATHS = [
     re.compile(r"^/static(/.*)?$"),
     re.compile(r"^/favicon.ico$"),
     re.compile(r"^/\.well-known(/.*)?$"),
+    re.compile(r"^/manifest\.json$"),
+    re.compile(r"^/manifest\.webmanifest$"),
+    re.compile(r"^/sw\.js$"),
 ]
 
 

--- a/src/family_assistant/web/auth.py
+++ b/src/family_assistant/web/auth.py
@@ -58,7 +58,6 @@ PUBLIC_PATHS = [
     re.compile(r"^/static(/.*)?$"),
     re.compile(r"^/favicon.ico$"),
     re.compile(r"^/\.well-known(/.*)?$"),
-    re.compile(r"^/manifest\.json$"),
     re.compile(r"^/manifest\.webmanifest$"),
     re.compile(r"^/sw\.js$"),
 ]

--- a/tests/unit/web/test_auth_public_paths.py
+++ b/tests/unit/web/test_auth_public_paths.py
@@ -1,0 +1,68 @@
+"""Tests that PWA-related paths bypass authentication in AuthMiddleware."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from starlette.types import Receive, Scope, Send
+
+from family_assistant.web.auth import PUBLIC_PATHS, AuthMiddleware, AuthService
+
+
+async def _ok_app(scope: Scope, receive: Receive, send: Send) -> None:
+    """Minimal ASGI app that returns 200 for any request."""
+    assert scope["type"] == "http"
+    await send({
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [(b"content-type", b"text/plain")],
+    })
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+@pytest_asyncio.fixture
+async def auth_client() -> AsyncGenerator[AsyncClient]:
+    """Client wrapping AuthMiddleware with auth enabled and no session user."""
+    auth_service = AuthService()
+    auth_service.auth_enabled = True
+    middleware = AuthMiddleware(_ok_app, auth_service)
+    transport = ASGITransport(app=middleware)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/manifest.json",
+        "/manifest.webmanifest",
+        "/sw.js",
+        "/.well-known/apple-app-site-association",
+    ],
+)
+@pytest.mark.asyncio
+async def test_pwa_paths_are_public(auth_client: AsyncClient, path: str) -> None:
+    """PWA asset paths must be served without redirecting to login."""
+    response = await auth_client.get(path)
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+def _is_public(path: str) -> bool:
+    return any(pattern.match(path) for pattern in PUBLIC_PATHS)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/notes",
+        "/manifest.jsonx",
+        "/sw.json",
+        "/swxjs",
+        "/manifest.webmanifestx",
+    ],
+)
+def test_non_public_paths_are_not_matched(path: str) -> None:
+    """Protected paths and near-miss PWA paths must not be treated as public."""
+    assert not _is_public(path)

--- a/tests/unit/web/test_auth_public_paths.py
+++ b/tests/unit/web/test_auth_public_paths.py
@@ -35,7 +35,6 @@ async def auth_client() -> AsyncGenerator[AsyncClient]:
 @pytest.mark.parametrize(
     "path",
     [
-        "/manifest.json",
         "/manifest.webmanifest",
         "/sw.js",
         "/.well-known/apple-app-site-association",
@@ -57,6 +56,7 @@ def _is_public(path: str) -> bool:
     "path",
     [
         "/notes",
+        "/manifest.json",
         "/manifest.jsonx",
         "/sw.json",
         "/swxjs",


### PR DESCRIPTION
## Summary
This change adds Progressive Web App (PWA) asset paths to the public routes list in AuthMiddleware, allowing these resources to be served without authentication.

## Key Changes
- Added two new public path patterns to `PUBLIC_PATHS` in `src/family_assistant/web/auth.py`:
  - `/manifest.webmanifest` - web app manifest (served by the Vite pages router)
  - `/sw.js` - service worker script (served by the Vite pages router)
- Added unit tests in `tests/unit/web/test_auth_public_paths.py` to verify:
  - PWA asset paths (and `/.well-known/*`) are accessible without authentication
  - Non-public paths and near-miss patterns are correctly rejected (e.g., `/manifest.json`, `/manifest.jsonx`, `/sw.json`)

## Implementation Details
The patterns use exact path matching (anchored with `^` and `$`) to prevent unintended matches on similar paths. This ensures that only the specific PWA assets are exposed publicly while maintaining security for other endpoints.

Note: `/manifest.json` is intentionally **not** included — this app serves its manifest at `/manifest.webmanifest`, and no route serves `/manifest.json` (the catch-all 404s it). Whitelisting it would only convert a login-redirect into a 404 without serving a manifest.

https://claude.ai/code/session_01LQ1HdShoVKHvvZpwoCbwbd