### PR TITLE
Decouple A2A async delegation cap from per-call HTTP timeout

### DIFF
--- a/docs/design/a2a-native-async-delegation.md
+++ b/docs/design/a2a-native-async-delegation.md
@@ -398,8 +398,10 @@ The existing SDK-based `send_message` stays for the synchronous delegation path 
 - Poll via `tasks/get` (not `resubscribe`) for v1 — restart-safe, no held connection. The async
   server makes a real `tasks/get` available in the loopback.
 - Config (`remote_a2a` profile): `poll_interval_seconds` (default 10 s, light backoff to 60 s) and
-  `max_async_seconds` (the wall-clock cap). `max_async_seconds` defaults to the profile's
-  `timeout_seconds` so an existing remote keeps its effective cap; raise it explicitly to let async
-  delegation outlast a single HTTP timeout.
+  `max_async_seconds` (the wall-clock cap). `max_async_seconds` is decoupled from the per-HTTP-call
+  `timeout_seconds` and defaults to one hour (`DEFAULT_REMOTE_MAX_ASYNC_SECONDS = 3600 s`), so a
+  long-running async delegation is not killed at the single-request timeout boundary. Lower or raise
+  it explicitly per remote. The cap only reaps a genuinely orphaned remote run; the assistant can
+  poll a still-running delegation via `get_delegation_status` within this envelope.
 - No user-facing `cancel_delegation` tool in v1 (cancellation is internal: reaper/cap); revisit with
   the `input_required` continuation work.

--- a/src/family_assistant/assistant.py
+++ b/src/family_assistant/assistant.py
@@ -18,7 +18,10 @@ import uvicorn
 
 # Import Embedding interface/clients
 from family_assistant import embeddings
-from family_assistant.config_models import AppConfig  # noqa: TC001  # Used at runtime
+from family_assistant.config_models import (
+    DEFAULT_REMOTE_MAX_ASYNC_SECONDS,
+    AppConfig,  # noqa: TC001  # Used at runtime
+)
 from family_assistant.config_models import (  # noqa: TC001  # Used at runtime
     CalendarConfig as PydanticCalendarConfig,
 )
@@ -1312,13 +1315,15 @@ class Assistant:
             timeout=remote_config.timeout_seconds,
         )
 
