### PR TITLE
Make jq_query and read_text_attachment available in all profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,7 +344,9 @@ profile's tool-policy engine, regardless of the profile's own `tools_policy` (wh
 replaces the shipped defaults wholesale). Use it for tools that must be available in all contexts.
 Operator policy still overrides global rules. The shipped default uses it to make
 `report_technical_problem` available in every profile so the assistant can always report bugs (they
-surface in the error-log and diagnostics endpoints above).
+surface in the error-log and diagnostics endpoints above), and to make `read_text_attachment` and
+`jq_query` available in every profile so the assistant can always read back tool results that
+exceeded the large-result threshold and were auto-converted to attachments.
 
 ### Embedding Providers
 

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -317,6 +317,13 @@ global_tools_policy:
       decision: "allow"
       priority: 50
       description: "report_technical_problem is available in every profile so the assistant can always report bugs."
+    - match:
+        names:
+          - "read_text_attachment"
+          - "jq_query"
+      decision: "allow"
+      priority: 50
+      description: "read_text_attachment and jq_query are available in every profile so the assistant can always read back tool results that exceeded the large-result threshold and were auto-converted to attachments."
 
 default_profile_settings:
   processing_config:

--- a/tests/functional/tools/test_defaults_tool_policy_parity.py
+++ b/tests/functional/tools/test_defaults_tool_policy_parity.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 import yaml
 
+from family_assistant.assistant import (
+    _build_profile_policy_engine,  # noqa: PLC2701 - smallest helper that applies global_tools_policy injection to a profile
+)
 from family_assistant.config_loader import (
     load_prompts_yaml,
     resolve_all_service_profiles,
@@ -13,7 +16,7 @@ from family_assistant.config_models import (
     ServiceProfile,
 )
 from family_assistant.tools import LOCAL_TOOL_DESCRIPTORS, PolicyEngine, ToolDescriptor
-from family_assistant.tools.policy import ToolPolicyDecision
+from family_assistant.tools.policy import ToolPolicyConfig, ToolPolicyDecision
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DEFAULTS_PATH = REPO_ROOT / "defaults.yaml"
@@ -189,6 +192,55 @@ def test_ucp_tools_are_default_on_demand_and_not_confirm_gated() -> None:
             ).decision
             == ToolPolicyDecision.ALLOW
         )
+
+
+def _load_global_tools_policy() -> ToolPolicyConfig:
+    defaults_data = _load_defaults_yaml()
+    global_policy = defaults_data["global_tools_policy"]
+    assert isinstance(global_policy, dict)
+    return ToolPolicyConfig.model_validate(global_policy)
+
+
+def _local_descriptor(name: str) -> ToolDescriptor:
+    for descriptor in LOCAL_TOOL_DESCRIPTORS:
+        if descriptor.name == name:
+            return descriptor
+    raise AssertionError(f"{name} descriptor not found")
+
+
+def test_large_result_tools_available_in_every_profile() -> None:
+    """read_text_attachment and jq_query must be reachable from every profile.
+
+    Large tool results are auto-converted to attachments and the assistant is
+    told to read them back with these tools, so they have to survive even a
+    deny-by-default profile that never mentions them. The shipped
+    global_tools_policy injects them into every profile's engine.
+    """
+    default_settings, profiles = _load_resolved_profiles()
+    global_policy = _load_global_tools_policy()
+    read_text = _local_descriptor("read_text_attachment")
+    jq = _local_descriptor("jq_query")
+
+    profile_map: dict[str, DefaultProfileSettings | ServiceProfile] = {
+        "default_profile_settings": default_settings,
+        **{profile.id: profile for profile in profiles},
+    }
+
+    for profile_id, profile in profile_map.items():
+        engine = _build_profile_policy_engine(
+            profile_id,
+            profile.tools_policy,
+            None,
+            global_policy,
+        )
+        for descriptor in (read_text, jq):
+            assert (
+                engine.evaluate_for_execution(
+                    descriptor,
+                    can_confirm=False,
+                ).decision
+                is ToolPolicyDecision.ALLOW
+            ), f"{descriptor.name} not allowed in {profile_id}"
 
 
 def _delegate_descriptor() -> ToolDescriptor:


### PR DESCRIPTION
## Summary

When a tool result exceeds the large-result threshold, the system auto-converts it to an attachment and instructs the LLM to read it back with `read_text_attachment` (or `jq_query` for JSON). But a profile's `tools_policy` *replaces* the shipped defaults wholesale, so any deny-by-default profile (e.g. `email_intake`, `browser_profile`, `research`, `data_visualization`) that didn't explicitly list these tools could not access its own large output — leaving the assistant stuck.

This wires both tools through the existing `global_tools_policy` mechanism, which injects rules into **every** profile's policy engine regardless of the profile's own `tools_policy`. This mirrors the existing `report_technical_problem` rule. Operator policy can still override.

## Changes

- **`defaults.yaml`** — added a `global_tools_policy` rule allowing `read_text_attachment` and `jq_query` in all profiles (priority 50, same pattern as the existing `report_technical_problem` rule).
- **`tests/functional/tools/test_defaults_tool_policy_parity.py`** — added `test_large_result_tools_available_in_every_profile`, which loads the shipped `global_tools_policy` and asserts via the real `_build_profile_policy_engine` injection that both tools are executable (without confirmation) in every shipped profile.
- **`AGENTS.md`** — documented the new global rule alongside the existing `report_technical_problem` description.

## Security note

`read_text_attachment` is tagged `SENSITIVE_DATA`, so making it global slightly widens what `[AC]` untrusted-sandboxed-style profiles can touch. In practice it only reads attachments resolvable through the conversation's attachment registry (the same scope used for the auto-converted results), and the change is processing infrastructure rather than a new data path. If tighter scoping is preferred (e.g. excluding specific sandboxed profiles), that's a straightforward follow-up.

## Testing

- `pytest tests/functional/tools/test_defaults_tool_policy_parity.py tests/unit/tools/test_global_tools_policy.py` — pass
- `pytest tests/functional/tools/test_large_tool_results.py tests/unit/tools/test_email_intake_policy.py tests/functional/tools/test_report_technical_problem.py` — pass
- `scripts/format-and-lint.sh` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)