### PR TITLE
Add markdown styling and comprehensive MarkdownText tests

### DIFF
--- a/frontend/src/chat/__tests__/MarkdownText.test.jsx
+++ b/frontend/src/chat/__tests__/MarkdownText.test.jsx
@@ -33,4 +33,78 @@ describe('MarkdownText', () => {
     expect(codeElement).toBeTruthy();
     expect(codeElement?.textContent?.trim()).toBe('const x = 1;');
   });
+
+  it('wraps output in a markdown-text container for scoped styling', () => {
+    const { container } = render(<MarkdownText text="hello" />);
+
+    expect(container.querySelector('.markdown-text')).toBeTruthy();
+  });
+
+  it('renders separate paragraphs for blank-line-separated text', () => {
+    const text = 'First paragraph.\n\nSecond paragraph.';
+    const { container } = render(<MarkdownText text={text} />);
+
+    const paragraphs = container.querySelectorAll('.markdown-text > p');
+    expect(paragraphs.length).toBe(2);
+    expect(paragraphs[0]?.textContent).toBe('First paragraph.');
+    expect(paragraphs[1]?.textContent).toBe('Second paragraph.');
+  });
+
+  it('renders links as safe external anchors', () => {
+    const text = 'See the [family calendar](https://example.com/cal).';
+    const { container } = render(<MarkdownText text={text} />);
+
+    const link = container.querySelector('a');
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute('href')).toBe('https://example.com/cal');
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(link?.textContent).toBe('family calendar');
+  });
+
+  it('renders unordered lists with list items', () => {
+    const text = '- Apples\n- Oranges\n- Pears';
+    const { container } = render(<MarkdownText text={text} />);
+
+    const list = container.querySelector('ul');
+    expect(list).toBeTruthy();
+    expect(list?.querySelectorAll('li').length).toBe(3);
+  });
+
+  it('renders ordered lists', () => {
+    const text = '1. First\n2. Second';
+    const { container } = render(<MarkdownText text={text} />);
+
+    const list = container.querySelector('ol');
+    expect(list).toBeTruthy();
+    expect(list?.querySelectorAll('li').length).toBe(2);
+  });
+
+  it('renders headings', () => {
+    const text = '# Big title\n\nSome body text.';
+    const { container } = render(<MarkdownText text={text} />);
+
+    const heading = container.querySelector('h1');
+    expect(heading).toBeTruthy();
+    expect(heading?.textContent).toBe('Big title');
+  });
+
+  it('renders blockquotes', () => {
+    const text = '> Remember to arrive early.';
+    const { container } = render(<MarkdownText text={text} />);
+
+    const quote = container.querySelector('blockquote');
+    expect(quote).toBeTruthy();
+    expect(quote?.textContent?.trim()).toBe('Remember to arrive early.');
+  });
+
+  it('renders GitHub-flavored markdown tables', () => {
+    const text = '| Item | Done |\n| --- | --- |\n| Tent | yes |';
+    const { container } = render(<MarkdownText text={text} />);
+
+    const table = container.querySelector('table');
+    expect(table).toBeTruthy();
+    expect(table?.querySelectorAll('th').length).toBe(2);
+    expect(table?.querySelectorAll('tbody td').length).toBe(2);
+  });
 });

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -32,7 +32,9 @@
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
-    
+
+    --link: 221 83% 45%;
+
     --radius: 0.5rem;
 
     /* Legacy CSS variables for compatibility with existing components */
@@ -74,6 +76,8 @@
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;
+
+    --link: 213 94% 74%;
 
     /* Legacy CSS variables for dark mode */
     --bg: hsl(222.2, 84%, 4.9%);
@@ -127,5 +131,167 @@
   border-radius: 3px;
   font-size: 0.875em;
   word-break: break-all;
