### PR TITLE
Allow delegation to/from engineer profile with confirmation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -610,9 +610,13 @@ dynamically adjusting available tools and supervision requirements based on inpu
 4. **Engineer Profile [B]**: Read-only diagnostic access for debugging the application
 
    - Can read sensitive data (source code, database, error logs, notes)
-   - Cannot change state or communicate externally (delegation blocked)
-   - Only side effect: creating GitHub issues (requires user confirmation)
-   - Used via `/engineer` slash command
+   - Cannot change state or communicate externally on its own; delegation to/from the engineer is
+     allowed but always requires user confirmation, so a human approves before the engineer hands
+     off a fix or another profile hands it an investigation
+   - Side effects (all require user confirmation): creating GitHub issues, reconnecting an MCP
+     server, and delegating to another profile
+   - Used via `/engineer` slash command or by delegating to the `engineer` profile (with
+     confirmation)
    - Example: "Why isn't my daily brief firing?" - reads DB state, error logs, source code
 
 5. **Complex Tasks Profile [BC]**: Advanced reasoning with Claude Opus 4.7 for complex tasks

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -473,8 +473,9 @@ default_profile_settings:
             - "delegate_to_service"
           argument_equals:
             target_service_id: "engineer"
-        decision: "deny"
+        decision: "confirm"
         priority: 99
+        description: "Delegating to the read-only engineer profile is allowed but requires user confirmation."
       - match:
           names:
             - "delete_calendar_event"
@@ -1245,8 +1246,9 @@ service_profiles:
               - "delegate_to_service"
             argument_equals:
               target_service_id: "engineer"
-          decision: "deny"
+          decision: "confirm"
           priority: 99
+          description: "Delegating to the read-only engineer profile is allowed but requires user confirmation."
     slash_commands: []
   - id: "telephone_external"
     description: "Restricted profile for external callers. Takes messages and notifies family."
@@ -1456,8 +1458,9 @@ service_profiles:
               - "delegate_to_service"
             argument_equals:
               target_service_id: "engineer"
-          decision: "deny"
+          decision: "confirm"
           priority: 99
+          description: "Delegating to the read-only engineer profile is allowed but requires user confirmation."
         - match:
             names:
               - "delete_calendar_event"
@@ -1499,7 +1502,7 @@ service_profiles:
           - You CANNOT modify any data (no INSERT, UPDATE, DELETE)
           - You CANNOT execute code or scripts
           - You CANNOT send messages to users
-          - You CANNOT delegate to other profiles
+          - You CAN delegate to another profile to hand off a fix or follow-up action, but only after the user confirms (so a human always approves before the engineer reaches outside its read-only sandbox)
           - You CAN create GitHub issues to report bugs (requires confirmation)
           - You CAN reconnect a failed MCP server (requires confirmation)
 
@@ -1542,8 +1545,16 @@ service_profiles:
               - "list_automations"
               - "get_automation"
               - "get_automation_stats"
+              - "get_delegation_status"
+              - "list_delegations"
           decision: "allow"
           priority: 10
+        - match:
+            names:
+              - "delegate_to_service"
+          decision: "confirm"
+          priority: 20
+          description: "The engineer may hand off to another profile (e.g. to implement a fix), but only with user confirmation."
         - match:
             names:
               - "create_github_issue"

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -623,6 +623,14 @@ service_profiles:
               - "list_delegations"
           decision: "allow"
           priority: 10
+        - match:
+            names:
+              - "delegate_to_service"
+            argument_equals:
+              target_service_id: "engineer"
+          decision: "confirm"
+          priority: 99
+          description: "Delegating to the read-only engineer profile is allowed but requires user confirmation."
     slash_commands:
       - "/browse"
   - id: "browser_visual_profile"
@@ -1552,9 +1560,30 @@ service_profiles:
         - match:
             names:
               - "delegate_to_service"
+            argument_equals:
+              target_service_id: "reminder"
+          decision: "deny"
+          priority: 99
+        - match:
+            names:
+              - "delegate_to_service"
+            argument_equals:
+              target_service_id: "event_handler"
+          decision: "deny"
+          priority: 99
+        - match:
+            names:
+              - "delegate_to_service"
+            argument_equals:
+              target_service_id: "telephone_external"
+          decision: "deny"
+          priority: 99
+        - match:
+            names:
+              - "delegate_to_service"
           decision: "confirm"
           priority: 20
-          description: "The engineer may hand off to another profile (e.g. to implement a fix), but only with user confirmation."
+          description: "The engineer may hand off to another profile (e.g. to implement a fix), but only with user confirmation. Internal/external-caller profiles are denied above."
         - match:
             names:
               - "create_github_issue"

--- a/docs/design/engineer_profile.md
+++ b/docs/design/engineer_profile.md
@@ -49,18 +49,29 @@ Source code tools validate all file paths using `PROJECT_ROOT` from `family_assi
 
 Delegation to and from the engineer profile is gated by confirmation rather than blocked outright:
 
-- **Into the engineer** (`delegate_to_service` with `target_service_id: "engineer"`): the rule in
-  every delegating profile is `confirm` (priority 99), so the main assistant or a complex-tasks run
-  can hand an investigation to the engineer once the user approves.
+- **Into the engineer** (`delegate_to_service` with `target_service_id: "engineer"`): a `confirm`
+  rule (priority 99) is present in every profile that can delegate at all. Profiles that inherit
+  `default_profile_settings` (e.g. `default_assistant`) get it from there; profiles that replace
+  `tools_policy` wholesale and still permit `delegate_to_service` — `browser_profile`, `telephone`,
+  and `complex_tasks` — each carry their own copy of the gate. The delegation tool only checks the
+  *source* profile's policy (and the target's `allowed_delegation_sources`), so the gate must live
+  on every source that can reach the engineer; otherwise a wholesale-replacing profile would allow
+  the engineer unconditionally.
 - **Out of the engineer**: the engineer's `tools_policy` allows `delegate_to_service` with a
   `confirm` decision, so the engineer can hand a fix or follow-up action to another profile — but
-  only after the user confirms.
+  only after the user confirms. Higher-priority (99) `deny` rules block hand-offs to the internal /
+  external-caller profiles that the ordinary delegating policies also deny (`reminder`,
+  `event_handler`, `telephone_external`), so confirmation cannot be used to start those reserved
+  profiles.
 
 The confirmation requirement preserves the engineer's read-only posture in practice: a human always
 approves before the engineer reaches outside its diagnostic sandbox (the engineer diagnoses and
 reports; a human or another profile implements fixes), while still letting investigation and
-hand-off flow without a hard block. Read-only delegation status tools (`get_delegation_status`,
-`list_delegations`) are allowed without confirmation so the engineer can track an async hand-off.
+hand-off flow without a hard block. The `delegate_to_service` confirmation prompt shows the full
+target, the (bounded, explicitly-truncation-marked) request text, and any attachment ids, so the
+approver can see exactly what diagnostic context is being handed off. Read-only delegation status
+tools (`get_delegation_status`, `list_delegations`) are allowed without confirmation so the engineer
+can track an async hand-off.
 
 ### Confirmation for Side Effects
 

--- a/docs/design/engineer_profile.md
+++ b/docs/design/engineer_profile.md
@@ -47,9 +47,20 @@ Source code tools validate all file paths using `PROJECT_ROOT` from `family_assi
 
 ### Delegation Security
 
