### PR TITLE
Make UCP shopping tools available in complex_tasks profile

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1343,6 +1343,9 @@ service_profiles:
         - "list_home_assistant_entities"
         - "list_home_assistant_actions"
         - "call_home_assistant_action"
+        - "ucp_add_to_cart"
+        - "ucp_get_cart"
+        - "ucp_transfer_checkout_to_human"
       on_demand_mcp_server_ids:
         - "homeassistant"
     tools_policy:
@@ -1401,6 +1404,9 @@ service_profiles:
               - "list_worker_tasks"
               - "cancel_worker_task"
               - "mqtt_publish"
+              - "ucp_add_to_cart"
+              - "ucp_get_cart"
+              - "ucp_transfer_checkout_to_human"
           decision: "allow"
           priority: 10
         - match:

--- a/tests/functional/tools/test_defaults_tool_policy_parity.py
+++ b/tests/functional/tools/test_defaults_tool_policy_parity.py
@@ -152,6 +152,13 @@ def test_ucp_tools_are_default_on_demand_and_not_confirm_gated() -> None:
     assert "shopping_profile" not in profile_by_id
     browser_profile = profile_by_id["browser_profile"]
     browser_engine = PolicyEngine.from_policy_config(browser_profile.tools_policy)
+    complex_tasks_profile = profile_by_id["complex_tasks"]
+    complex_tasks_engine = PolicyEngine.from_policy_config(
+        complex_tasks_profile.tools_policy
+    )
+    assert shopping_tool_names <= set(
+        complex_tasks_profile.tools_config.on_demand_local_tools
+    )
 
     for descriptor in descriptors.values():
         assert (
@@ -170,6 +177,13 @@ def test_ucp_tools_are_default_on_demand_and_not_confirm_gated() -> None:
         )
         assert (
             default_engine.evaluate_for_advertisement(
+                descriptor,
+                can_confirm=False,
+            ).decision
+            == ToolPolicyDecision.ALLOW
+        )
+        assert (
+            complex_tasks_engine.evaluate_for_advertisement(
                 descriptor,
                 can_confirm=False,
             ).decision


### PR DESCRIPTION
The complex_tasks profile defines its own tools_policy that replaces the
default wholesale, so it did not include the UCP shopping tools
(ucp_add_to_cart, ucp_get_cart, ucp_transfer_checkout_to_human) that
default_assistant and browser_profile already have. Add them to both the
profile's on_demand_local_tools and its policy allow list so the Shopping
skill works when delegated to complex_tasks, and extend the policy parity
test to cover the profile.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TGHm4q6oUnkDusTHxo8JaB