### PR TITLE
Add REST-transport support to the UCP shopping client

### DIFF
--- a/docs/design/ucp-cart-response-and-cross-origin-endpoints.md
+++ b/docs/design/ucp-cart-response-and-cross-origin-endpoints.md
@@ -74,9 +74,28 @@ prior same-origin path posted to the attacker-influenced storefront origin too) 
 in this change. A private-IP/internal-host guard on the shopping POST path remains possible future
 hardening.
 
-## Follow-up: REST transport
+## Follow-up: REST transport (done)
 
-THE ICONIC and Adore Beauty advertise `transport: "rest"`, not `mcp`. The client only speaks the MCP
-JSON-RPC transport, so those merchants still fall back to a non-existent `/api/ucp/mcp` path and
-fail. Adding a REST-transport client (the `dev.ucp.shopping` `rest` binding /
-`rest.openapi.json`) is the unlock for REST-only merchants and is tracked separately.
+THE ICONIC and Adore Beauty advertise `transport: "rest"`, not `mcp`. The client originally only
+spoke the MCP JSON-RPC transport, so those merchants fell back to a non-existent `/api/ucp/mcp` path
+and failed (surfacing as `UCP response was not JSON`). REST-transport support has since been added
+so those merchants are reachable:
+
+- **Discovery** now surfaces `rest` bindings alongside `mcp` ones
+  (`MerchantUCPProfile.rest_endpoints`), and `usable_shopping_endpoint(...)` selects the safest
+  endpoint across both transports using the unchanged trust ranking (same-origin → same-site →
+  trusted suffix), preferring MCP within a trust class. The resolved transport is threaded through
+  `_ResolvedMerchant`.
+- **The tools branch on transport.** `_ucp_call` dispatches each UCP operation
+  (`create_cart`/`get_cart`/`update_cart`/`create_checkout`) to either the MCP `tools/call` body or
+  the REST verb/path from `rest.openapi.json` (`POST /carts`, `GET|PUT /carts/{id}`,
+  `POST /checkout-sessions`). The cart/checkout object is the REST request body directly (not
+  wrapped under a key) and the resource id is URL-encoded into the path. RFC 9421 signing
+  (`sign_ucp_request`) is reused unchanged. A REST response is the cart/checkout object itself,
+  re-nested under the MCP `result.structuredContent` shape so
+  `_cart_from_response`/`_checkout_from_response` work as-is.
+- **Adore Beauty** is checkout-only (advertises checkout but not `dev.ucp.shopping.cart`), so it
+  exercises the signed REST checkout handoff; its checkout path requires signing to be configured.
+- **Coverage:** `rest.openapi.json` is vendored into `tests/data/ucp/2026-04-08/`, and the contract
+  test (`tests/unit/tools/test_shopping_ucp_contract.py`) validates the REST request bodies and
+  verb/path against it the same way it validates the MCP `tools/call` bodies.

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -206,12 +206,15 @@ You can ask the assistant a wide variety of things:
   `/.well-known/ucp` profile (following any redirect the merchant serves there), and while browsing
   it automatically notices when a site supports UCP shopping. This includes Shopify stores on their
   own custom domain, whose commerce endpoint lives on a `*.myshopify.com` host — you can just give
-  the assistant the storefront you browsed. Some merchants are checkout-only (they support checkout
-  but not a cart); for these the assistant opens a checkout session directly from the selected items
-  instead of building a cart first. The server also publishes its own public UCP platform profile at
-  `/.well-known/ucp`. Checkout handoff requires signed UCP requests; configure `UCP_SIGNING_KEY_ID`
-  and either `UCP_SIGNING_PRIVATE_KEY` or `UCP_SIGNING_PRIVATE_KEY_PATH` with an EC P-256 or P-384
-  private key. The assistant does not complete checkout or collect payment credentials in chat.
+  the assistant the storefront you browsed. The assistant speaks both UCP transports — the MCP
+  JSON-RPC transport that Shopify stores use and the REST transport that merchants such as THE
+  ICONIC and Adore Beauty advertise — so a merchant's choice of transport is transparent to you.
+  Some merchants are checkout-only (they support checkout but not a cart); for these the assistant
+  opens a checkout session directly from the selected items instead of building a cart first. The
+  server also publishes its own public UCP platform profile at `/.well-known/ucp`. Checkout handoff
+  requires signed UCP requests; configure `UCP_SIGNING_KEY_ID` and either `UCP_SIGNING_PRIVATE_KEY`
+  or `UCP_SIGNING_PRIVATE_KEY_PATH` with an EC P-256 or P-384 private key. The assistant does not
+  complete checkout or collect payment credentials in chat.
 
 - **Ingest Documents (Files and URLs):**
 

--- a/src/family_assistant/services/ucp.py
+++ b/src/family_assistant/services/ucp.py
@@ -30,7 +30,21 @@ logger = logging.getLogger(__name__)
 UCP_PROFILE_PATH = "/.well-known/ucp"
 SHOPPING_SERVICE_NAME = "dev.ucp.shopping"
 MCP_TRANSPORT = "mcp"
+REST_TRANSPORT = "rest"
 STATE_CHANGING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+@dataclass(frozen=True, slots=True)
+class ShoppingEndpoint:
+    """A usable shopping endpoint plus the transport the merchant speaks there.
+
+    ``transport`` is one of ``MCP_TRANSPORT`` / ``REST_TRANSPORT`` so the caller
+    knows whether to drive the endpoint with the MCP JSON-RPC body or the REST
+    verbs/paths from ``rest.openapi.json``.
+    """
+
+    transport: str
+    endpoint: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,46 +70,57 @@ class MerchantUCPProfile:
     service_names: tuple[str, ...]
     capability_names: tuple[str, ...]
     version: str | None
+    rest_endpoints: tuple[str, ...] = ()
 
     @property
     def supports_shopping(self) -> bool:
-        """Whether the merchant advertises any shopping MCP endpoint."""
-        return bool(self.mcp_endpoints)
+        """Whether the merchant advertises any shopping endpoint (MCP or REST)."""
+        return bool(self.mcp_endpoints or self.rest_endpoints)
 
     @property
     def mcp_endpoint(self) -> str | None:
         """The first advertised shopping MCP endpoint, if any."""
         return self.mcp_endpoints[0] if self.mcp_endpoints else None
 