-The profile uses `delegation_security_level: "blocked"` to prevent the engineer from delegating to
-other profiles. This is intentional: the engineer diagnoses and reports (via GitHub issue); a human
-or the main assistant implements fixes.
+Delegation to and from the engineer profile is gated by confirmation rather than blocked outright:
+
+- **Into the engineer** (`delegate_to_service` with `target_service_id: "engineer"`): the rule in
+  every delegating profile is `confirm` (priority 99), so the main assistant or a complex-tasks run
+  can hand an investigation to the engineer once the user approves.
+- **Out of the engineer**: the engineer's `tools_policy` allows `delegate_to_service` with a
+  `confirm` decision, so the engineer can hand a fix or follow-up action to another profile — but
+  only after the user confirms.
+
+The confirmation requirement preserves the engineer's read-only posture in practice: a human always
+approves before the engineer reaches outside its diagnostic sandbox (the engineer diagnoses and
+reports; a human or another profile implements fixes), while still letting investigation and
+hand-off flow without a hard block. Read-only delegation status tools (`get_delegation_status`,
+`list_delegations`) are allowed without confirmation so the engineer can track an async hand-off.
 
 ### Confirmation for Side Effects
 
@@ -83,7 +94,8 @@ code or modify files.
 
 ## Usage
 
-Activate via the `/engineer` slash command or by delegating to the `engineer` profile.
+Activate via the `/engineer` slash command or by delegating to the `engineer` profile (delegation
+into the engineer requires user confirmation).
 
 ## History
 

--- a/docs/design/engineer_profile.md
+++ b/docs/design/engineer_profile.md
@@ -65,13 +65,26 @@ Delegation to and from the engineer profile is gated by confirmation rather than
   profiles.
 
 The confirmation requirement preserves the engineer's read-only posture in practice: a human always
-approves before the engineer reaches outside its diagnostic sandbox (the engineer diagnoses and
+approves before the engineer hands work to a *different* profile (the engineer diagnoses and
 reports; a human or another profile implements fixes), while still letting investigation and
 hand-off flow without a hard block. The `delegate_to_service` confirmation prompt shows the full
-target, the (bounded, explicitly-truncation-marked) request text, and any attachment ids, so the
-approver can see exactly what diagnostic context is being handed off. Read-only delegation status
+target, the **complete** request text, and any attachment ids. So the approver can never
+rubber-stamp a silently-cut request, `delegate_to_service` refuses any request longer than
+`MAX_DELEGATION_REQUEST_CHARS` (3000 — well above the generic 1200-char field bound, and sized to
+keep the whole prompt within Telegram's single-message confirmation budget): the tool returns an
+error instead of delegating, and the confirmation prompt for such a request states plainly that the
+hand-off will be refused rather than displaying a partial body. Bulk content therefore belongs in an
+attachment (referenced via `attachment_ids`), not the request string. Read-only delegation status
 tools (`get_delegation_status`, `list_delegations`) are allowed without confirmation so the engineer
 can track an async hand-off.
+
+**Self-delegation.** `engineer → engineer` is *not* confirm-gated: the runtime injects a synthetic
+self-delegation `ALLOW` rule (in `_build_profile_policy_engine`) that, by design, lets every profile
+reach itself without confirmation and outranks the profile's own rules. This is intentional and
+consistent with the project-wide invariant that self-delegation is never a privilege escalation — an
+`engineer → engineer` hand-off stays entirely within the same read-only sandbox and confers no new
+capability. The confirmation gate therefore applies to delegation *between distinct* profiles, which
+is where the trust boundary is actually crossed.
 
 ### Confirmation for Side Effects
 

--- a/src/family_assistant/telegram/ui.py
+++ b/src/family_assistant/telegram/ui.py
@@ -92,6 +92,27 @@ def _truncate_confirmation_prompt_for_telegram(prompt_text: str) -> str:
     return prompt_text[:max_prompt_chars] + TELEGRAM_CONFIRMATION_TRUNCATION_NOTICE
 
 
+def confirmation_text_and_parse_mode(
+    prompt_text: str,
+) -> tuple[str, ParseMode | None]:
+    """Choose the message body and parse mode that stay within Telegram's limit.
+
+    MarkdownV2 escaping can expand the text past Telegram's single-message limit
+    even when the raw prompt fit — which would make ``send_message`` fail with a
+    length error and leave the user unable to approve. So only use MarkdownV2 when
+    the *converted* text still fits; otherwise fall back to the already
+    length-bounded plain text.
+    """
+    prompt_text_to_send = _truncate_confirmation_prompt_for_telegram(prompt_text)
+    if prompt_text_to_send != prompt_text:
+        # Already truncated; send as plain text (see _send_confirmation_message).
+        return prompt_text_to_send, None
+    converted_text, parse_mode_str = convert_to_telegram_markdown(prompt_text_to_send)
+    if parse_mode_str and len(converted_text) <= TELEGRAM_CONFIRMATION_MESSAGE_LIMIT:
+        return converted_text, ParseMode.MARKDOWN_V2
+    return prompt_text_to_send, None
+
+
 class TelegramConfirmationUIManager(ConfirmationUIManager):
     """Implementation of ConfirmationUIManager using Telegram Inline Keyboards."""
 
@@ -149,14 +170,7 @@ class TelegramConfirmationUIManager(ConfirmationUIManager):
         ])
 
         prompt_text_to_send = _truncate_confirmation_prompt_for_telegram(prompt_text)
