### PR TITLE
Merge profile tools_config with inherited defaults

### DIFF
--- a/src/family_assistant/config_loader.py
+++ b/src/family_assistant/config_loader.py
@@ -33,6 +33,10 @@ from .config_sources import deep_merge_dicts, load_yaml_file
 logger = logging.getLogger(__name__)
 
 SYSTEM_PROMPT_DOCS_KEY = "system_prompt_docs"
+ADDITIVE_TOOLS_CONFIG_LIST_KEYS = frozenset({
+    "on_demand_local_tools",
+    "on_demand_mcp_server_ids",
+})
 
 # Default paths
 # defaults.yaml: Shipped with the application, contains default configuration
@@ -209,6 +213,34 @@ def get_nested_value(
             return default
         current = current[key]
     return current
+
+
+def merge_profile_tools_config(
+    default_tools_config: dict[str, Any],
+    profile_tools_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge profile tool settings with defaults.
+
+    Most ``tools_config`` values are operational scalars where the profile value
+    should replace the inherited default. On-demand declarations are different:
+    they describe tools and MCP servers that should be lazy in this profile.
+    Making an inherited tool eager because a profile adds one local override is
+    surprising and expensive, so those lists are additive.
+    """
+    merged = deep_merge_dicts(default_tools_config, profile_tools_config)
+
+    for key in ADDITIVE_TOOLS_CONFIG_LIST_KEYS:
+        if key not in profile_tools_config:
+            continue
+
+        inherited_items = default_tools_config.get(key, [])
+        profile_items = profile_tools_config.get(key, [])
+        if not isinstance(inherited_items, list) or not isinstance(profile_items, list):
+            continue
+
+        merged[key] = list(dict.fromkeys([*inherited_items, *profile_items]))
+
+    return merged
 
 
 def parse_env_value(
@@ -749,9 +781,13 @@ def resolve_service_profile(
                         SYSTEM_PROMPT_DOCS_KEY,
                     )
 
-    # Replace tools_config entirely if defined.
+    # Merge tools_config so profiles can tune one operational setting without
+    # accidentally making inherited on-demand tools eager.
     if "tools_config" in profile_def and isinstance(profile_def["tools_config"], dict):
-        resolved["tools_config"] = copy.deepcopy(profile_def["tools_config"])
+        resolved["tools_config"] = merge_profile_tools_config(
+            resolved.get("tools_config", {}),
+            profile_def["tools_config"],
+        )
 
     # Replace tools_policy entirely if defined (operator layer is preserved
     # separately so it still applies via PolicyEngine.from_layers)

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -942,24 +942,55 @@ class TestResolveServiceProfile:
             == "Config YAML prompt"
         )
 
-    def test_tools_config_replaced_entirely(self) -> None:
-        """Test that tools_config is replaced, not merged."""
+    def test_tools_config_merges_profile_overrides_with_defaults(self) -> None:
+        """Profiles can tune tools_config without dropping inherited lazy tools."""
         default_settings: dict[str, Any] = {
             "processing_config": {},
             "tools_config": {
                 "confirmation_timeout_seconds": 60.0,
                 "on_demand_local_tools": ["lazy_default"],
+                "on_demand_mcp_server_ids": ["vikunja", "trino"],
+                "mcp_initialization_timeout_seconds": 10,
             },
             "chat_id_to_name_map": {},
             "slash_commands": [],
         }
         profile_def = {
             "id": "test_profile",
-            "tools_config": {"on_demand_local_tools": ["specific_tool"]},
+            "tools_config": {
+                "confirmation_timeout_seconds": 120.0,
+                "on_demand_local_tools": ["specific_tool"],
+                "on_demand_mcp_server_ids": ["homeassistant"],
+            },
         }
         result = resolve_service_profile(profile_def, default_settings, {})
-        # tools_config should be completely replaced
-        assert result["tools_config"] == {"on_demand_local_tools": ["specific_tool"]}
+        assert result["tools_config"] == {
+            "confirmation_timeout_seconds": 120.0,
+            "on_demand_local_tools": ["lazy_default", "specific_tool"],
+            "on_demand_mcp_server_ids": ["vikunja", "trino", "homeassistant"],
+            "mcp_initialization_timeout_seconds": 10,
+        }
+
+    def test_tools_config_scalar_override_preserves_on_demand_lists(self) -> None:
+        """Regression test for email_intake timeout overriding all lazy MCP IDs."""
+        default_settings: dict[str, Any] = {
+            "processing_config": {},
+            "tools_config": {
+                "confirmation_timeout_seconds": 60.0,
+                "on_demand_mcp_server_ids": ["vikunja", "code-execution"],
+            },
+            "chat_id_to_name_map": {},
+            "slash_commands": [],
+        }
+        profile_def = {
+            "id": "email_intake",
+            "tools_config": {"confirmation_timeout_seconds": 86400.0},
+        }
+        result = resolve_service_profile(profile_def, default_settings, {})
+        assert result["tools_config"] == {
+            "confirmation_timeout_seconds": 86400.0,
+            "on_demand_mcp_server_ids": ["vikunja", "code-execution"],
+        }
 
     def test_tools_policy_inherited_from_defaults(self) -> None:
         """Test that tools_policy is inherited when the profile does not override it."""


### PR DESCRIPTION
### Motivation
- Prevent profiles from accidentally dropping inherited on-demand tool/MCP hints when they provide a small `tools_config` override, which was causing tools like Vikunja to load eagerly in some profiles.
- Make it straightforward for operators to tune individual operational scalars (timeouts, etc.) without losing the inherited lazy-loading hints.

### Description
- Add `ADDITIVE_TOOLS_CONFIG_LIST_KEYS` and `merge_profile_tools_config()` to perform a deep-merge but treat certain `tools_config` list keys (e.g. `on_demand_local_tools`, `on_demand_mcp_server_ids`) as additive instead of replaced. (changed: `src/family_assistant/config_loader.py`)
- Replace the previous full-replace behavior for `tools_config` in `resolve_service_profile()` with a call to `merge_profile_tools_config()` so profiles merge with `default_profile_settings` rather than wiping it out. (changed: `src/family_assistant/config_loader.py`)
- Add regression tests that assert profile overrides merge with defaults and that scalar-only overrides (e.g. `confirmation_timeout_seconds`) preserve inherited on-demand lists. (changed: `tests/unit/test_config_loader.py`)

### Testing
- Ran formatting and lint checks with the project venv: `PATH="$PWD/.venv/bin:$PATH" scripts/format-and-lint.sh src/family_assistant/config_loader.py tests/unit/test_config_loader.py`, which passed after using the venv `ast-grep` binary.
- Ran the focused unit tests: `.venv/bin/pytest tests/unit/test_config_loader.py -q`, and the tests passed (regressions covered).
- Ran the local test suite used during development (`.venv/bin/pytest` as executed in the log) and observed the test run reporting successful results (107 passed, warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a406f7572ec8330b79d3cc4f875fb4a)