-    def usable_mcp_endpoint(
+    def usable_shopping_endpoint(
         self, *, trusted_suffixes: tuple[str, ...] = ()
-    ) -> str | None:
-        """The first advertised endpoint safe to post to for this merchant.
+    ) -> ShoppingEndpoint | None:
+        """The first advertised endpoint safe to call for this merchant.
 
         The profile is untrusted merchant-controlled metadata, so the signed
-        POST must not be redirected to an arbitrary host. An endpoint is usable
-        when it is same-origin as the merchant, same-site as the merchant (a
-        sibling subdomain of the same registrable domain — still the merchant's
-        own site, e.g. ``eve.theiconic.com.au`` for ``www.theiconic.com.au``),
-        or hosted on a configured trusted commerce-platform suffix
-        (``myshopify.com`` covers Shopify storefronts on custom domains, whose
-        UCP endpoint lives on the ``*.myshopify.com`` shop host). Anything else
-        is ignored so the caller falls back rather than posting to an unrelated
-        host. This is also what the browser shopping hint gates on.
+        request must not be redirected to an arbitrary host. An endpoint is
+        usable when it is same-origin as the merchant, same-site as the merchant
+        (a sibling subdomain of the same registrable domain — still the
+        merchant's own site, e.g. ``eve.theiconic.com.au`` for
+        ``www.theiconic.com.au``), or hosted on a configured trusted
+        commerce-platform suffix (``myshopify.com`` covers Shopify storefronts
+        on custom domains, whose UCP endpoint lives on the ``*.myshopify.com``
+        shop host). Anything else is ignored so the caller falls back rather than
+        calling an unrelated host. This is also what the browser shopping hint
+        gates on.
 
-        Candidates are ranked by trust class — same-origin first, then
-        same-site, then trusted suffix — so a profile that lists a platform or
-        same-site binding ahead of the merchant-local one still resolves to the
-        safest available endpoint rather than the first broad match.
+        Both transports are considered. Candidates are ranked by trust class —
+        same-origin first, then same-site, then trusted suffix — so a profile
+        that lists a platform or same-site binding ahead of the merchant-local
+        one still resolves to the safest available endpoint rather than the first
+        broad match. Within a trust class the MCP binding is preferred over a
+        REST one (it is the richer transport), so a merchant advertising both is
+        driven over MCP.
         """
+        candidates: tuple[ShoppingEndpoint, ...] = tuple(
+            ShoppingEndpoint(MCP_TRANSPORT, endpoint) for endpoint in self.mcp_endpoints
+        ) + tuple(
+            ShoppingEndpoint(REST_TRANSPORT, endpoint)
+            for endpoint in self.rest_endpoints
+        )
         for predicate in (
             lambda endpoint: same_origin(endpoint, self.origin),
             lambda endpoint: same_site(endpoint, self.origin),
             lambda endpoint: host_matches_trusted_suffix(endpoint, trusted_suffixes),
         ):
-            for endpoint in self.mcp_endpoints:
-                if predicate(endpoint):
-                    return endpoint
+            for candidate in candidates:
+                if predicate(candidate.endpoint):
+                    return candidate
         return None
 
 
@@ -229,10 +254,10 @@ def merchant_origin(url: str) -> str | None:
     return f"https://{netloc}"
 
 
-def _shopping_mcp_endpoints(
-    origin: str, services: Mapping[str, object]
+def _shopping_endpoints(
+    origin: str, services: Mapping[str, object], transport: str
 ) -> tuple[str, ...]:
-    """Return every advertised HTTPS shopping MCP endpoint, in profile order.
+    """Return every advertised HTTPS shopping endpoint for ``transport``.
 
     All candidates are returned (not just the first) so callers can apply their
     own selection policy — e.g. the shopping tools prefer a same-origin binding
@@ -247,7 +272,7 @@ def _shopping_mcp_endpoints(
     for binding in bindings:
         if not isinstance(binding, dict):
             continue
-        if binding.get("transport") != MCP_TRANSPORT:
+        if binding.get("transport") != transport:
             continue
         endpoint = binding.get("endpoint")
         if not isinstance(endpoint, str) or not endpoint:
@@ -279,7 +304,8 @@ def _parse_merchant_profile(origin: str, payload: object) -> MerchantUCPProfile 
     version = ucp.get("version")
     return MerchantUCPProfile(
         origin=origin,
-        mcp_endpoints=_shopping_mcp_endpoints(origin, services),
+        mcp_endpoints=_shopping_endpoints(origin, services, MCP_TRANSPORT),
+        rest_endpoints=_shopping_endpoints(origin, services, REST_TRANSPORT),
         service_names=tuple(services.keys()),
         capability_names=tuple(capabilities.keys()),
         version=version if isinstance(version, str) else None,

--- a/src/family_assistant/tools/browser_dom.py
+++ b/src/family_assistant/tools/browser_dom.py
@@ -295,7 +295,8 @@ async def _probe_ucp_support(
     trusted_suffixes = _trusted_endpoint_suffixes(exec_context)
     if (
         profile is not None
-        and profile.usable_mcp_endpoint(trusted_suffixes=trusted_suffixes) is not None
+        and profile.usable_shopping_endpoint(trusted_suffixes=trusted_suffixes)
+        is not None
     ):
         return _format_ucp_hint(profile)
     return None

--- a/src/family_assistant/tools/shopping.py
+++ b/src/family_assistant/tools/shopping.py
@@ -1,9 +1,10 @@
-"""Shopping tools backed by UCP merchant MCP endpoints.
+"""Shopping tools backed by UCP merchant shopping endpoints.
 
 These tools work with any merchant that advertises a Universal Commerce Protocol
-(UCP) profile at ``/.well-known/ucp``. The merchant's shopping MCP endpoint is
-discovered from that profile; when a merchant does not advertise one, the tools
-fall back to the Shopify convention (``/api/ucp/mcp``).
+(UCP) profile at ``/.well-known/ucp``. The merchant's shopping endpoint and its
+transport (MCP JSON-RPC or REST) are discovered from that profile; when a
+merchant does not advertise a usable binding, the tools fall back to the Shopify
+MCP convention (``/api/ucp/mcp``).
 """
 
 from __future__ import annotations
@@ -12,11 +13,14 @@ import json
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 from uuid import uuid4
 
 import httpx
 
 from family_assistant.services.ucp import (
+    MCP_TRANSPORT,
+    REST_TRANSPORT,
     UCPConfigurationError,
     discover_merchant_ucp_profile,
     has_ucp_signing_key,
@@ -47,14 +51,19 @@ CHECKOUT_CAPABILITY = "dev.ucp.shopping.checkout"
 
 @dataclass(frozen=True, slots=True)
 class _ResolvedMerchant:
-    """The endpoint to use for a merchant plus its cart/checkout shape.
+    """The endpoint to use for a merchant, its transport, and cart/checkout shape.
+
+    ``transport`` is ``MCP_TRANSPORT`` or ``REST_TRANSPORT`` and selects whether
+    operations are driven over the MCP JSON-RPC ``tools/call`` body or the REST
+    verbs/paths from ``rest.openapi.json``.
 
     ``checkout_only`` is True when the merchant advertises the checkout
-    capability but not the cart capability, meaning its MCP endpoint has no
-    cart methods and a cart must be skipped in favour of a direct checkout.
+    capability but not the cart capability, meaning its endpoint has no cart
+    methods and a cart must be skipped in favour of a direct checkout.
     """
 
     endpoint: str
+    transport: str
     checkout_only: bool
 
 
@@ -203,26 +212,28 @@ async def _resolve_ucp_endpoint(
     client: httpx.AsyncClient,
     trusted_suffixes: tuple[str, ...] = (),
 ) -> _ResolvedMerchant:
-    """Resolve the merchant's shopping MCP endpoint for ``business_url``.
+    """Resolve the merchant's shopping endpoint and transport for ``business_url``.
 
     Discovers the endpoints from the merchant's ``/.well-known/ucp`` profile and
-    falls back to the Shopify convention (``/api/ucp/mcp``) when the merchant
-    advertises no usable shopping MCP binding. The returned ``checkout_only``
-    flag reflects the discovered capabilities so callers can bypass the cart for
-    checkout-only merchants — but only when the profile's own endpoint is used;
-    on fallback the flag is cleared, since the capability described a binding
-    that was not adopted.
+    falls back to the Shopify MCP convention (``/api/ucp/mcp``) when the merchant
+    advertises no usable shopping binding. The returned ``transport`` (MCP or
+    REST) selects how the endpoint is driven. The ``checkout_only`` flag reflects
+    the discovered capabilities so callers can bypass the cart for checkout-only
+    merchants — but only when the profile's own endpoint is used; on fallback the
+    flag is cleared, since the capability described a binding that was not
+    adopted.
 
     A binding is usable when it is same-origin, same-site (a sibling subdomain of
     ``business_url``'s registrable domain), or hosted on a configured trusted
     platform suffix (``trusted_suffixes``, e.g. ``myshopify.com`` for Shopify
-    storefronts on custom domains). Every advertised binding is considered, so a
-    usable one is still selected when an unusable binding is listed ahead of it.
-    Anything else is ignored: the profile is untrusted merchant-controlled
-    metadata, so an arbitrary cross-host endpoint could otherwise redirect the
-    signed POST at an unrelated/internal host — an SSRF vector. Discovery is also
-    given a short timeout so a store that does not publish a profile (and may
-    tarpit the well-known path) falls back promptly instead of stalling the POST.
+    storefronts on custom domains). Every advertised binding — MCP or REST — is
+    considered, so a usable one is still selected when an unusable binding is
+    listed ahead of it. Anything else is ignored: the profile is untrusted
+    merchant-controlled metadata, so an arbitrary cross-host endpoint could
+    otherwise redirect the signed request at an unrelated/internal host — an SSRF
+    vector. Discovery is also given a short timeout so a store that does not
+    publish a profile (and may tarpit the well-known path) falls back promptly
+    instead of stalling the request.
     """
     origin = merchant_origin(business_url)
     if origin is None:
@@ -232,24 +243,27 @@ async def _resolve_ucp_endpoint(
         business_url, client=client, timeout=UCP_DISCOVERY_TIMEOUT_SECONDS
     )
     if profile is not None:
-        usable_endpoint = profile.usable_mcp_endpoint(trusted_suffixes=trusted_suffixes)
-        if usable_endpoint is not None:
+        usable = profile.usable_shopping_endpoint(trusted_suffixes=trusted_suffixes)
+        if usable is not None:
             return _ResolvedMerchant(
-                endpoint=usable_endpoint,
+                endpoint=usable.endpoint,
+                transport=usable.transport,
                 checkout_only=_is_checkout_only(profile),
             )
-        if profile.mcp_endpoints:
+        if profile.mcp_endpoints or profile.rest_endpoints:
             logger.warning(
                 "Ignoring %d untrusted cross-host UCP endpoint(s) advertised by %s",
-                len(profile.mcp_endpoints),
+                len(profile.mcp_endpoints) + len(profile.rest_endpoints),
                 origin,
             )
     # No profile, or only unusable (untrusted cross-host) bindings: fall back to
-    # the Shopify convention. That endpoint supports carts, so the profile's
+    # the Shopify MCP convention. That endpoint supports carts, so the profile's
     # checkout-only capability — which described the binding we just refused —
     # must not carry over and make the caller skip the cart here.
     return _ResolvedMerchant(
-        endpoint=f"{origin}{SHOPIFY_FALLBACK_MCP_PATH}", checkout_only=False
+        endpoint=f"{origin}{SHOPIFY_FALLBACK_MCP_PATH}",
+        transport=MCP_TRANSPORT,
+        checkout_only=False,
     )
 
 
@@ -431,6 +445,191 @@ async def _post_ucp_tool_call(
     }
 
 
+# REST transport: each UCP operation maps to a verb + path template from the
+# shopping ``rest.openapi.json``. The object body (cart/checkout) is sent
+# directly — REST does not wrap it under a key the way the MCP tools/call
+# arguments do — and the resource id travels in the path, not the body.
+_REST_ROUTES: dict[str, tuple[str, str]] = {
+    "create_cart": ("POST", "/carts"),
+    "get_cart": ("GET", "/carts/{id}"),
+    "update_cart": ("PUT", "/carts/{id}"),
+    "create_checkout": ("POST", "/checkout-sessions"),
+}
+
+# Which tools/call argument key wraps the object payload for each MCP method; the
+# resource id (when present) is a sibling top-level argument, not nested.
+_MCP_OBJECT_KEY: dict[str, str | None] = {
+    "create_cart": "cart",
+    "get_cart": None,
+    "update_cart": "cart",
+    "create_checkout": "checkout",
+}
+
+
+def _mcp_arguments(
+    operation: str, resource_id: str | None, payload: dict[str, object] | None
+) -> dict[str, object]:
+    """Build the MCP ``tools/call`` arguments for a UCP operation.
+
+    Re-creates the transport-specific shape the merchant's MCP endpoint expects:
+    the id as a top-level ``id`` argument and the object payload wrapped under
+    its ``cart``/``checkout`` key.
+    """
+    arguments: dict[str, object] = {}
+    if resource_id is not None:
+        arguments["id"] = resource_id
+    object_key = _MCP_OBJECT_KEY[operation]
+    if object_key is not None and payload is not None:
+        arguments[object_key] = payload
+    return arguments
+
+
+def _rest_route(
+    base_endpoint: str, operation: str, resource_id: str | None
+) -> tuple[str, str]:
+    """Return the ``(verb, url)`` for a UCP operation on a REST endpoint.
+
+    The resource id is URL-encoded into the path (cart/checkout ids are opaque
+    and may contain ``/`` and ``:``) so it cannot escape its path segment.
+    """
+    verb, path_template = _REST_ROUTES[operation]
+    if "{id}" in path_template:
+        if not resource_id:
+            msg = f"UCP REST {operation} requires a resource id."
+            raise ValueError(msg)
+        path = path_template.replace("{id}", quote(resource_id, safe=""))
+    else:
+        path = path_template
+    return verb, f"{base_endpoint.rstrip('/')}{path}"
+
+
+def _rest_error_text(body: dict[str, object]) -> str | None:
+    """First message text from a UCP REST ``error_response`` body, if any."""
+    messages = body.get("messages")
+    if isinstance(messages, list):
+        for message in messages:
+            if isinstance(message, dict):
+                return _message_text(message)
+    return None
+
+
+def _raise_for_rest_failure(
+    response: httpx.Response, response_data: dict[str, object]
+) -> None:
+    """Raise on a hard REST failure (HTTP error status).
+
+    A non-2xx response carries an ``error_response`` body (``cart_result =
+    oneOf[cart, error_response]``), so its first message gives a clearer reason
+    than the bare status. Recoverable, in-resource failures (a 2xx cart/checkout
+    carrying error messages) are left for the shared cart/checkout parsers.
+    """
+    if response.is_error:
+        msg = (
+            _rest_error_text(response_data) or f"UCP HTTP error {response.status_code}."
+        )
+        raise ValueError(msg)
+
+
+async def _post_ucp_rest_call(
+    app_config: AppConfig,
+    *,
+    base_endpoint: str,
+    operation: str,
+    resource_id: str | None = None,
+    payload: dict[str, object] | None = None,
+    require_signed: bool = False,
+) -> dict[str, object]:
+    """Drive a UCP operation over the REST transport and normalize the response.
+
+    Signs the request with the same RFC 9421 helper as the MCP path (when a
+    signing key is configured), then re-nests the REST resource under the MCP
+    ``result.structuredContent`` shape so the shared cart/checkout parsers work
+    unchanged — a REST cart/checkout response IS the resource object.
+    """
+    verb, url = _rest_route(base_endpoint, operation, resource_id)
+    body = payload if verb in {"POST", "PUT"} else None
+
+    if require_signed:
+        _require_signing_config(app_config)
+
+    if has_ucp_signing_key(app_config):
+        try:
+            signed_request = sign_ucp_request(
+                app_config, method=verb, url=url, body=body
+            )
+        except UCPConfigurationError as exc:
+            raise ValueError(str(exc)) from exc
+        request_headers = signed_request.headers
+        request_body = signed_request.body
+    else:
+        request_headers = {"UCP-Agent": ucp_agent_header(app_config)}
+        request_body = None
+        if body is not None:
+            request_headers["Content-Type"] = "application/json"
+            request_body = _json_bytes(body)
+
+    logger.info("Calling UCP REST %s %s", verb, url)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.request(
+            verb, url, headers=request_headers, content=request_body
+        )
+
+    try:
+        response_data = response.json()
+    except json.JSONDecodeError as exc:
+        msg = f"UCP response was not JSON: HTTP {response.status_code}"
+        raise ValueError(msg) from exc
+
+    if not isinstance(response_data, dict):
+        msg = "UCP response JSON must be an object."
+        raise ValueError(msg)
+    _raise_for_rest_failure(response, response_data)
+
+    return {
+        "status_code": response.status_code,
+        "response": {"result": {"structuredContent": response_data}},
+        "request": {
+            "url": url,
+            "tool_name": operation,
+            "signed": has_ucp_signing_key(app_config),
+        },
+    }
+
+
+async def _ucp_call(
+    app_config: AppConfig,
+    *,
+    resolved: _ResolvedMerchant,
+    operation: str,
+    resource_id: str | None = None,
+    payload: dict[str, object] | None = None,
+    require_signed: bool = False,
+) -> dict[str, object]:
+    """Dispatch a UCP operation over the merchant's resolved transport.
+
+    The same semantic operation (``create_cart``/``get_cart``/``update_cart``/
+    ``create_checkout``) is mapped to a JSON-RPC ``tools/call`` body for an MCP
+    endpoint or to a REST verb/path for a REST endpoint; both return the shared
+    normalized response shape the cart/checkout parsers consume.
+    """
+    if resolved.transport == REST_TRANSPORT:
+        return await _post_ucp_rest_call(
+            app_config,
+            base_endpoint=resolved.endpoint,
+            operation=operation,
+            resource_id=resource_id,
+            payload=payload,
+            require_signed=require_signed,
+        )
+    return await _post_ucp_tool_call(
+        app_config,
+        endpoint=resolved.endpoint,
+        tool_name=operation,
+        arguments=_mcp_arguments(operation, resource_id, payload),
+        require_signed=require_signed,
+    )
+
+
 def _structured_content(response_data: dict[str, object]) -> dict[str, object]:
     response = response_data.get("response")
     if not isinstance(response, dict):
@@ -607,20 +806,20 @@ def _cart_result_text(cart: dict[str, object]) -> str:
 async def _create_checkout_session(
     app_config: AppConfig,
     *,
-    endpoint: str,
-    arguments: dict[str, object],
+    resolved: _ResolvedMerchant,
+    checkout_payload: dict[str, object],
 ) -> ToolResult:
-    """Post a signed ``create_checkout`` call and render the handoff result.
+    """Make a signed ``create_checkout`` call and render the handoff result.
 
     Shared by the cart-based checkout handoff and the checkout-only add-to-cart
-    path; ``arguments`` carries the ``meta``/``checkout`` params the UCP
-    create_checkout binding expects (the ``checkout`` object holding line items).
+    path; ``checkout_payload`` is the ``checkout`` object (holding line items and
+    any supported checkout fields) the UCP create_checkout binding expects.
     """
-    response_data = await _post_ucp_tool_call(
+    response_data = await _ucp_call(
         app_config,
-        endpoint=endpoint,
-        tool_name="create_checkout",
-        arguments=arguments,
+        resolved=resolved,
+        operation="create_checkout",
+        payload=checkout_payload,
         require_signed=True,
     )
     checkout = _checkout_from_response(response_data)
@@ -652,7 +851,7 @@ async def _create_checkout_session(
 async def _add_to_cart_checkout_only(
     app_config: AppConfig,
     *,
-    endpoint: str,
+    resolved: _ResolvedMerchant,
     normalized_items: list[dict[str, object]],
     cart_id: str | None,
     context: dict[str, object] | None,
@@ -670,14 +869,14 @@ async def _add_to_cart_checkout_only(
             "the line items."
         )
         raise ValueError(msg)
-    # The UCP create_checkout binding takes a top-level `checkout` object with
-    # line items (and any supported checkout fields) nested inside it, mirroring
-    # how create_cart nests its payload under `cart`.
+    # The UCP create_checkout binding takes a `checkout` object with line items
+    # (and any supported checkout fields) inside it, mirroring how create_cart
+    # carries its payload as the cart object.
     checkout_payload: dict[str, object] = {"line_items": normalized_items}
     if context is not None:
         checkout_payload["context"] = context
     return await _create_checkout_session(
-        app_config, endpoint=endpoint, arguments={"checkout": checkout_payload}
+        app_config, resolved=resolved, checkout_payload=checkout_payload
     )
 
 
@@ -727,36 +926,37 @@ async def ucp_add_to_cart_tool(
     if resolved.checkout_only:
         return await _add_to_cart_checkout_only(
             app_config,
-            endpoint=resolved.endpoint,
+            resolved=resolved,
             normalized_items=normalized_items,
             cart_id=cart_id,
             context=context,
         )
 
     if cart_id:
-        current = await _post_ucp_tool_call(
+        current = await _ucp_call(
             app_config,
-            endpoint=resolved.endpoint,
-            tool_name="get_cart",
-            arguments={"id": cart_id},
+            resolved=resolved,
+            operation="get_cart",
+            resource_id=cart_id,
         )
         existing_cart = _cart_from_response(current)
         cart_payload = _cart_update_payload(existing_cart, normalized_items, context)
-        response_data = await _post_ucp_tool_call(
+        response_data = await _ucp_call(
             app_config,
-            endpoint=resolved.endpoint,
-            tool_name="update_cart",
-            arguments={"id": cart_id, "cart": cart_payload},
+            resolved=resolved,
+            operation="update_cart",
+            resource_id=cart_id,
+            payload=cart_payload,
         )
     else:
         cart_payload: dict[str, object] = {"line_items": normalized_items}
         if context is not None:
             cart_payload["context"] = context
-        response_data = await _post_ucp_tool_call(
+        response_data = await _ucp_call(
             app_config,
-            endpoint=resolved.endpoint,
-            tool_name="create_cart",
-            arguments={"cart": cart_payload},
+            resolved=resolved,
+            operation="create_cart",
+            payload=cart_payload,
         )
 
     cart = _cart_from_response(response_data)
@@ -773,11 +973,11 @@ async def ucp_get_cart_tool(
     resolved = await _resolve_endpoint_for(
         business_url, trusted_suffixes=_trusted_endpoint_suffixes(app_config)
     )
-    response_data = await _post_ucp_tool_call(
+    response_data = await _ucp_call(
         app_config,
-        endpoint=resolved.endpoint,
-        tool_name="get_cart",
-        arguments={"id": cart_id},
+        resolved=resolved,
+        operation="get_cart",
+        resource_id=cart_id,
     )
     cart = _cart_from_response(response_data)
     return ToolResult(text=_cart_result_text(cart), data=response_data)
@@ -800,15 +1000,15 @@ async def ucp_transfer_checkout_to_human_tool(
     # The cart capability extends create_checkout with cart_id for
     # cart-to-checkout conversion, so read the cart and hand off its cart_id
     # (plus its contents) inside the checkout object.
-    cart_response = await _post_ucp_tool_call(
+    cart_response = await _ucp_call(
         app_config,
-        endpoint=resolved.endpoint,
-        tool_name="get_cart",
-        arguments={"id": cart_id},
+        resolved=resolved,
+        operation="get_cart",
+        resource_id=cart_id,
     )
     cart = _cart_from_response(cart_response)
     return await _create_checkout_session(
         app_config,
-        endpoint=resolved.endpoint,
-        arguments={"checkout": _checkout_input_from_cart(cart, cart_id)},
+        resolved=resolved,
+        checkout_payload=_checkout_input_from_cart(cart, cart_id),
     )

--- a/src/family_assistant/tools/shopping.py
+++ b/src/family_assistant/tools/shopping.py
@@ -548,6 +548,14 @@ async def _post_ucp_rest_call(
     """
     verb, url = _rest_route(base_endpoint, operation, resource_id)
     body = payload if verb in {"POST", "PUT"} else None
+    # The REST OpenAPI marks Request-Id required on every route and
+    # Idempotency-Key required on the write routes (POST/PUT), so a
+    # spec-enforcing merchant would reject a call missing them. Generate both:
+    # the signing helper folds the idempotency key into the signed headers (and
+    # already supplies one for state-changing methods), while Request-Id rides
+    # as an unsigned tracing header on both the signed and unsigned paths.
+    request_id = str(uuid4())
+    idempotency_key = str(uuid4()) if verb in {"POST", "PUT"} else None
 
     if require_signed:
         _require_signing_config(app_config)
@@ -555,14 +563,24 @@ async def _post_ucp_rest_call(
     if has_ucp_signing_key(app_config):
         try:
             signed_request = sign_ucp_request(
-                app_config, method=verb, url=url, body=body
+                app_config,
+                method=verb,
+                url=url,
+                body=body,
+                idempotency_key=idempotency_key,
+                additional_headers={"Request-Id": request_id},
             )
         except UCPConfigurationError as exc:
             raise ValueError(str(exc)) from exc
         request_headers = signed_request.headers
         request_body = signed_request.body
     else:
-        request_headers = {"UCP-Agent": ucp_agent_header(app_config)}
+        request_headers = {
+            "UCP-Agent": ucp_agent_header(app_config),
+            "Request-Id": request_id,
+        }
+        if idempotency_key is not None:
+            request_headers["Idempotency-Key"] = idempotency_key
         request_body = None
         if body is not None:
             request_headers["Content-Type"] = "application/json"

--- a/tests/data/ucp/2026-04-08/SOURCE.md
+++ b/tests/data/ucp/2026-04-08/SOURCE.md
@@ -8,16 +8,25 @@ than against hand-authored types that could re-encode the same mistake.
 
 ## What is vendored
 
-The transitive `$ref` closure rooted at the shopping MCP OpenRPC document and the cart/checkout
-schemas is vendored under this directory, mirroring the upstream layout (top-level schemas at the
-root, shared types under `types/`). The roots are:
+The transitive `$ref` closure rooted at the shopping MCP OpenRPC document, the REST OpenAPI
+document, and the cart/checkout schemas is vendored under this directory, mirroring the upstream
+layout (top-level schemas at the root, shared types under `types/`). The roots are:
 
-| File               | Source URL                                                    |
-| ------------------ | ------------------------------------------------------------- |
-| `mcp.openrpc.json` | https://ucp.dev/2026-04-08/services/shopping/mcp.openrpc.json |
-| `cart.json`        | https://ucp.dev/2026-04-08/schemas/shopping/cart.json         |
-| `checkout.json`    | https://ucp.dev/2026-04-08/schemas/shopping/checkout.json     |
-| `ucp.json`         | https://ucp.dev/2026-04-08/schemas/ucp.json                   |
+| File                | Source URL                                                     |
+| ------------------- | -------------------------------------------------------------- |
+| `mcp.openrpc.json`  | https://ucp.dev/2026-04-08/services/shopping/mcp.openrpc.json  |
+| `rest.openapi.json` | https://ucp.dev/2026-04-08/services/shopping/rest.openapi.json |
+| `cart.json`         | https://ucp.dev/2026-04-08/schemas/shopping/cart.json          |
+| `checkout.json`     | https://ucp.dev/2026-04-08/schemas/shopping/checkout.json      |
+| `ucp.json`          | https://ucp.dev/2026-04-08/schemas/ucp.json                    |
+
+`rest.openapi.json` defines the REST transport's operations: each maps a UCP operation to an HTTP
+verb + path (`create_cart` → `POST /carts`, `get_cart` → `GET /carts/{id}`, `update_cart` →
+`PUT /carts/{id}`, `create_checkout` → `POST /checkout-sessions`), with the cart/checkout object as
+the request body directly (not wrapped under a key) and the resource id in the path. Its request/
+response bodies `$ref` the same `cart.json`/`checkout.json` schemas as the MCP transport, so the
+contract test validates REST request bodies and paths against it the same way it does MCP
+`tools/call` bodies.
 
 Every other `*.json` here is reachable from those via `$ref` (e.g. `types/error_response.json`,
 `types/totals.json`, `types/line_item.json`). Each carries its upstream `$id`; the contract test
@@ -39,8 +48,8 @@ rejected.
 
 ## How response shapes are checked
 
-A cart/checkout method's MCP `result` is the cart/checkout object itself (`cart_result =
-oneOf[cart, error_response]`), so its fields are top-level in `structuredContent` — not nested under
-a `cart`/`checkout` key. The contract test validates the canned response fixtures against `cart.json`
-/ `checkout.json` (with the full ref closure resolved) and asserts the parser rejects a legacy
-`{"cart": {...}}` wrapper, so the wrapper bug cannot return unnoticed.
+A cart/checkout method's MCP `result` is the cart/checkout object itself
+(`cart_result = oneOf[cart, error_response]`), so its fields are top-level in `structuredContent` —
+not nested under a `cart`/`checkout` key. The contract test validates the canned response fixtures
+against `cart.json` / `checkout.json` (with the full ref closure resolved) and asserts the parser
+rejects a legacy `{"cart": {...}}` wrapper, so the wrapper bug cannot return unnoticed.

--- a/tests/data/ucp/2026-04-08/rest.openapi.json
+++ b/tests/data/ucp/2026-04-08/rest.openapi.json
@@ -1,0 +1,1339 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "UCP Shopping Service",
+    "description": "Canonical REST interface for UCP Shopping service. Schema references are logical pointers - actual payload shape is determined by negotiated capabilities.\n\n**Endpoint Resolution:** This spec defines operations only. The base URL MUST be obtained from the merchant's discovery profile at `/.well-known/ucp` under `services[\"dev.ucp.shopping\"][transport=rest].endpoint`. The `{endpoint}` server variable below is a placeholder for tooling compatibility.",
+    "version": "2026-04-08"
+  },
+  "servers": [
+    {
+      "url": "{endpoint}",
+      "description": "Merchant-provided endpoint from UCP discovery profile",
+      "variables": {
+        "endpoint": {
+          "default": "https://merchant.example.com/ucp",
+          "description": "Obtain from /.well-known/ucp \u2192 services[\"dev.ucp.shopping\"][transport=rest].endpoint"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/checkout-sessions": {
+      "post": {
+        "operationId": "create_checkout",
+        "summary": "Create Checkout",
+        "description": "Create a new checkout session.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/idempotency_key"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/checkout"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Checkout session created",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/checkout_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/checkout-sessions/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/checkout_session_id_path"
+        }
+      ],
+      "get": {
+        "operationId": "get_checkout",
+        "summary": "Get Checkout",
+        "description": "Get the latest state of a checkout session.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Checkout session retrieved",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/checkout_response"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "update_checkout",
+        "summary": "Update Checkout",
+        "description": "If an optional field is provided in the request body, its value is treated as a complete replacement for the corresponding data. If optional field is omitted, then current checkout session is unchanged.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/idempotency_key"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/checkout"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Checkout session updated",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/checkout_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/checkout-sessions/{id}/complete": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/checkout_session_id_path"
+        }
+      ],
+      "post": {
+        "operationId": "complete_checkout",
+        "summary": "Complete Checkout",
+        "description": "Place the order",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/idempotency_key"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/checkout"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Checkout session completed",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/checkout_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/checkout-sessions/{id}/cancel": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/checkout_session_id_path"
+        }
+      ],
+      "post": {
+        "operationId": "cancel_checkout",
+        "summary": "Cancel Checkout",
+        "description": "Cancel a checkout session",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/idempotency_key"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Checkout session canceled",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/checkout_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/carts": {
+      "post": {
+        "operationId": "create_cart",
+        "summary": "Create Cart",
+        "description": "Create a new cart session.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/idempotency_key"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/cart"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Cart created",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/cart_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/carts/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/cart_id_path"
+        }
+      ],
+      "get": {
+        "operationId": "get_cart",
+        "summary": "Get Cart",
+        "description": "Get the latest state of a cart session.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cart retrieved",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/cart_response"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "update_cart",
+        "summary": "Update Cart",
+        "description": "Update a cart session.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/idempotency_key"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/cart"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cart updated",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/cart_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/carts/{id}/cancel": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/cart_id_path"
+        }
+      ],
+      "post": {
+        "operationId": "cancel_cart",
+        "summary": "Cancel Cart",
+        "description": "Cancel a cart session. Returns the cart state at time of cancellation.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/idempotency_key"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cart cancelled",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/cart_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/catalog/search": {
+      "post": {
+        "operationId": "search_catalog",
+        "summary": "Search Catalog",
+        "description": "Search for products in the business's catalog.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/catalog_search_request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/catalog_search_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/catalog/lookup": {
+      "post": {
+        "operationId": "lookup_catalog",
+        "summary": "Batch Lookup Catalog Items",
+        "description": "Lookup one or more products by ID with explicit market context. Supports batch lookups of multiple items in a single request.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/catalog_lookup_request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Lookup result",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/catalog_lookup_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orders/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/order_id_path"
+        }
+      ],
+      "get": {
+        "operationId": "get_order",
+        "summary": "Get Order",
+        "description": "Get the current state of an order. Returns the full order entity as a current-state snapshot. The business verifies the requesting platform created the checkout that produced this order.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Order retrieved or business outcome message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/order_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/catalog/product": {
+      "post": {
+        "operationId": "get_product",
+        "summary": "Get Product Details",
+        "description": "Retrieve complete product detail by identifier. Returns a singular product with a relevant set of variants, exact pricing, and real-time availability. Supports interactive option selection via `selected` and `preferences` parameters for variant narrowing and availability signals.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/authorization"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/request_id"
+          },
+          {
+            "$ref": "#/components/parameters/user_agent"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/content_type"
+          },
+          {
+            "$ref": "#/components/parameters/accept"
+          },
+          {
+            "$ref": "#/components/parameters/accept_language"
+          },
+          {
+            "$ref": "#/components/parameters/accept_encoding"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/catalog_get_product_request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Product detail",
+            "headers": {
+              "Signature": {
+                "$ref": "#/components/headers/signature"
+              },
+              "Signature-Input": {
+                "$ref": "#/components/headers/signature_input"
+              },
+              "Content-Digest": {
+                "$ref": "#/components/headers/content_digest"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/catalog_get_product_response"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "webhooks": {
+    "orderEvent": {
+      "post": {
+        "operationId": "order_event_webhook",
+        "summary": "Order Event Webhook",
+        "description": "Merchant sends order lifecycle events to the platform's registered webhook URL. The platform provides the webhook URL during partner onboarding.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/signature"
+          },
+          {
+            "$ref": "#/components/parameters/signature_input"
+          },
+          {
+            "$ref": "#/components/parameters/content_digest"
+          },
+          {
+            "$ref": "#/components/parameters/ucp_agent"
+          },
+          {
+            "$ref": "#/components/parameters/x_api_key"
+          },
+          {
+            "$ref": "#/components/parameters/webhook_timestamp"
+          },
+          {
+            "$ref": "#/components/parameters/webhook_id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/order"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Event received and acknowledged",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ucp"
+                  ],
+                  "properties": {
+                    "ucp": {
+                      "$ref": "#/components/schemas/ucp"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "checkout_session_id_path": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "The unique identifier of the checkout session.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "cart_id_path": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "The unique identifier of the cart.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "order_id_path": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "The unique identifier of the order.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "authorization": {
+        "name": "Authorization",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Should contain oauth token representing the following 2 schemes: 1. Platform self authenticating (client_credentials). 2. Platform authenticating on behalf of end user (authorization_code)."
+      },
+      "x_api_key": {
+        "name": "X-API-Key",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Authenticates the platform with a reusable api key allocated to the platform by the business."
+      },
+      "signature": {
+        "name": "Signature",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "RFC 9421 HTTP Message Signature. Required when using HTTP Message Signatures for authentication. Format: `sig1=:<base64-signature>:`."
+      },
+      "signature_input": {
+        "name": "Signature-Input",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "RFC 9421 Signature-Input header. Required when using HTTP Message Signatures for authentication. Format: `sig1=(\"@method\" \"@path\" ...);created=<timestamp>;keyid=\"<key-id>\"`."
+      },
+      "content_digest": {
+        "name": "Content-Digest",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Body digest per RFC 9530. Required for requests/responses with a body. Format: `sha-256=:<base64-digest>:`."
+      },
+      "idempotency_key": {
+        "name": "Idempotency-Key",
+        "in": "header",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "description": "Ensures duplicate operations don't happen during retries."
+      },
+      "request_id": {
+        "name": "Request-Id",
+        "in": "header",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "description": "For tracing the requests across network layers and components."
+      },
+      "user_agent": {
+        "name": "User-Agent",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Identifies the user agent string making the call."
+      },
+      "ucp_agent": {
+        "name": "UCP-Agent",
+        "in": "header",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Identifies the UCP agent making the call. All requests MUST include the UCP-Agent header containing the signer's profile URI using RFC 8941 Dictionary syntax. The URL MUST point to /.well-known/ucp. Format: profile=\"https://example.com/.well-known/ucp\"."
+      },
+      "content_type": {
+        "name": "Content-Type",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Representation Metadata. Tells the receiver what the data in the message body actually is."
+      },
+      "accept": {
+        "name": "Accept",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Content Negotiation. The client tells the server what data formats it is capable of understanding."
+      },
+      "accept_language": {
+        "name": "Accept-Language",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Localization. Tells the receiver the user's preferred natural languages, often with \"weights\" or priorities."
+      },
+      "accept_encoding": {
+        "name": "Accept-Encoding",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Compression. The client tells the server which content-codings it supports, usually for compression."
+      },
+      "webhook_timestamp": {
+        "name": "Webhook-Timestamp",
+        "in": "header",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        },
+        "description": "Webhook event occurrence unix timestamp (seconds since epoch)."
+      },
+      "webhook_id": {
+        "name": "Webhook-Id",
+        "in": "header",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "description": "The unique identifier of a webhook event."
+      }
+    },
+    "headers": {
+      "signature": {
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "RFC 9421 HTTP Message Signature for response. Contains the signature value in the format `sig1=:<base64-signature>:`."
+      },
+      "signature_input": {
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "RFC 9421 Signature-Input header for response. Describes signed components, timestamp, and key ID."
+      },
+      "content_digest": {
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "JCS-canonicalized body digest per RFC 8785. Format: `sha-256=:<base64-digest>:`."
+      }
+    },
+    "schemas": {
+      "checkout": {
+        "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
+      },
+      "checkout_response": {
+        "oneOf": [
+          {
+            "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
+          },
+          {
+            "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/types/error_response.json"
+          }
+        ]
+      },
+      "cart": {
+        "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/cart.json"
+      },
+      "cart_response": {
+        "oneOf": [
+          {
+            "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/cart.json"
+          },
+          {
+            "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/types/error_response.json"
+          }
+        ]
+      },
+      "order": {
+        "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/order.json"
+      },
+      "order_response": {
+        "oneOf": [
+          {
+            "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/order.json"
+          },
+          {
+            "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/types/error_response.json"
+          }
+        ]
+      },
+      "payment": {
+        "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/payment.json"
+      },
+      "ucp": {
+        "$ref": "https://ucp.dev/2026-04-08/schemas/ucp.json"
+      },
+      "catalog_search_request": {
+        "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/catalog_search.json#/$defs/search_request"
+      },
+      "catalog_search_response": {
+        "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/catalog_search.json#/$defs/search_response"
+      },
+      "catalog_lookup_request": {
+        "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/catalog_lookup.json#/$defs/lookup_request"
+      },
+      "catalog_lookup_response": {
+        "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/catalog_lookup.json#/$defs/lookup_response"
+      },
+      "catalog_get_product_request": {
+        "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/catalog_lookup.json#/$defs/get_product_request"
+      },
+      "catalog_get_product_response": {
+        "oneOf": [
+          {
+            "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/catalog_lookup.json#/$defs/get_product_response"
+          },
+          {
+            "$ref": "https://ucp.dev/2026-04-08/schemas/shopping/types/error_response.json"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/unit/services/test_ucp_service.py
+++ b/tests/unit/services/test_ucp_service.py
@@ -322,11 +322,13 @@ async def test_discover_merchant_ucp_profile_collects_all_endpoints() -> None:
         )
 
     assert profile is not None
-    # Only MCP bindings, in profile order; the first is exposed as mcp_endpoint.
+    # MCP and REST bindings are each surfaced, in profile order; the first MCP
+    # binding is exposed as mcp_endpoint.
     assert profile.mcp_endpoints == (
         "https://a.example/mcp",
         "https://b.example/mcp",
     )
+    assert profile.rest_endpoints == ("https://a.example/rest",)
     assert profile.mcp_endpoint == "https://a.example/mcp"
 
 
@@ -380,7 +382,7 @@ async def test_discover_merchant_ucp_profile_returns_none_on_undecodable_body() 
     assert profile is None
 
 
-def test_usable_mcp_endpoint_prefers_same_origin_binding() -> None:
+def test_usable_shopping_endpoint_prefers_same_origin_binding() -> None:
     profile = MerchantUCPProfile(
         origin="https://shop.example.com",
         mcp_endpoints=(
@@ -393,10 +395,13 @@ def test_usable_mcp_endpoint_prefers_same_origin_binding() -> None:
     )
 
     # Skips the untrusted cross-host binding; matches the same-origin one.
-    assert profile.usable_mcp_endpoint() == "https://shop.example.com:443/ucp/rpc"
+    usable = profile.usable_shopping_endpoint()
+    assert usable is not None
+    assert usable.endpoint == "https://shop.example.com:443/ucp/rpc"
+    assert usable.transport == "mcp"
 
 
-def test_usable_mcp_endpoint_none_when_only_untrusted_cross_host() -> None:
+def test_usable_shopping_endpoint_none_when_only_untrusted_cross_host() -> None:
     profile = MerchantUCPProfile(
         origin="https://shop.example.com",
         mcp_endpoints=("https://other.unrelated.com/mcp",),
@@ -405,11 +410,11 @@ def test_usable_mcp_endpoint_none_when_only_untrusted_cross_host() -> None:
         version=None,
     )
 
-    assert profile.usable_mcp_endpoint() is None
+    assert profile.usable_shopping_endpoint() is None
     assert profile.supports_shopping is True
 
 
-def test_usable_mcp_endpoint_accepts_same_site_subdomain() -> None:
+def test_usable_shopping_endpoint_accepts_same_site_subdomain() -> None:
     # THE ICONIC serves its endpoint from a sibling subdomain of the storefront.
     profile = MerchantUCPProfile(
         origin="https://www.theiconic.com.au",
@@ -419,10 +424,48 @@ def test_usable_mcp_endpoint_accepts_same_site_subdomain() -> None:
         version=None,
     )
 
-    assert profile.usable_mcp_endpoint() == "https://eve.theiconic.com.au/ucp/v1"
+    usable = profile.usable_shopping_endpoint()
+    assert usable is not None
+    assert usable.endpoint == "https://eve.theiconic.com.au/ucp/v1"
 
 
-def test_usable_mcp_endpoint_accepts_trusted_suffix_only_when_configured() -> None:
+def test_usable_shopping_endpoint_selects_rest_binding() -> None:
+    # THE ICONIC and Adore Beauty advertise a same-site/same-origin REST binding
+    # rather than MCP; it must be selected and tagged with the rest transport.
+    profile = MerchantUCPProfile(
+        origin="https://www.theiconic.com.au",
+        mcp_endpoints=(),
+        rest_endpoints=("https://eve.theiconic.com.au/ucp/v1",),
+        service_names=("dev.ucp.shopping",),
+        capability_names=(),
+        version=None,
+    )
+
+    usable = profile.usable_shopping_endpoint()
+    assert usable is not None
+    assert usable.endpoint == "https://eve.theiconic.com.au/ucp/v1"
+    assert usable.transport == "rest"
+
+
+def test_usable_shopping_endpoint_prefers_mcp_over_rest_in_same_trust_class() -> None:
+    # A merchant advertising both transports same-origin is driven over MCP, the
+    # richer transport, regardless of profile order.
+    profile = MerchantUCPProfile(
+        origin="https://shop.example.com",
+        mcp_endpoints=("https://shop.example.com/ucp/rpc",),
+        rest_endpoints=("https://shop.example.com/ucp/v1",),
+        service_names=("dev.ucp.shopping",),
+        capability_names=(),
+        version=None,
+    )
+
+    usable = profile.usable_shopping_endpoint()
+    assert usable is not None
+    assert usable.transport == "mcp"
+    assert usable.endpoint == "https://shop.example.com/ucp/rpc"
+
+
+def test_usable_shopping_endpoint_accepts_trusted_suffix_only_when_configured() -> None:
     # A Shopify storefront on a custom domain advertises its *.myshopify.com host.
     profile = MerchantUCPProfile(
         origin="https://statusanxiety.com.au",
@@ -432,10 +475,10 @@ def test_usable_mcp_endpoint_accepts_trusted_suffix_only_when_configured() -> No
         version=None,
     )
 
-    assert profile.usable_mcp_endpoint() is None
-    assert profile.usable_mcp_endpoint(trusted_suffixes=("myshopify.com",)) == (
-        "https://status-anxiety-2.myshopify.com/api/ucp/mcp"
-    )
+    assert profile.usable_shopping_endpoint() is None
+    usable = profile.usable_shopping_endpoint(trusted_suffixes=("myshopify.com",))
+    assert usable is not None
+    assert usable.endpoint == "https://status-anxiety-2.myshopify.com/api/ucp/mcp"
 
 
 def test_same_site_uses_registrable_domain() -> None:
@@ -458,7 +501,7 @@ def test_host_matches_trusted_suffix_is_label_anchored() -> None:
     assert not host_matches_trusted_suffix("http://shop.myshopify.com/api", suffixes)
 
 
-def test_usable_mcp_endpoint_prefers_same_origin_over_broader_trust() -> None:
+def test_usable_shopping_endpoint_prefers_same_origin_over_broader_trust() -> None:
     # A same-origin binding listed after a trusted-suffix and a same-site one is
     # still chosen — the safest merchant-local endpoint wins over platform/
     # same-site fallbacks regardless of profile order.
@@ -474,9 +517,9 @@ def test_usable_mcp_endpoint_prefers_same_origin_over_broader_trust() -> None:
         version=None,
     )
 
-    assert profile.usable_mcp_endpoint(trusted_suffixes=("myshopify.com",)) == (
-        "https://shop.example.com/ucp/rpc"
-    )
+    usable = profile.usable_shopping_endpoint(trusted_suffixes=("myshopify.com",))
+    assert usable is not None
+    assert usable.endpoint == "https://shop.example.com/ucp/rpc"
 
 
 def test_same_site_rejects_ip_and_internal_hosts() -> None:

--- a/tests/unit/tools/test_shopping_ucp_contract.py
+++ b/tests/unit/tools/test_shopping_ucp_contract.py
@@ -18,6 +18,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
+from urllib.parse import quote
 
 import httpx
 import pytest
@@ -244,6 +245,62 @@ def _assert_conforms(
     ).validate(arguments)
 
 
+_REST_SPEC = _load_schema("rest.openapi.json")
+_CART_SCHEMA_ID = "https://ucp.dev/2026-04-08/schemas/shopping/cart.json"
+_CHECKOUT_SCHEMA_ID = "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
+
+
+def _rest_route(operation: str) -> tuple[str, str]:
+    """The ``(verb, path template)`` the vendored REST OpenAPI defines for an op."""
+    paths = cast("dict[str, dict[str, object]]", _REST_SPEC["paths"])
+    for path, item in paths.items():
+        for method, op in item.items():
+            if isinstance(op, dict) and op.get("operationId") == operation:
+                return method.upper(), path
+    msg = f"operation {operation} is not in the vendored REST OpenAPI document"
+    raise AssertionError(msg)
+
+
+def _rest_body_schema(
+    operation: str, op: str, *, cart_checkout: bool = False
+) -> dict[str, object]:
+    """The request-body schema a REST operation must conform to.
+
+    A REST cart/checkout request body is the object itself (not wrapped under a
+    ``cart``/``checkout`` key the way the MCP ``tools/call`` arguments are), and
+    the resource id travels in the path, never the body.
+    """
+    object_schema = {
+        "create_cart": _SCHEMAS_BY_ID[_CART_SCHEMA_ID],
+        "update_cart": _SCHEMAS_BY_ID[_CART_SCHEMA_ID],
+        "create_checkout": _CART_CHECKOUT_SCHEMA
+        if cart_checkout
+        else _SCHEMAS_BY_ID[_CHECKOUT_SCHEMA_ID],
+    }[operation]
+    return _request_object_schema(object_schema, op, provided_params=frozenset({"id"}))
+
+
+def _assert_rest_conforms(
+    operation: str,
+    captured: dict[str, object],
+    *,
+    expected_url: str,
+    cart_checkout: bool = False,
+) -> None:
+    """Validate a captured REST request's verb, URL, and body against the spec."""
+    verb, _path = _rest_route(operation)
+    assert captured["method"] == verb
+    assert captured["url"] == expected_url
+    body = captured["body"]
+    if operation in {"create_cart", "update_cart", "create_checkout"}:
+        op = _METHOD_OP[operation]
+        Draft202012Validator(
+            _rest_body_schema(operation, op, cart_checkout=cart_checkout)
+        ).validate(body)
+    else:
+        assert body is None
+
+
 def _private_key_pem() -> str:
     private_key = ec.generate_private_key(ec.SECP256R1())
     return private_key.private_bytes(
@@ -272,6 +329,7 @@ def _context(app_config: AppConfig) -> ToolExecutionContext:
 
 class _CapturingClient:
     posts: list[dict[str, object]] = []
+    requests: list[dict[str, object]] = []
     post_responses: list[httpx.Response] = []
     profile_responses: list[httpx.Response] = []
 
@@ -305,6 +363,24 @@ class _CapturingClient:
         self.posts.append(json.loads((content or b"{}").decode("utf-8")))
         return self.post_responses.pop(0)
 
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str],
+        content: bytes | None,
+    ) -> httpx.Response:
+        # REST transport calls go through client.request(verb, url, ...). Record
+        # the verb, URL, and decoded body so the contract test can validate the
+        # request the REST path actually emits.
+        self.requests.append({
+            "method": method,
+            "url": url,
+            "body": json.loads(content.decode("utf-8")) if content else None,
+        })
+        return self.post_responses.pop(0)
+
 
 def _reset_client(
     monkeypatch: MonkeyPatch,
@@ -314,6 +390,7 @@ def _reset_client(
 ) -> None:
     monkeypatch.setattr(shopping.httpx, "AsyncClient", _CapturingClient)
     _CapturingClient.posts = []
+    _CapturingClient.requests = []
     _CapturingClient.post_responses = post_responses
     _CapturingClient.profile_responses = profile_responses or []
 
@@ -410,6 +487,42 @@ def _checkout_only_profile() -> httpx.Response:
             }
         },
     )
+
+
+def _rest_profile(*, checkout_only: bool = False) -> httpx.Response:
+    # THE ICONIC / Adore Beauty advertise a same-origin/same-site REST binding
+    # instead of MCP. Adore is checkout-only (no cart capability).
+    capabilities: dict[str, object] = {"dev.ucp.shopping.checkout": [{}]}
+    if not checkout_only:
+        capabilities["dev.ucp.shopping.cart"] = [{}]
+    return httpx.Response(
+        200,
+        json={
+            "ucp": {
+                "services": {
+                    "dev.ucp.shopping": [
+                        {
+                            "transport": "rest",
+                            "endpoint": "https://shop.example.com/ucp/v1",
+                        }
+                    ]
+                },
+                "capabilities": capabilities,
+            }
+        },
+    )
+
+
+def _rest_cart_response(
+    *, line_items: list[dict[str, object]] | None = None
+) -> httpx.Response:
+    # A REST cart response IS the cart object itself (cart_result =
+    # oneOf[cart, error_response]) — no JSON-RPC envelope, no structuredContent.
+    return httpx.Response(200, json=_spec_cart(line_items=line_items))
+
+
+def _rest_checkout_response() -> httpx.Response:
+    return httpx.Response(200, json=_spec_checkout())
 
 
 async def test_create_cart_request_conforms_to_spec(monkeypatch: MonkeyPatch) -> None:
@@ -552,3 +665,123 @@ def test_cart_parser_reads_spec_shaped_response_and_rejects_legacy_wrapper() -> 
     with pytest.raises(ValueError, match="did not include a cart"):
         # SLF001: same rationale — exercise the private parser directly.
         shopping._cart_from_response(wrapped)  # noqa: SLF001
+
+
+async def test_rest_create_cart_request_conforms_to_spec(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _reset_client(
+        monkeypatch,
+        post_responses=[_rest_cart_response()],
+        profile_responses=[_rest_profile()],
+    )
+
+    await shopping.ucp_add_to_cart_tool(
+        _context(AppConfig(server_url="https://assistant.example")),
+        business_url="https://shop.example.com/products/sweater",
+        line_items=[{"variant_id": "gid://shopify/ProductVariant/1", "quantity": 2}],
+    )
+
+    _assert_rest_conforms(
+        "create_cart",
+        _CapturingClient.requests[0],
+        expected_url="https://shop.example.com/ucp/v1/carts",
+    )
+
+
+async def test_rest_update_cart_requests_conform_to_spec(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    existing = [{"quantity": 1, "item": {"id": "gid://shopify/ProductVariant/1"}}]
+    cart_id = "gid://shopify/Cart/cart_abc123"
+    _reset_client(
+        monkeypatch,
+        post_responses=[
+            _rest_cart_response(line_items=existing),
+            _rest_cart_response(),
+        ],
+        profile_responses=[_rest_profile()],
+    )
+
+    await shopping.ucp_add_to_cart_tool(
+        _context(AppConfig(server_url="https://assistant.example")),
+        business_url="https://shop.example.com",
+        cart_id=cart_id,
+        line_items=[{"variant_id": "gid://shopify/ProductVariant/2", "quantity": 1}],
+    )
+
+    quoted = quote(cart_id, safe="")
+    # The opaque cart id is URL-encoded into the path so its slashes/colons
+    # cannot escape the segment.
+    assert "%2F" in quoted
+    _assert_rest_conforms(
+        "get_cart",
+        _CapturingClient.requests[0],
+        expected_url=f"https://shop.example.com/ucp/v1/carts/{quoted}",
+    )
+    _assert_rest_conforms(
+        "update_cart",
+        _CapturingClient.requests[1],
+        expected_url=f"https://shop.example.com/ucp/v1/carts/{quoted}",
+    )
+
+
+async def test_rest_checkout_only_create_checkout_request_conforms_to_spec(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    _reset_client(
+        monkeypatch,
+        post_responses=[_rest_checkout_response()],
+        profile_responses=[_rest_profile(checkout_only=True)],
+    )
+
+    await shopping.ucp_add_to_cart_tool(
+        _context(_signed_config()),
+        business_url="https://shop.example.com/products/serum",
+        line_items=[{"variant_id": "gid://shopify/ProductVariant/1", "quantity": 2}],
+        context={"address_country": "AU"},
+    )
+
+    _assert_rest_conforms(
+        "create_checkout",
+        _CapturingClient.requests[0],
+        expected_url="https://shop.example.com/ucp/v1/checkout-sessions",
+    )
+
+
+async def test_rest_cart_handoff_create_checkout_request_conforms_to_spec(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    existing = [{"quantity": 1, "item": {"id": "gid://shopify/ProductVariant/1"}}]
+    cart_id = "gid://shopify/Cart/cart_abc123"
+    _reset_client(
+        monkeypatch,
+        post_responses=[
+            _rest_cart_response(line_items=existing),
+            _rest_checkout_response(),
+        ],
+        profile_responses=[_rest_profile()],
+    )
+
+    await shopping.ucp_transfer_checkout_to_human_tool(
+        _context(_signed_config()),
+        business_url="https://shop.example.com",
+        cart_id=cart_id,
+    )
+
+    quoted = quote(cart_id, safe="")
+    _assert_rest_conforms(
+        "get_cart",
+        _CapturingClient.requests[0],
+        expected_url=f"https://shop.example.com/ucp/v1/carts/{quoted}",
+    )
+    create = _CapturingClient.requests[1]
+    # The cart handoff converts via cart_id inside the checkout object, valid
+    # under the cart-capability "Checkout with Cart" extension.
+    _assert_rest_conforms(
+        "create_checkout",
+        create,
+        expected_url="https://shop.example.com/ucp/v1/checkout-sessions",
+        cart_checkout=True,
+    )
+    assert cast("dict[str, object]", create["body"])["cart_id"] == cart_id

--- a/tests/unit/tools/test_shopping_ucp_contract.py
+++ b/tests/unit/tools/test_shopping_ucp_contract.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from urllib.parse import quote
+from uuid import UUID
 
 import httpx
 import pytest
@@ -250,15 +251,50 @@ _CART_SCHEMA_ID = "https://ucp.dev/2026-04-08/schemas/shopping/cart.json"
 _CHECKOUT_SCHEMA_ID = "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json"
 
 
-def _rest_route(operation: str) -> tuple[str, str]:
-    """The ``(verb, path template)`` the vendored REST OpenAPI defines for an op."""
+def _rest_path_item(operation: str) -> tuple[str, str, dict[str, object]]:
+    """Return ``(verb, path, path_item)`` for a REST operation in the spec."""
     paths = cast("dict[str, dict[str, object]]", _REST_SPEC["paths"])
     for path, item in paths.items():
         for method, op in item.items():
             if isinstance(op, dict) and op.get("operationId") == operation:
-                return method.upper(), path
+                return method.upper(), path, cast("dict[str, object]", item)
     msg = f"operation {operation} is not in the vendored REST OpenAPI document"
     raise AssertionError(msg)
+
+
+def _rest_route(operation: str) -> tuple[str, str]:
+    """The ``(verb, path template)`` the vendored REST OpenAPI defines for an op."""
+    verb, path, _item = _rest_path_item(operation)
+    return verb, path
+
+
+def _rest_required_headers(operation: str) -> set[str]:
+    """Header parameters the vendored REST OpenAPI marks required for an op.
+
+    Path/query/cookie params are excluded; ``$ref``-ed parameter components are
+    resolved so shared headers (``Request-Id``, ``Idempotency-Key``,
+    ``UCP-Agent``) are picked up.
+    """
+    components = cast(
+        "dict[str, dict[str, object]]",
+        cast("dict[str, object]", _REST_SPEC["components"])["parameters"],
+    )
+    _verb, _path, item = _rest_path_item(operation)
+    op = next(
+        value
+        for key, value in item.items()
+        if isinstance(value, dict) and value.get("operationId") == operation
+    )
+    raw_params = cast("list[dict[str, object]]", item.get("parameters", [])) + cast(
+        "list[dict[str, object]]", cast("dict[str, object]", op).get("parameters", [])
+    )
+    required: set[str] = set()
+    for param in raw_params:
+        ref = param.get("$ref")
+        resolved = components[cast("str", ref).split("/")[-1]] if ref else param
+        if resolved.get("in") == "header" and resolved.get("required"):
+            required.add(cast("str", resolved["name"]))
+    return required
 
 
 def _rest_body_schema(
@@ -291,6 +327,17 @@ def _assert_rest_conforms(
     verb, _path = _rest_route(operation)
     assert captured["method"] == verb
     assert captured["url"] == expected_url
+
+    # Every spec-required REST header must be present (case-insensitive). This
+    # binds the test to rest.openapi.json: Request-Id (all routes) and
+    # Idempotency-Key (write routes), plus UCP-Agent.
+    sent_headers = {
+        name.lower(): value
+        for name, value in cast("dict[str, str]", captured["headers"]).items()
+    }
+    for header in _rest_required_headers(operation):
+        assert header.lower() in sent_headers, f"missing required REST header {header}"
+
     body = captured["body"]
     if operation in {"create_cart", "update_cart", "create_checkout"}:
         op = _METHOD_OP[operation]
@@ -372,11 +419,12 @@ class _CapturingClient:
         content: bytes | None,
     ) -> httpx.Response:
         # REST transport calls go through client.request(verb, url, ...). Record
-        # the verb, URL, and decoded body so the contract test can validate the
-        # request the REST path actually emits.
+        # the verb, URL, headers, and decoded body so the contract test can
+        # validate the request the REST path actually emits.
         self.requests.append({
             "method": method,
             "url": url,
+            "headers": dict(headers),
             "body": json.loads(content.decode("utf-8")) if content else None,
         })
         return self.post_responses.pop(0)
@@ -785,3 +833,38 @@ async def test_rest_cart_handoff_create_checkout_request_conforms_to_spec(
         cart_checkout=True,
     )
     assert cast("dict[str, object]", create["body"])["cart_id"] == cart_id
+
+
+def _header(captured: dict[str, object], name: str) -> str | None:
+    for key, value in cast("dict[str, str]", captured["headers"]).items():
+        if key.lower() == name.lower():
+            return value
+    return None
+
+
+async def test_rest_write_request_sends_uuid_request_and_idempotency_headers(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # The REST OpenAPI requires Request-Id (all routes) and Idempotency-Key
+    # (write routes) as UUIDs. The unsigned create_cart path must emit both as
+    # valid UUIDs; a spec-enforcing merchant rejects the call otherwise.
+    _reset_client(
+        monkeypatch,
+        post_responses=[_rest_cart_response()],
+        profile_responses=[_rest_profile()],
+    )
+
+    await shopping.ucp_add_to_cart_tool(
+        _context(AppConfig(server_url="https://assistant.example")),
+        business_url="https://shop.example.com/products/sweater",
+        line_items=[{"variant_id": "gid://shopify/ProductVariant/1", "quantity": 2}],
+    )
+
+    write = _CapturingClient.requests[0]
+    request_id = _header(write, "Request-Id")
+    idempotency_key = _header(write, "Idempotency-Key")
+    assert request_id is not None
+    assert idempotency_key is not None
+    # Parsing as a UUID asserts the spec's `format: uuid` is honoured.
+    assert str(UUID(request_id)) == request_id
+    assert str(UUID(idempotency_key)) == idempotency_key


### PR DESCRIPTION
THE ICONIC and Adore Beauty advertise the UCP shopping service over
transport "rest" rather than "mcp". The client only spoke the MCP
JSON-RPC transport, so discovery surfaced no usable endpoint for those
merchants and the tools fell back to the Shopify "/api/ucp/mcp"
convention, which does not exist on those hosts — every rest-only
merchant was unreachable ("UCP response was not JSON").

Discovery now surfaces "rest" bindings alongside "mcp" ones
(MerchantUCPProfile.rest_endpoints). usable_shopping_endpoint() replaces
usable_mcp_endpoint(), selecting the safest endpoint across both
transports using the unchanged trust ranking (same-origin -> same-site
-> trusted suffix) and preferring MCP within a trust class; it returns
the chosen transport so it can be threaded through _ResolvedMerchant.

The shopping tools branch on transport via a _ucp_call dispatcher: each
UCP operation maps to the MCP tools/call body or to the REST verb/path
from rest.openapi.json (POST /carts, GET|PUT /carts/{id},
POST /checkout-sessions). The cart/checkout object is the REST request
body directly (the resource id is URL-encoded into the path), RFC 9421
signing is reused unchanged, and a REST response is re-nested under the
MCP result.structuredContent shape so the cart/checkout parsers work
as-is. The browser shoppable hint now also fires for REST merchants.

rest.openapi.json is vendored into tests/data/ucp/2026-04-08/ and the
contract test validates the REST request bodies and verb/paths against
it, the same way it validates the MCP tools/call bodies.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GQZaEXRzzdCGvdQVnseMkY