-        if prompt_text_to_send == prompt_text:
-            text_to_send, parse_mode_str = convert_to_telegram_markdown(
-                prompt_text_to_send
-            )
-            parse_mode = ParseMode.MARKDOWN_V2 if parse_mode_str else None
-        else:
-            text_to_send = prompt_text_to_send
-            parse_mode = None
+        text_to_send, parse_mode = confirmation_text_and_parse_mode(prompt_text)
 
         try:
             message = await self.application.bot.send_message(

--- a/src/family_assistant/tools/confirmation.py
+++ b/src/family_assistant/tools/confirmation.py
@@ -25,6 +25,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 CONFIRMATION_VALUE_MAX_CHARS = 1200
 
+# A delegation hand-off is approved against its confirmation prompt, so the
+# approver must be able to read the ENTIRE delegated request — not a silently cut
+# slice. We therefore show the full request (well above the generic 1200-char
+# field bound) and refuse, rather than truncate, anything longer. The cap keeps
+# the whole prompt within Telegram's single-message confirmation budget
+# (TELEGRAM_CONFIRMATION_MESSAGE_LIMIT = 3800 in telegram/ui.py), reserving
+# headroom for the source prefix, field labels, the target id, attachment ids,
+# and code fences. Bulk content belongs in an attachment, not the request string.
+MAX_DELEGATION_REQUEST_CHARS = 3000
+
 
 def _markdown_code_block(text: str) -> str:
     """Render text as inert markdown using a fence longer than any content fence."""
@@ -402,9 +412,22 @@ async def render_delegate_to_service_confirmation(
     )
 
     _ = context
+    if len(user_request) > MAX_DELEGATION_REQUEST_CHARS:
+        # delegate_to_service_tool refuses requests over this length, so never
+        # show a partial body the approver might rubber-stamp — say plainly that
+        # the hand-off will be refused.
+        request_field = (
+            f"- Request: ⚠️ This request is {len(user_request)} characters, longer than the "
+            f"{MAX_DELEGATION_REQUEST_CHARS}-character limit that keeps it fully reviewable here. "
+            "The delegation will be refused — ask the delegating profile to shorten the request or "
+            "move bulk content into an attachment."
+        )
+    else:
+        request_field = f"- Request:\n{_markdown_code_block(user_request)}"
+
     fields = [
         _confirmation_field("Target profile", target_service_id or "target service"),
-        _confirmation_field("Request", user_request),
+        request_field,
     ]
     if attachment_ids:
         fields.append(_confirmation_field("Attachments", ", ".join(attachment_ids)))

--- a/src/family_assistant/tools/confirmation.py
+++ b/src/family_assistant/tools/confirmation.py
@@ -394,19 +394,21 @@ async def render_delegate_to_service_confirmation(
     """Render a confirmation prompt for delegating a task to another service."""
     target_service_id = str(args.get("target_service_id", "")).strip()
     user_request = str(args.get("user_request", "")).strip()
-
-    prompt_target = target_service_id if target_service_id else "target service"
-    request_preview = user_request[:100]
-    if user_request and len(user_request) > 100:
-        request_preview += "..."
+    raw_attachment_ids = args.get("attachment_ids")
+    attachment_ids = (
+        [str(a) for a in raw_attachment_ids]
+        if isinstance(raw_attachment_ids, (list, tuple))
+        else []
+    )
 
     _ = context
-    return (
-        "Do you want to delegate this task:\n"
-        f"{_markdown_code_block(request_preview)}\n"
-        "to this profile?\n"
-        f"{_markdown_code_block(prompt_target)}"
-    )
+    fields = [
+        _confirmation_field("Target profile", target_service_id or "target service"),
+        _confirmation_field("Request", user_request),
+    ]
+    if attachment_ids:
+        fields.append(_confirmation_field("Attachments", ", ".join(attachment_ids)))
+    return "Do you want to delegate this task to another profile?\n" + "\n".join(fields)
 
 
 # Mapping of tool names to their confirmation renderers

--- a/src/family_assistant/tools/confirmation.py
+++ b/src/family_assistant/tools/confirmation.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Protocol, cast
 from family_assistant import calendar_integration
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from zoneinfo import ZoneInfo
 
     from family_assistant.tools.infrastructure import ToolsProvider
@@ -413,9 +414,9 @@ async def render_delegate_to_service_confirmation(
 
     _ = context
     if len(user_request) > MAX_DELEGATION_REQUEST_CHARS:
-        # delegate_to_service_tool refuses requests over this length, so never
-        # show a partial body the approver might rubber-stamp — say plainly that
-        # the hand-off will be refused.
+        # A confirm-gated delegation over this length is refused before it runs
+        # (see confirmation_payload_block_reason), so never show a partial body
+        # the approver might rubber-stamp — say plainly that it will be refused.
         request_field = (
             f"- Request: ⚠️ This request is {len(user_request)} characters, longer than the "
             f"{MAX_DELEGATION_REQUEST_CHARS}-character limit that keeps it fully reviewable here. "
@@ -432,6 +433,44 @@ async def render_delegate_to_service_confirmation(
     if attachment_ids:
         fields.append(_confirmation_field("Attachments", ", ".join(attachment_ids)))
     return "Do you want to delegate this task to another profile?\n" + "\n".join(fields)
+
+
+def over_length_delegation_block_reason(user_request: str) -> str | None:
+    """Return an error if a delegation request is too long to confirm, else None.
+
+    A confirm-gated hand-off is approved against its confirmation prompt, so a
+    request that cannot be shown there in full must be refused rather than
+    delegated on the strength of a partial preview. This applies only to
+    delegations that are actually confirm-gated; unconfirmed hand-offs are not
+    size-capped (bulk content there is legitimate and never shown for approval).
+    """
+    if len(user_request) <= MAX_DELEGATION_REQUEST_CHARS:
+        return None
+    return (
+        f"Error: delegation request is {len(user_request)} characters, which exceeds the "
+        f"{MAX_DELEGATION_REQUEST_CHARS}-character limit that keeps it fully reviewable in a "
+        "confirmation prompt. Shorten the request, or move bulk content into an attachment and "
+        "reference it via attachment_ids."
+    )
+
+
+def confirmation_payload_block_reason(
+    tool_name: str,
+    arguments: Mapping[str, object],
+) -> str | None:
+    """Return why a confirm-gated tool call must be refused before prompting, else None.
+
+    Lets the policy layer refuse a call whose confirmation prompt could not show
+    the approver the full payload they would be approving, instead of rendering a
+    truncated or misleading prompt. Only invoked once a call is known to be
+    confirm-gated, so it never constrains unconfirmed calls. Currently only
+    ``delegate_to_service`` is bounded.
+    """
+    if tool_name == "delegate_to_service":
+        return over_length_delegation_block_reason(
+            str(arguments.get("user_request", ""))
+        )
+    return None
 
 
 # Mapping of tool names to their confirmation renderers

--- a/src/family_assistant/tools/infrastructure.py
+++ b/src/family_assistant/tools/infrastructure.py
@@ -856,6 +856,19 @@ class PolicyEnforcingToolsProvider(ToolsProvider):
             raise ToolPolicyDeniedError(name, evaluation.reason or "denied by policy")
 
         if evaluation.decision is ToolPolicyDecision.CONFIRM:
+            from family_assistant.tools.confirmation import (  # noqa: PLC0415
+                confirmation_payload_block_reason,
+            )
+
+            # Refuse a confirm-gated call whose confirmation prompt could not show
+            # the approver the full payload, instead of rendering a misleading
+            # prompt. Scoped to confirm-gated calls, so unconfirmed calls are
+            # never constrained by it.
+            block_reason = confirmation_payload_block_reason(name, arguments)
+            if block_reason is not None:
+                logger.info("Refusing confirm-gated tool '%s': %s", name, block_reason)
+                return ToolResult(text=block_reason, attachments=None)
+
             logger.info("Tool '%s' requires policy confirmation.", name)
             if not context.request_confirmation_callback:
                 raise ToolNotFoundError(name, type(self).__name__)

--- a/src/family_assistant/tools/infrastructure.py
+++ b/src/family_assistant/tools/infrastructure.py
@@ -25,6 +25,7 @@ from typing import (
 )
 
 from family_assistant.tools.attachment_utils import process_attachment_arguments
+from family_assistant.tools.confirmation import confirmation_payload_block_reason
 from family_assistant.tools.metadata import (
     ToolDescriptor,
     ToolRegistration,
@@ -856,10 +857,6 @@ class PolicyEnforcingToolsProvider(ToolsProvider):
             raise ToolPolicyDeniedError(name, evaluation.reason or "denied by policy")
 
         if evaluation.decision is ToolPolicyDecision.CONFIRM:
-            from family_assistant.tools.confirmation import (  # noqa: PLC0415
-                confirmation_payload_block_reason,
-            )
-
             # Refuse a confirm-gated call whose confirmation prompt could not show
             # the approver the full payload, instead of rendering a misleading
             # prompt. Scoped to confirm-gated calls, so unconfirmed calls are

--- a/src/family_assistant/tools/services.py
+++ b/src/family_assistant/tools/services.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 from family_assistant.llm.content_parts import attachment_content, text_content
 from family_assistant.storage.delegation_runs import TERMINAL_DELEGATION_STATUSES
+from family_assistant.tools.confirmation import MAX_DELEGATION_REQUEST_CHARS
 from family_assistant.tools.types import (
     ConfirmationOutcome,
     ToolAttachment,
@@ -554,6 +555,27 @@ async def delegate_to_service_tool(
     logger.info(
         f"Executing delegate_to_service_tool: target='{target_service_id}', request='{user_request[:50]}...', confirm={confirm_delegation}"
     )
+
+    if len(user_request) > MAX_DELEGATION_REQUEST_CHARS:
+        # A confirm-gated delegation is approved against its confirmation prompt;
+        # an over-long request cannot be shown in full there, so refuse it rather
+        # than hand off context the approver could not fully review. Bulk content
+        # belongs in an attachment, which is surfaced separately.
+        logger.warning(
+            "Refusing delegation to '%s': request is %d chars (limit %d).",
+            target_service_id,
+            len(user_request),
+            MAX_DELEGATION_REQUEST_CHARS,
+        )
+        return ToolResult(
+            text=(
+                f"Error: delegation request is {len(user_request)} characters, which exceeds the "
+                f"{MAX_DELEGATION_REQUEST_CHARS}-character limit that keeps it fully reviewable in a "
+                "confirmation prompt. Shorten the request, or move bulk content into an attachment "
+                "and reference it via attachment_ids."
+            ),
+            attachments=None,
+        )
 
     if (
         not exec_context.processing_service

--- a/src/family_assistant/tools/services.py
+++ b/src/family_assistant/tools/services.py
@@ -14,7 +14,10 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 from family_assistant.llm.content_parts import attachment_content, text_content
 from family_assistant.storage.delegation_runs import TERMINAL_DELEGATION_STATUSES
-from family_assistant.tools.confirmation import MAX_DELEGATION_REQUEST_CHARS
+from family_assistant.tools.confirmation import (
+    MAX_DELEGATION_REQUEST_CHARS,
+    over_length_delegation_block_reason,
+)
 from family_assistant.tools.types import (
     ConfirmationOutcome,
     ToolAttachment,
@@ -556,27 +559,6 @@ async def delegate_to_service_tool(
         f"Executing delegate_to_service_tool: target='{target_service_id}', request='{user_request[:50]}...', confirm={confirm_delegation}"
     )
 
-    if len(user_request) > MAX_DELEGATION_REQUEST_CHARS:
-        # A confirm-gated delegation is approved against its confirmation prompt;
-        # an over-long request cannot be shown in full there, so refuse it rather
-        # than hand off context the approver could not fully review. Bulk content
-        # belongs in an attachment, which is surfaced separately.
-        logger.warning(
-            "Refusing delegation to '%s': request is %d chars (limit %d).",
-            target_service_id,
-            len(user_request),
-            MAX_DELEGATION_REQUEST_CHARS,
-        )
-        return ToolResult(
-            text=(
-                f"Error: delegation request is {len(user_request)} characters, which exceeds the "
-                f"{MAX_DELEGATION_REQUEST_CHARS}-character limit that keeps it fully reviewable in a "
-                "confirmation prompt. Shorten the request, or move bulk content into an attachment "
-                "and reference it via attachment_ids."
-            ),
-            attachments=None,
-        )
-
     if (
         not exec_context.processing_service
         or not exec_context.processing_service.processing_services_registry
@@ -626,6 +608,21 @@ async def delegate_to_service_tool(
     actual_confirm_delegation = confirm_delegation
 
     if actual_confirm_delegation:
+        # This hand-off will be approved against a confirmation prompt, so refuse
+        # a request too long to show there in full rather than ask the user to
+        # approve a payload they cannot fully review. (Policy-confirm-gated calls
+        # are bounded earlier, in PolicyEnforcingToolsProvider.) Unconfirmed
+        # delegations are intentionally not size-capped.
+        over_length_reason = over_length_delegation_block_reason(user_request)
+        if over_length_reason is not None:
+            logger.warning(
+                "Refusing confirm-gated delegation to '%s': request is %d chars (limit %d).",
+                target_service_id,
+                len(user_request),
+                MAX_DELEGATION_REQUEST_CHARS,
+            )
+            return ToolResult(text=over_length_reason, attachments=None)
+
         if not exec_context.request_confirmation_callback:
             logger.error(
                 f"Confirmation required for delegating to '{target_service_id}', but no confirmation callback is available. Aborting delegation."

--- a/tests/functional/tools/test_defaults_tool_policy_parity.py
+++ b/tests/functional/tools/test_defaults_tool_policy_parity.py
@@ -189,3 +189,74 @@ def test_ucp_tools_are_default_on_demand_and_not_confirm_gated() -> None:
             ).decision
             == ToolPolicyDecision.ALLOW
         )
+
+
+def _delegate_descriptor() -> ToolDescriptor:
+    for descriptor in LOCAL_TOOL_DESCRIPTORS:
+        if descriptor.name == "delegate_to_service":
+            return descriptor
+    raise AssertionError("delegate_to_service descriptor not found")
+
+
+def test_delegation_to_engineer_is_confirm_gated_not_blocked() -> None:
+    default_settings, profiles = _load_resolved_profiles()
+    profile_by_id = {profile.id: profile for profile in profiles}
+    delegate = _delegate_descriptor()
+
+    source_engines = {
+        "default_profile_settings": PolicyEngine.from_policy_config(
+            default_settings.tools_policy
+        ),
+        "complex_tasks": PolicyEngine.from_policy_config(
+            profile_by_id["complex_tasks"].tools_policy
+        ),
+        "telephone": PolicyEngine.from_policy_config(
+            profile_by_id["telephone"].tools_policy
+        ),
+    }
+
+    for source_id, engine in source_engines.items():
+        to_engineer = engine.evaluate_for_execution(
+            delegate,
+            arguments={"target_service_id": "engineer"},
+            can_confirm=True,
+        )
+        assert to_engineer.decision is ToolPolicyDecision.CONFIRM, source_id
+
+        # Without a confirmation channel the confirm decision degrades to deny,
+        # so the engineer is never reached unattended.
+        to_engineer_unattended = engine.evaluate_for_execution(
+            delegate,
+            arguments={"target_service_id": "engineer"},
+            can_confirm=False,
+        )
+        assert to_engineer_unattended.decision is ToolPolicyDecision.DENY, source_id
+
+        # Profiles that are blocked outright (e.g. reminder) stay blocked.
+        to_reminder = engine.evaluate_for_execution(
+            delegate,
+            arguments={"target_service_id": "reminder"},
+            can_confirm=True,
+        )
+        assert to_reminder.decision is ToolPolicyDecision.DENY, source_id
+
+
+def test_engineer_can_delegate_out_only_with_confirmation() -> None:
+    _, profiles = _load_resolved_profiles()
+    engineer = {profile.id: profile for profile in profiles}["engineer"]
+    engine = PolicyEngine.from_policy_config(engineer.tools_policy)
+    delegate = _delegate_descriptor()
+
+    outbound = engine.evaluate_for_execution(
+        delegate,
+        arguments={"target_service_id": "default_assistant"},
+        can_confirm=True,
+    )
+    assert outbound.decision is ToolPolicyDecision.CONFIRM
+
+    outbound_unattended = engine.evaluate_for_execution(
+        delegate,
+        arguments={"target_service_id": "default_assistant"},
+        can_confirm=False,
+    )
+    assert outbound_unattended.decision is ToolPolicyDecision.DENY

--- a/tests/functional/tools/test_defaults_tool_policy_parity.py
+++ b/tests/functional/tools/test_defaults_tool_policy_parity.py
@@ -203,6 +203,10 @@ def test_delegation_to_engineer_is_confirm_gated_not_blocked() -> None:
     profile_by_id = {profile.id: profile for profile in profiles}
     delegate = _delegate_descriptor()
 
+    # Every profile that can delegate at all must route the engineer through a
+    # confirmation gate (never an unconditional allow). browser_profile,
+    # telephone, and complex_tasks each replace tools_policy wholesale, so each
+    # needs its own gate; default_assistant inherits default_profile_settings.
     source_engines = {
         "default_profile_settings": PolicyEngine.from_policy_config(
             default_settings.tools_policy
@@ -212,6 +216,9 @@ def test_delegation_to_engineer_is_confirm_gated_not_blocked() -> None:
         ),
         "telephone": PolicyEngine.from_policy_config(
             profile_by_id["telephone"].tools_policy
+        ),
+        "browser_profile": PolicyEngine.from_policy_config(
+            profile_by_id["browser_profile"].tools_policy
         ),
     }
 
@@ -232,8 +239,9 @@ def test_delegation_to_engineer_is_confirm_gated_not_blocked() -> None:
         )
         assert to_engineer_unattended.decision is ToolPolicyDecision.DENY, source_id
 
-        # Profiles that are blocked outright (e.g. reminder) stay blocked.
-        to_reminder = engine.evaluate_for_execution(
+    # Profiles that block specific internal targets outright keep blocking them.
+    for source_id in ("default_profile_settings", "complex_tasks", "telephone"):
+        to_reminder = source_engines[source_id].evaluate_for_execution(
             delegate,
             arguments={"target_service_id": "reminder"},
             can_confirm=True,
@@ -260,3 +268,13 @@ def test_engineer_can_delegate_out_only_with_confirmation() -> None:
         can_confirm=False,
     )
     assert outbound_unattended.decision is ToolPolicyDecision.DENY
+
+    # The engineer must not reach internal/external-caller profiles that the
+    # ordinary delegating policies deny outright, even with confirmation.
+    for blocked_target in ("reminder", "event_handler", "telephone_external"):
+        outbound_blocked = engine.evaluate_for_execution(
+            delegate,
+            arguments={"target_service_id": blocked_target},
+            can_confirm=True,
+        )
+        assert outbound_blocked.decision is ToolPolicyDecision.DENY, blocked_target

--- a/tests/functional/tools/test_policy_enforcing_provider.py
+++ b/tests/functional/tools/test_policy_enforcing_provider.py
@@ -26,7 +26,10 @@ from family_assistant.tools.types import ToolExecutionContext, ToolResult
 
 if TYPE_CHECKING:
     from family_assistant.processing import ProcessingService
-    from family_assistant.tools.types import ToolDefinition
+    from family_assistant.tools.types import (
+        RequestConfirmationCallback,
+        ToolDefinition,
+    )
 
 
 def _names(definitions: list[ToolDefinition]) -> list[str]:
@@ -60,7 +63,9 @@ def _exec_context(
         turn_id=None,
         db_context=MagicMock(spec=DatabaseContext),
         processing_service=cast("ProcessingService", processing_service),
-        request_confirmation_callback=confirmation_callback,  # type: ignore[arg-type]
+        request_confirmation_callback=cast(
+            "RequestConfirmationCallback | None", confirmation_callback
+        ),
         clock=None,
         home_assistant_client=None,
         event_sources=None,

--- a/tests/functional/tools/test_policy_enforcing_provider.py
+++ b/tests/functional/tools/test_policy_enforcing_provider.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, MagicMock
+from zoneinfo import ZoneInfo
 
 import pytest
 
+from family_assistant.storage.context import DatabaseContext
 from family_assistant.tools import (
     LOCAL_TOOL_REGISTRATIONS,
     LocalToolsProvider,
     PolicyEnforcingToolsProvider,
 )
+from family_assistant.tools.confirmation import MAX_DELEGATION_REQUEST_CHARS
 from family_assistant.tools.metadata import ToolTag
 from family_assistant.tools.policy import (
     PolicyEngine,
@@ -17,13 +22,106 @@ from family_assistant.tools.policy import (
     ToolPolicyConfig,
     ToolPolicyDecision,
 )
+from family_assistant.tools.types import ToolExecutionContext, ToolResult
 
 if TYPE_CHECKING:
+    from family_assistant.processing import ProcessingService
     from family_assistant.tools.types import ToolDefinition
 
 
 def _names(definitions: list[ToolDefinition]) -> list[str]:
     return [definition["function"]["name"] for definition in definitions]
+
+
+def _delegate_policy(decision: ToolPolicyDecision) -> PolicyEngine:
+    return PolicyEngine.from_policy_config(
+        ToolPolicyConfig(
+            default_decision=ToolPolicyDecision.DENY,
+            rules=[
+                PolicyRule(
+                    match=ToolMatcher(names=["delegate_to_service"]),
+                    decision=decision,
+                    priority=10,
+                ),
+            ],
+        )
+    )
+
+
+def _exec_context(
+    *,
+    confirmation_callback: object | None,
+    processing_service: object | None,
+) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        interface_type="test",
+        conversation_id="conversation",
+        user_name="User",
+        turn_id=None,
+        db_context=MagicMock(spec=DatabaseContext),
+        processing_service=cast("ProcessingService", processing_service),
+        request_confirmation_callback=confirmation_callback,  # type: ignore[arg-type]
+        clock=None,
+        home_assistant_client=None,
+        event_sources=None,
+        attachment_registry=None,
+        camera_backend=None,
+        timezone=ZoneInfo("UTC"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_confirm_gated_delegation_refuses_over_length_request() -> None:
+    policy_provider = PolicyEnforcingToolsProvider(
+        wrapped_provider=LocalToolsProvider(registrations=LOCAL_TOOL_REGISTRATIONS),
+        policy_engine=_delegate_policy(ToolPolicyDecision.CONFIRM),
+    )
+    confirmation_callback = AsyncMock()
+    context = _exec_context(
+        confirmation_callback=confirmation_callback, processing_service=None
+    )
+
+    result = await policy_provider.execute_tool(
+        "delegate_to_service",
+        {
+            "target_service_id": "engineer",
+            "user_request": "x" * (MAX_DELEGATION_REQUEST_CHARS + 1),
+        },
+        context,
+    )
+
+    assert isinstance(result, ToolResult)
+    assert result.text is not None
+    assert str(MAX_DELEGATION_REQUEST_CHARS) in result.text
+    # The over-long request is refused before a confirmation prompt is ever shown.
+    confirmation_callback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_delegation_is_not_size_capped() -> None:
+    policy_provider = PolicyEnforcingToolsProvider(
+        wrapped_provider=LocalToolsProvider(registrations=LOCAL_TOOL_REGISTRATIONS),
+        policy_engine=_delegate_policy(ToolPolicyDecision.ALLOW),
+    )
+    # No registry, so the underlying tool reports that — proving the size guard
+    # did NOT short-circuit an ordinary (unconfirmed) hand-off.
+    source_service = SimpleNamespace(processing_services_registry=None)
+    context = _exec_context(
+        confirmation_callback=None, processing_service=source_service
+    )
+
+    result = await policy_provider.execute_tool(
+        "delegate_to_service",
+        {
+            "target_service_id": "complex_tasks",
+            "user_request": "x" * (MAX_DELEGATION_REQUEST_CHARS + 1),
+        },
+        context,
+    )
+
+    text = result.get_text() if isinstance(result, ToolResult) else str(result)
+    assert str(MAX_DELEGATION_REQUEST_CHARS) not in text
+    assert "registry is not available" in text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/telegram/test_confirmation_message_length.py
+++ b/tests/unit/telegram/test_confirmation_message_length.py
@@ -1,0 +1,53 @@
+"""Tests that Telegram confirmation messages stay within the send limit.
+
+MarkdownV2 escaping expands the prompt (a backslash before each reserved
+character), so a prompt that fits raw can overflow Telegram's single-message
+limit once converted. When that happens the message must fall back to the
+already length-bounded plain text rather than be sent over-limit and fail —
+otherwise the user can never approve the confirmation.
+"""
+
+from __future__ import annotations
+
+from telegram.constants import ParseMode
+
+from family_assistant.telegram.ui import (
+    TELEGRAM_CONFIRMATION_MESSAGE_LIMIT,
+    confirmation_text_and_parse_mode,
+)
+
+
+def _select(prompt_text: str) -> tuple[str, ParseMode | None]:
+    return confirmation_text_and_parse_mode(prompt_text)
+
+
+def test_markdown_is_used_when_converted_text_fits() -> None:
+    # A short prompt with a reserved character converts to MarkdownV2 and fits.
+    text, parse_mode = _select("a_b reserved")
+    assert parse_mode is ParseMode.MARKDOWN_V2
+    assert "\\_" in text
+
+
+def test_falls_back_to_plain_text_when_markdown_overflows_limit() -> None:
+    # Raw length fits, but escaping each reserved '.' to '\.' doubles it, pushing
+    # the converted text past the limit (mimicking a log/source snippet).
+    reserved_heavy = "." * 3000
+    assert len(reserved_heavy) <= TELEGRAM_CONFIRMATION_MESSAGE_LIMIT
+
+    text, parse_mode = _select(reserved_heavy)
+
+    assert parse_mode is None
+    assert text == reserved_heavy
+    assert len(text) <= TELEGRAM_CONFIRMATION_MESSAGE_LIMIT
+
+
+def test_selected_text_never_exceeds_the_limit() -> None:
+    for prompt in (
+        "short",
+        "a_b*c[d]e",
+        "." * 3000,
+        "(arg) " * 900,
+        "x" * (TELEGRAM_CONFIRMATION_MESSAGE_LIMIT * 2),
+    ):
+        text, _ = _select(prompt)
+        assert len(text) <= TELEGRAM_CONFIRMATION_MESSAGE_LIMIT, prompt

--- a/tests/unit/tools/test_delegate_confirmation_renderer.py
+++ b/tests/unit/tools/test_delegate_confirmation_renderer.py
@@ -15,6 +15,7 @@ import pytest
 
 from family_assistant.tools.confirmation import (
     CONFIRMATION_VALUE_MAX_CHARS,
+    MAX_DELEGATION_REQUEST_CHARS,
     render_delegate_to_service_confirmation,
 )
 
@@ -46,15 +47,36 @@ async def test_delegate_confirmation_shows_target_request_and_attachments() -> N
 
 
 @pytest.mark.asyncio
-async def test_delegate_confirmation_marks_truncated_request() -> None:
-    long_request = "x" * (CONFIRMATION_VALUE_MAX_CHARS + 500)
+async def test_delegate_confirmation_shows_request_in_full_above_generic_bound() -> (
+    None
+):
+    # A request longer than the generic 1200-char field bound but within the
+    # delegation budget must still be shown in full so the approver reviews the
+    # complete payload.
+    request = "x" * (CONFIRMATION_VALUE_MAX_CHARS + 500)
+    assert len(request) <= MAX_DELEGATION_REQUEST_CHARS
 
     prompt = await render_delegate_to_service_confirmation(
-        {"target_service_id": "complex_tasks", "user_request": long_request},
+        {"target_service_id": "complex_tasks", "user_request": request},
         _no_context(),
     )
 
-    # The user is shown a bounded slice and explicitly told it was truncated,
-    # so a long request cannot hide sensitive content behind a short prefix.
-    assert "... [truncated]" in prompt
-    assert long_request not in prompt
+    assert request in prompt
+    assert "[truncated]" not in prompt
+    assert "will be refused" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_delegate_confirmation_refuses_over_limit_request() -> None:
+    over_limit = "y" * (MAX_DELEGATION_REQUEST_CHARS + 1)
+
+    prompt = await render_delegate_to_service_confirmation(
+        {"target_service_id": "engineer", "user_request": over_limit},
+        _no_context(),
+    )
+
+    # No partial body is shown (which could be rubber-stamped); the prompt states
+    # the hand-off will be refused so the approver isn't misled.
+    assert over_limit not in prompt
+    assert "will be refused" in prompt
+    assert str(len(over_limit)) in prompt

--- a/tests/unit/tools/test_delegate_confirmation_renderer.py
+++ b/tests/unit/tools/test_delegate_confirmation_renderer.py
@@ -1,0 +1,60 @@
+"""Unit tests for the delegate_to_service confirmation renderer.
+
+The confirmation prompt is the sole safeguard before a profile (notably the
+read-only engineer) hands its context to another profile, so the user must be
+able to review the full delegated request, its target, and any attachments —
+and be told explicitly when content is truncated rather than silently shown a
+short prefix.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from family_assistant.tools.confirmation import (
+    CONFIRMATION_VALUE_MAX_CHARS,
+    render_delegate_to_service_confirmation,
+)
+
+if TYPE_CHECKING:
+    from family_assistant.tools.types import ToolExecutionContext
+
+
+def _no_context() -> ToolExecutionContext:
+    # The renderer ignores its context argument.
+    return cast("ToolExecutionContext", None)
+
+
+@pytest.mark.asyncio
+async def test_delegate_confirmation_shows_target_request_and_attachments() -> None:
+    prompt = await render_delegate_to_service_confirmation(
+        {
+            "target_service_id": "default_assistant",
+            "user_request": "Please apply the fix in services.py",
+            "attachment_ids": ["att-1", "att-2"],
+        },
+        _no_context(),
+    )
+
+    assert "default_assistant" in prompt
+    assert "Please apply the fix in services.py" in prompt
+    assert "att-1" in prompt
+    assert "att-2" in prompt
+    assert "[truncated]" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_delegate_confirmation_marks_truncated_request() -> None:
+    long_request = "x" * (CONFIRMATION_VALUE_MAX_CHARS + 500)
+
+    prompt = await render_delegate_to_service_confirmation(
+        {"target_service_id": "complex_tasks", "user_request": long_request},
+        _no_context(),
+    )
+
+    # The user is shown a bounded slice and explicitly told it was truncated,
+    # so a long request cannot hide sensitive content behind a short prefix.
+    assert "... [truncated]" in prompt
+    assert long_request not in prompt

--- a/tests/unit/tools/test_delegate_confirmation_renderer.py
+++ b/tests/unit/tools/test_delegate_confirmation_renderer.py
@@ -16,6 +16,8 @@ import pytest
 from family_assistant.tools.confirmation import (
     CONFIRMATION_VALUE_MAX_CHARS,
     MAX_DELEGATION_REQUEST_CHARS,
+    confirmation_payload_block_reason,
+    over_length_delegation_block_reason,
     render_delegate_to_service_confirmation,
 )
 
@@ -80,3 +82,42 @@ async def test_delegate_confirmation_refuses_over_limit_request() -> None:
     assert over_limit not in prompt
     assert "will be refused" in prompt
     assert str(len(over_limit)) in prompt
+
+
+def test_over_length_block_reason_only_fires_above_the_cap() -> None:
+    assert (
+        over_length_delegation_block_reason("x" * MAX_DELEGATION_REQUEST_CHARS) is None
+    )
+    reason = over_length_delegation_block_reason(
+        "x" * (MAX_DELEGATION_REQUEST_CHARS + 1)
+    )
+    assert reason is not None
+    assert str(MAX_DELEGATION_REQUEST_CHARS) in reason
+    assert "exceeds" in reason
+
+
+def test_confirmation_payload_block_reason_only_applies_to_delegation() -> None:
+    over_limit = "x" * (MAX_DELEGATION_REQUEST_CHARS + 1)
+
+    # A non-delegation tool is never size-capped by this hook.
+    assert (
+        confirmation_payload_block_reason(
+            "add_calendar_event", {"user_request": over_limit}
+        )
+        is None
+    )
+
+    # A delegation with an over-limit request is refused.
+    assert (
+        confirmation_payload_block_reason(
+            "delegate_to_service", {"user_request": over_limit}
+        )
+        is not None
+    )
+    # A delegation within the cap is allowed through.
+    assert (
+        confirmation_payload_block_reason(
+            "delegate_to_service", {"user_request": "short"}
+        )
+        is None
+    )

--- a/tests/unit/tools/test_delegation_policy.py
+++ b/tests/unit/tools/test_delegation_policy.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from zoneinfo import ZoneInfo
 
 import pytest
 
 from family_assistant.storage.context import DatabaseContext
+from family_assistant.tools.confirmation import MAX_DELEGATION_REQUEST_CHARS
 from family_assistant.tools.services import delegate_to_service_tool
 from family_assistant.tools.types import ToolExecutionContext, ToolResult
 
@@ -56,3 +57,51 @@ async def test_delegate_to_service_blocks_disallowed_source_profile() -> None:
     assert result.text is not None
     assert "source_profile" in result.text
     assert "not permitted to delegate" in result.text
+
+
+@pytest.mark.asyncio
+async def test_delegate_to_service_refuses_over_length_request() -> None:
+    target_handler = AsyncMock()
+    target_service = SimpleNamespace(
+        service_config=SimpleNamespace(
+            id="target_profile",
+            allowed_delegation_sources=None,
+        ),
+        handle_chat_interaction=target_handler,
+    )
+    source_service = SimpleNamespace(
+        service_config=SimpleNamespace(
+            id="source_profile",
+            tools_config=SimpleNamespace(confirmation_timeout_seconds=10.0),
+        ),
+        processing_services_registry={"target_profile": target_service},
+    )
+
+    context = ToolExecutionContext(
+        interface_type="test",
+        conversation_id="conversation",
+        user_name="User",
+        turn_id=None,
+        db_context=MagicMock(spec=DatabaseContext),
+        processing_service=cast("ProcessingService", source_service),
+        clock=None,
+        home_assistant_client=None,
+        event_sources=None,
+        attachment_registry=None,
+        camera_backend=None,
+        timezone=ZoneInfo("UTC"),
+    )
+
+    over_limit = "x" * (MAX_DELEGATION_REQUEST_CHARS + 1)
+    result = await delegate_to_service_tool(
+        exec_context=context,
+        target_service_id="target_profile",
+        user_request=over_limit,
+    )
+
+    assert isinstance(result, ToolResult)
+    assert result.text is not None
+    assert str(MAX_DELEGATION_REQUEST_CHARS) in result.text
+    assert "exceeds" in result.text
+    # The over-long request must never reach the target profile.
+    target_handler.assert_not_awaited()

--- a/tests/unit/tools/test_delegation_policy.py
+++ b/tests/unit/tools/test_delegation_policy.py
@@ -60,7 +60,9 @@ async def test_delegate_to_service_blocks_disallowed_source_profile() -> None:
 
 
 @pytest.mark.asyncio
-async def test_delegate_to_service_refuses_over_length_request() -> None:
+async def test_delegate_to_service_refuses_over_length_request_when_confirming() -> (
+    None
+):
     target_handler = AsyncMock()
     target_service = SimpleNamespace(
         service_config=SimpleNamespace(
@@ -93,10 +95,13 @@ async def test_delegate_to_service_refuses_over_length_request() -> None:
     )
 
     over_limit = "x" * (MAX_DELEGATION_REQUEST_CHARS + 1)
+    # confirm_delegation=True means this hand-off will be approved against a
+    # confirmation prompt, so the over-long request must be refused.
     result = await delegate_to_service_tool(
         exec_context=context,
         target_service_id="target_profile",
         user_request=over_limit,
+        confirm_delegation=True,
     )
 
     assert isinstance(result, ToolResult)


### PR DESCRIPTION
## Summary

The engineer profile previously blocked delegation outright in both directions. This replaces the hard block with **confirmation gating**, so a human always approves before the engineer is reached or reaches outside its read-only sandbox.

### Delegation *into* the engineer
Every delegating profile (`default_profile_settings`, `telephone`, `complex_tasks`) had a hard `deny` rule for `delegate_to_service` → `target_service_id: "engineer"` at priority 99. These are now `confirm`. Because the policy engine degrades a `confirm` decision to `deny` when no confirmation channel is available (`can_confirm=False`), unattended/voice contexts still can't reach the engineer silently.

### Delegation *out of* the engineer
The engineer's `tools_policy` previously gave it no `delegate_to_service` access. It now allows `delegate_to_service` with a `confirm` decision (so it can hand a fix off to another profile, but only with user approval), plus read-only `get_delegation_status` / `list_delegations` so it can track an async hand-off.

### Docs & prompt
- Engineer system prompt: "You CANNOT delegate" → "You CAN delegate… but only after the user confirms".
- `docs/design/engineer_profile.md` — rewrote the Delegation Security section.
- `AGENTS.md` — updated the `Engineer Profile [B]` description.

## Security note
This is a deliberate relaxation of the engineer's Rule-of-Two `[B]` posture — the engineer can now reach state-changing/external-comms profiles, with **user confirmation as the sole safeguard**. The `confirm → deny` degradation keeps unattended contexts safe, but the human approval is now load-bearing.

## Testing
Added two tests to `test_defaults_tool_policy_parity.py`:
- `test_delegation_to_engineer_is_confirm_gated_not_blocked` — each delegating profile resolves engineer to `CONFIRM` (and to `DENY` without a confirmation channel), while outright-blocked targets like `reminder` stay `DENY`.
- `test_engineer_can_delegate_out_only_with_confirmation` — the engineer's outbound `delegate_to_service` is `CONFIRM`, degrading to `DENY` unattended.

All targeted tests pass (22 policy/delegation + 131 profile/config tests); lint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZmCNAYj6CAJK6hmjU11ac)_