### PR TITLE
[codex] Fix assistant attachment history rendering

### DIFF
--- a/frontend/src/chat/ChatApp.tsx
+++ b/frontend/src/chat/ChatApp.tsx
@@ -226,6 +226,48 @@ function extractMessagePreview(content: BackendConversationMessage['content']): 
   return '';
 }
 
+function normalizeAttachmentForToolArtifact(attachment: BackendAttachment): BackendAttachment {
+  const attachmentId =
+    typeof attachment.attachment_id === 'string'
+      ? attachment.attachment_id
+      : typeof attachment.id === 'string'
+        ? attachment.id
+        : undefined;
+  if (!attachmentId) {
+    return attachment;
+  }
+
+  const contentUrl =
+    typeof attachment.content_url === 'string' && attachment.content_url
+      ? attachment.content_url
+      : `/api/attachments/${encodeURIComponent(attachmentId)}`;
+  const mimeType =
+    typeof attachment.mime_type === 'string' && attachment.mime_type
+      ? attachment.mime_type
+      : typeof attachment.content_type === 'string' && attachment.content_type
+        ? attachment.content_type
+        : 'application/octet-stream';
+
+  let attachmentType: 'image' | 'tool_result' | 'user' = 'tool_result';
+  if (mimeType.startsWith('image/')) {
+    attachmentType = 'image';
+  } else if (
+    attachment.type === 'user' &&
+    typeof attachment.filename === 'string' &&
+    typeof attachment.size === 'number'
+  ) {
+    attachmentType = 'user';
+  }
+
+  return {
+    ...attachment,
+    attachment_id: attachmentId,
+    type: attachmentType,
+    mime_type: mimeType,
+    content_url: contentUrl,
+  };
+}
+
 function isToolOnlyAssistantMessage(message: Message): boolean {
   return (
     message.role === 'assistant' &&
@@ -1022,7 +1064,8 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
           if (
             msg.role === 'assistant' &&
             ((msg.tool_calls && msg.tool_calls.length > 0) ||
-              (msg.metadata?.attachments && msg.metadata.attachments.length > 0))
+              (msg.metadata?.attachments && msg.metadata.attachments.length > 0) ||
+              (msg.attachments && msg.attachments.length > 0))
           ) {
             const content: MessageContent[] = [];
             if (msg.content) {
@@ -1072,7 +1115,7 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
               msg.tool_calls.forEach((toolCall) => {
                 const attachments = toolAttachments.get(toolCall.id);
                 if (attachments && attachments.length > 0) {
-                  allToolAttachments.push(...attachments);
+                  allToolAttachments.push(...attachments.map(normalizeAttachmentForToolArtifact));
                   attachments.forEach((att) => {
                     if (typeof att.attachment_id === 'string') {
                       allAttachmentIds.push(att.attachment_id);
@@ -1086,9 +1129,22 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
             // These are attachments queued by tools like attach_to_response
             const metadataAttachments = msg.metadata?.attachments;
             if (Array.isArray(metadataAttachments) && metadataAttachments.length > 0) {
-              // Add attachments from metadata to the collection
-              allToolAttachments.push(...metadataAttachments);
+              allToolAttachments.push(
+                ...metadataAttachments.map(normalizeAttachmentForToolArtifact)
+              );
               metadataAttachments.forEach((att) => {
+                if (typeof att.attachment_id === 'string') {
+                  allAttachmentIds.push(att.attachment_id);
+                }
+              });
+            }
+
+            const assistantAttachments = msg.attachments;
+            if (Array.isArray(assistantAttachments) && assistantAttachments.length > 0) {
+              allToolAttachments.push(
+                ...assistantAttachments.map(normalizeAttachmentForToolArtifact)
+              );
+              assistantAttachments.forEach((att) => {
                 if (typeof att.attachment_id === 'string') {
                   allAttachmentIds.push(att.attachment_id);
                 }
@@ -1632,11 +1688,15 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
       return att;
     });
 
-    return {
-      ...message,
+    const { attachments: _attachments, ...messageWithoutAttachments } = message;
+    const convertedMessage = {
+      ...messageWithoutAttachments,
       content,
-      attachments: convertedAttachments,
     };
+    if (message.role === 'user' && convertedAttachments && convertedAttachments.length > 0) {
+      return { ...convertedMessage, attachments: convertedAttachments };
+    }
+    return convertedMessage;
   }, []);
 
   const runtime = useExternalStoreRuntime({

--- a/frontend/src/chat/__tests__/ChatApp.test.tsx
+++ b/frontend/src/chat/__tests__/ChatApp.test.tsx
@@ -375,6 +375,59 @@ describe('ChatApp', () => {
     ).toBeInTheDocument();
   }, 30000);
 
+  it('loads assistant history rows with attachments without passing message attachments to assistant-ui', async () => {
+    const { server } = await import('../../test/setup.js');
+    const { http, HttpResponse } = await import('msw');
+
+    server.use(
+      http.get('/api/v1/chat/conversations/:conversationId/messages', ({ params }) => {
+        if (params.conversationId !== 'web_conv_assistant_attachment') {
+          return HttpResponse.json({ messages: [] });
+        }
+
+        return HttpResponse.json({
+          messages: [
+            {
+              internal_id: 101,
+              role: 'user',
+              content: 'Make a chart',
+              timestamp: '2026-06-24T12:00:00Z',
+            },
+            {
+              internal_id: 102,
+              role: 'assistant',
+              content: 'Here is the chart.',
+              timestamp: '2026-06-24T12:00:01Z',
+              attachments: [
+                {
+                  attachment_id: 'chart-attachment',
+                  type: 'attachment_reference',
+                },
+              ],
+            },
+          ],
+        });
+      })
+    );
+    mockLocalStorage.getItem.mockImplementation((key: string) =>
+      key === 'lastConversationId' ? 'web_conv_assistant_attachment' : null
+    );
+
+    await renderChatApp({
+      waitForReady: true,
+    });
+
+    expect(await screen.findByText('Here is the chart.')).toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId('tool-group-trigger'));
+    expect(await screen.findByText('1 attachment ready')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Download' })).toHaveAttribute(
+      'href',
+      '/api/attachments/chart-attachment'
+    );
+    expect(screen.getByTestId('assistant-message')).toBeInTheDocument();
+  });
+
   // Note: Attachment display from assistant message metadata is covered by E2E Playwright tests:
   // - test_tool_attachment_persistence_after_page_reload (tests/functional/web/test_chat_ui_attachment_response.py)
   // - test_attachment_response_flow (tests/functional/web/test_chat_ui_attachment_response.py)


### PR DESCRIPTION
## Summary

Fixes a chat UI crash when persisted assistant messages include attachment metadata. assistant-ui only accepts top-level `attachments` on user messages, but our history adapter could pass backend assistant attachments through at the message level.

## Changes

- Treat assistant message `attachments` the same way as existing tool/metadata attachments by folding them into the `attach_to_response` tool artifact path.
- Defensively strip top-level attachments from non-user messages in the assistant-ui runtime converter.
- Add a regression test for loading assistant history rows with attachments.

## Validation

- `scripts/format-and-lint.sh frontend/src/chat/ChatApp.tsx frontend/src/chat/__tests__/ChatApp.test.tsx`
- `npm test --prefix frontend -- ChatApp.test.tsx --run`
- `pytest tests/functional/web/ui/test_chat_*.py -q` (`52 passed`)