-        # Preserve the configured timeout as the async wall-clock cap unless an
-        # explicit max_async_seconds is set (async delegation may legitimately
-        # outlast a single HTTP timeout, but defaulting to it keeps prior caps).
+        # The async wall-clock cap is decoupled from the per-HTTP-call timeout: an
+        # async delegation is polled across many short calls and may legitimately
+        # run far longer than a single request, so default it to one hour rather
+        # than killing the run at the timeout_seconds boundary. The cap only reaps
+        # a genuinely orphaned remote run; the assistant can poll status within it.
         max_async_seconds = (
             remote_config.max_async_seconds
             if remote_config.max_async_seconds is not None
-            else remote_config.timeout_seconds
+            else DEFAULT_REMOTE_MAX_ASYNC_SECONDS
         )
         service_config = RemoteServiceConfig(
             id=profile_conf.id,

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -175,6 +175,16 @@ class RemoteA2AAuthConfig(BaseModel):
     header_name: str = "Authorization"
 
 
+# Default wall-clock cap for an async (submit-then-poll) A2A delegation when
+# ``max_async_seconds`` is not set explicitly. This is intentionally decoupled
+# from ``timeout_seconds`` (the per-HTTP-call timeout): an async delegation is
+# polled across many short HTTP calls and may legitimately run far longer than a
+# single request. The cap only exists to reap a genuinely orphaned remote run
+# that never reaches a terminal state; the assistant can poll a still-running
+# delegation via ``get_delegation_status`` within this envelope.
+DEFAULT_REMOTE_MAX_ASYNC_SECONDS = 3600.0
+
+
 class RemoteA2AConfig(BaseModel):
     """Configuration for a remote A2A agent profile."""
 
@@ -187,8 +197,9 @@ class RemoteA2AConfig(BaseModel):
     # Async (submit-then-poll) delegation tuning. poll_interval_seconds is the
     # base cadence for polling an in-flight remote task; max_async_seconds is the
     # total wall-clock cap before the delegation is cancelled + failed. When
-    # max_async_seconds is unset it defaults to timeout_seconds, preserving the
-    # effective cap configured for the (previously blocking) remote.
+    # max_async_seconds is unset it defaults to DEFAULT_REMOTE_MAX_ASYNC_SECONDS
+    # (1 hour) rather than the per-call timeout, so a long-running remote run is
+    # not killed at the 5-minute HTTP-call boundary.
     poll_interval_seconds: float = Field(default=10.0, gt=0)
     max_async_seconds: float | None = Field(default=None, gt=0)
 

--- a/tests/unit/test_remote_a2a_setup.py
+++ b/tests/unit/test_remote_a2a_setup.py
@@ -1,0 +1,56 @@
+"""Unit tests for resolving async-delegation config when registering a remote A2A profile."""
+
+from types import SimpleNamespace
+
+from family_assistant.a2a.remote_service import RemoteA2AService
+from family_assistant.assistant import Assistant
+from family_assistant.config_models import (
+    DEFAULT_REMOTE_MAX_ASYNC_SECONDS,
+    RemoteA2AConfig,
+    ServiceProfile,
+)
+
+
+def _register(profile: ServiceProfile) -> RemoteA2AService:
+    """Run ``_setup_remote_a2a_profile`` against a minimal stand-in self.
+
+    The method only reads ``self.processing_services_registry``, so a lightweight
+    namespace is sufficient and avoids constructing a full Assistant.
+    """
+    fake_self = SimpleNamespace(processing_services_registry={})
+    Assistant._setup_remote_a2a_profile(fake_self, profile)  # type: ignore[arg-type]
+    return fake_self.processing_services_registry[profile.id]
+
+
+def test_max_async_seconds_defaults_to_one_hour_not_call_timeout() -> None:
+    """Unset max_async_seconds resolves to the 1-hour default, decoupled from timeout_seconds."""
+    profile = ServiceProfile(
+        id="remote_agent",
+        remote_a2a=RemoteA2AConfig(
+            agent_url="https://agent.example.com/a2a",
+            timeout_seconds=120.0,
+        ),
+    )
+
+    service = _register(profile)
+
+    assert service.service_config.max_async_seconds == DEFAULT_REMOTE_MAX_ASYNC_SECONDS
+    assert service.service_config.max_async_seconds == 3600.0
+    # The per-HTTP-call timeout is preserved independently of the wall-clock cap.
+    assert service.service_config.timeout_seconds == 120.0
+
+
+def test_explicit_max_async_seconds_is_preserved() -> None:
+    """An explicit max_async_seconds overrides the default."""
+    profile = ServiceProfile(
+        id="remote_agent",
+        remote_a2a=RemoteA2AConfig(
+            agent_url="https://agent.example.com/a2a",
+            timeout_seconds=120.0,
+            max_async_seconds=7200.0,
+        ),
+    )
+
+    service = _register(profile)
+
+    assert service.service_config.max_async_seconds == 7200.0

--- a/tests/unit/test_remote_a2a_setup.py
+++ b/tests/unit/test_remote_a2a_setup.py
@@ -18,6 +18,9 @@ def _register(profile: ServiceProfile) -> RemoteA2AService:
     namespace is sufficient and avoids constructing a full Assistant.
     """
     fake_self = SimpleNamespace(processing_services_registry={})
+    # _setup_remote_a2a_profile reads only self.processing_services_registry, so a
+    # SimpleNamespace stand-in exercises the real method without constructing a full
+    # Assistant; the arg-type suppression covers that deliberate duck-typed self.
     Assistant._setup_remote_a2a_profile(fake_self, profile)  # type: ignore[arg-type]
     return fake_self.processing_services_registry[profile.id]
 


### PR DESCRIPTION
## Summary

Async (submit-then-poll) A2A delegations were effectively hard-capped at 5 minutes. The cap that matters for the whole delegation is `max_async_seconds` — the poll handler cancels and fails any delegation still pending past it — and it **defaulted to the per-HTTP-call `timeout_seconds` (300s)** when unset. That default was a holdover from the pre-async blocking path, where a delegation really was bounded by a single request.

With the async infrastructure in place (durable `delegation_runs` rows, submit-then-poll across many short HTTP calls, and `get_delegation_status` / `list_delegations` for the assistant to check progress), a legitimately long-running remote run was being killed at the single-request boundary for no architectural reason.

This change decouples the wall-clock cap from the per-call timeout and defaults it to **1 hour** (`DEFAULT_REMOTE_MAX_ASYNC_SECONDS = 3600s`).

## What changed

- **`config_models.py`** — added `DEFAULT_REMOTE_MAX_ASYNC_SECONDS = 3600.0`; documented that `max_async_seconds` is decoupled from `timeout_seconds`.
- **`assistant.py`** — when `max_async_seconds` is unset, resolve it to the 1-hour default instead of `timeout_seconds`. The per-HTTP-call `timeout_seconds` is unchanged, and an explicit `max_async_seconds` still overrides.
- **`docs/design/a2a-native-async-delegation.md`** — updated the "decisions locked in" note to reflect the new default.
- **`tests/unit/test_remote_a2a_setup.py`** — new tests pinning that an unset cap resolves to 1 hour (decoupled from `timeout_seconds`) and that an explicit value is preserved.

## Why keep a cap at all

A cap is still the only mechanism that reaps a genuinely orphaned remote run (one that never reaches a terminal state). Without it, a stuck run polls forever, leaving an `awaiting_remote` row and re-enqueuing poll tasks indefinitely; the cleanup reaper relies on the cap. Within the 1-hour envelope the assistant can poll a live delegation via the existing status tools rather than racing a short deadline. Operators who want a different ceiling can set `max_async_seconds` per remote.

## Testing

- New unit tests in `tests/unit/test_remote_a2a_setup.py` pass.
- Related suites pass: `tests/unit/test_config_loader.py`, `tests/functional/web/api/test_a2a_client_integration.py`, `tests/functional/automations/test_async_delegation.py` (231 passed).
- `scripts/format-and-lint.sh` passes on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyHeEv5oc735sYai9zjEvm)_