+}
+
+/*
+ * Tailwind's Preflight base layer resets margins, heading sizes/weights, list
+ * markers, and link colors on bare elements. Chat messages render raw markdown
+ * output (react-markdown), so without these rules paragraphs run together,
+ * headings look like body text, lists lose their bullets, and links are
+ * indistinguishable from surrounding text. Restore sensible defaults scoped to
+ * markdown content.
+ */
+.markdown-text p {
+  margin: 0.75em 0;
+  line-height: 1.6;
+}
+
+.markdown-text > :first-child {
+  margin-top: 0;
+}
+
+.markdown-text > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-text h1,
+.markdown-text h2,
+.markdown-text h3,
+.markdown-text h4,
+.markdown-text h5,
+.markdown-text h6 {
+  margin: 1.25em 0 0.5em;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.markdown-text h1 {
+  font-size: 1.5em;
+}
+
+.markdown-text h2 {
+  font-size: 1.3em;
+}
+
+.markdown-text h3 {
+  font-size: 1.15em;
+}
+
+.markdown-text h4 {
+  font-size: 1em;
+}
+
+.markdown-text h5,
+.markdown-text h6 {
+  font-size: 0.9em;
+}
+
+.markdown-text ul,
+.markdown-text ol {
+  margin: 0.75em 0;
+  padding-left: 1.5em;
+}
+
+.markdown-text ul {
+  list-style: disc;
+}
+
+.markdown-text ol {
+  list-style: decimal;
+}
+
+.markdown-text li {
+  margin: 0.25em 0;
+}
+
+.markdown-text li > ul,
+.markdown-text li > ol {
+  margin: 0.25em 0;
+}
+
+/* GitHub-flavored task lists render a checkbox as the list marker. */
+.markdown-text li:has(> input[type='checkbox']) {
+  list-style: none;
+  margin-left: -1.25em;
+}
+
+.markdown-text li > input[type='checkbox'] {
+  margin-right: 0.4em;
+}
+
+.markdown-text a {
+  color: hsl(var(--link));
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.markdown-text a:hover {
+  text-decoration-thickness: 2px;
+}
+
+/*
+ * User messages render on a filled primary bubble (see UserMessage in
+ * Thread.tsx), where the themed link color has poor contrast. Inherit the
+ * bubble's foreground color there and rely on the underline for affordance.
+ */
+[data-testid='user-message-content'] .markdown-text a {
+  color: inherit;
+}
+
+/*
+ * The muted background used for code and table headers has almost no contrast
+ * against the filled primary bubble. Tint with the bubble's own foreground
+ * color instead so it stays legible in both light and dark themes.
+ */
+[data-testid='user-message-content'] .markdown-text .inline-code,
+[data-testid='user-message-content'] .markdown-text .code-block,
+[data-testid='user-message-content'] .markdown-text th {
+  background-color: color-mix(in srgb, hsl(var(--primary-foreground)) 15%, transparent);
+}
+
+[data-testid='user-message-content'] .markdown-text .code-block {
+  border-color: color-mix(in srgb, hsl(var(--primary-foreground)) 25%, transparent);
+}
+
+.markdown-text strong {
+  font-weight: 600;
+}
+
+.markdown-text em {
+  font-style: italic;
+}
+
+.markdown-text blockquote {
+  margin: 0.75em 0;
+  padding: 0.25em 0 0.25em 1em;
+  border-left: 3px solid hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+}
+
+.markdown-text hr {
+  margin: 1.25em 0;
+  border: 0;
+  border-top: 1px solid hsl(var(--border));
+}
+
+.markdown-text table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  margin: 0.75em 0;
+  border-collapse: collapse;
+}
+
+.markdown-text th,
+.markdown-text td {
+  padding: 0.4em 0.75em;
+  border: 1px solid hsl(var(--border));
+  text-align: left;
+}
+
+.markdown-text th {
+  background-color: hsl(var(--muted));
+  font-weight: 600;
 }
 

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -253,6 +253,16 @@
   border-color: color-mix(in srgb, hsl(var(--primary-foreground)) 25%, transparent);
 }
 
+/*
+ * Blockquotes default to muted-foreground, which has poor contrast on the
+ * filled primary bubble. Inherit the bubble foreground and tint the accent
+ * border from it so quoted user text stays legible in both themes.
+ */
+[data-testid='user-message-content'] .markdown-text blockquote {
+  color: inherit;
+  border-left-color: color-mix(in srgb, hsl(var(--primary-foreground)) 40%, transparent);
+}
+
 .markdown-text strong {
   font-weight: 600;
 }
@@ -293,5 +303,42 @@
 .markdown-text th {
   background-color: hsl(var(--muted));
   font-weight: 600;
+}
+
+/*
+ * custom.css (imported after this file in the chat bundle) rewrites bare
+ * `table` elements into a stacked card layout on mobile: it blocks the row
+ * groups, hides `th`, and injects `td::before` labels. Those bare-element
+ * rules would otherwise leak into markdown tables, dropping the header row and
+ * showing stray ": " prefixes. Re-assert normal table rendering (kept
+ * horizontally scrollable by the `.markdown-text table` block above) for
+ * markdown content, relying on the higher `.markdown-text` specificity.
+ */
+@media (max-width: 768px) {
+  .markdown-text thead {
+    display: table-header-group;
+  }
+
+  .markdown-text tbody {
+    display: table-row-group;
+  }
+
+  .markdown-text tr {
+    display: table-row;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: none;
+  }
+
+  .markdown-text th,
+  .markdown-text td {
+    display: table-cell;
+  }
+
+  .markdown-text td::before {
+    content: none;
+  }
 }
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive styling for rendered markdown content and expands test coverage for the MarkdownText component. The changes ensure that markdown output (from react-markdown) displays with proper formatting and visual hierarchy, while also validating that all markdown elements render correctly.

## Key Changes
- **CSS Variables**: Added `--link` color variable for both light and dark themes to style markdown links consistently
- **Markdown Styling**: Introduced `.markdown-text` scoped styles that restore sensible defaults for:
  - Paragraphs with proper margins and line-height
  - Headings (h1-h6) with appropriate sizing, weight, and spacing
  - Lists (ordered and unordered) with proper indentation and markers
  - GitHub-flavored task list checkboxes
  - Links with underline decoration and hover effects
  - Blockquotes with left border and muted color
  - Tables with proper borders and header styling
  - Code blocks and inline code with special handling for user message bubbles
- **User Message Bubble Overrides**: Special styling for links and code elements within user message bubbles to maintain contrast and readability on filled backgrounds
- **Test Coverage**: Added 8 new test cases covering:
  - Markdown container wrapping
  - Paragraph separation
  - Link rendering with security attributes
  - Unordered and ordered lists
  - Headings
  - Blockquotes
  - GitHub-flavored markdown tables

## Implementation Details
The markdown styling is scoped to `.markdown-text` to avoid conflicts with Tailwind's Preflight base layer resets. User message content receives additional overrides to ensure proper contrast when rendered on the primary bubble background using `color-mix()` for theme-aware tinting.

https://claude.ai/code/session_01WDQAZBfCbcbtQNUuftiNng