### PR TITLE
Switch complex_tasks profile to OpenAI gpt-5.6-sol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -621,10 +621,10 @@ dynamically adjusting available tools and supervision requirements based on inpu
      confirmation)
    - Example: "Why isn't my daily brief firing?" - reads DB state, error logs, source code
 
-5. **Complex Tasks Profile [BC]**: Advanced reasoning with Claude Opus 4.7 for complex tasks
+5. **Complex Tasks Profile [BC]**: Advanced reasoning with OpenAI GPT-5.6-sol for complex tasks
 
    - Full tool access (same as Trusted Profile) for comprehensive task handling
-   - Uses Claude Opus 4.7 (`claude-opus-4-7`) for superior multi-step reasoning
+   - Uses OpenAI GPT-5.6-sol (`gpt-5.6-sol`) for superior multi-step reasoning
    - Higher iteration limit (100) for deep analysis workflows
    - Used via `/complex` slash command or delegation from default assistant
    - Example: "Plan a detailed family vacation itinerary considering everyone's preferences"

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1396,6 +1396,17 @@ service_profiles:
     processing_config:
       provider: "openai"
       llm_model: "gpt-5.6-sol"
+      # default_profile_settings ships a retry_config (Gemini primary, GPT-5.5
+      # fallback) which takes precedence over provider/llm_model above. Override
+      # it here so /complex actually runs on GPT-5.6-sol rather than inheriting
+      # the default retry chain.
+      retry_config:
+        primary:
+          provider: "openai"
+          model: "gpt-5.6-sol"
+        fallback:
+          provider: "openai"
+          model: "gpt-5.5"
       max_iterations: 100
       prompts:
         system_prompt: |

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1392,14 +1392,14 @@ service_profiles:
       - "/camera"
       - "/investigate"
   - id: "complex_tasks"
-    description: "Advanced reasoning profile using Claude Opus 4.7 for complex, multi-step tasks that require deep analysis, planning, or sophisticated judgment. Delegates here when the default model struggles with nuanced reasoning."
+    description: "Advanced reasoning profile using OpenAI GPT-5.6-sol for complex, multi-step tasks that require deep analysis, planning, or sophisticated judgment. Delegates here when the default model struggles with nuanced reasoning."
     processing_config:
-      provider: "anthropic"
-      llm_model: "claude-opus-4-7"
+      provider: "openai"
+      llm_model: "gpt-5.6-sol"
       max_iterations: 100
       prompts:
         system_prompt: |
-          You are an advanced reasoning assistant interacting with {user_name}, powered by Claude Opus 4.7. You are invoked for tasks that require deep analysis, multi-step planning, or sophisticated judgment.
+          You are an advanced reasoning assistant interacting with {user_name}, powered by OpenAI GPT-5.6-sol. You are invoked for tasks that require deep analysis, multi-step planning, or sophisticated judgment.
 
           You have full access to all Family Assistant tools — notes, calendar, documents, Home Assistant, scheduling, and more. Use these tools to gather context and take actions as needed. This is what distinguishes you from spawn_worker, which runs isolated coding agents with NO access to Family Assistant tools or data.
 

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1405,8 +1405,8 @@ service_profiles:
           provider: "openai"
           model: "gpt-5.6-sol"
         fallback:
-          provider: "openai"
-          model: "gpt-5.5"
+          provider: "anthropic"
+          model: "claude-fable-5"
       max_iterations: 100
       prompts:
         system_prompt: |

--- a/deploy/testflight-sandbox/config.yaml
+++ b/deploy/testflight-sandbox/config.yaml
@@ -69,6 +69,10 @@ service_profiles:
     processing_config:
       provider: "openai"
       llm_model: "deepseek/deepseek-v4-flash"
+      # complex_tasks pins its model via retry_config in defaults.yaml, which
+      # takes precedence over llm_model/provider. null it here so the single
+      # cheap llm_model+provider path is used.
+      retry_config: null
       # Keep the cost cap even for the "complex" profile in the sandbox.
       max_iterations: 8
   - id: "engineer"

--- a/scripts/container-smoke-test.sh
+++ b/scripts/container-smoke-test.sh
@@ -40,6 +40,7 @@ echo "Launching container..."
 docker run -d --name "$CONTAINER_NAME" -p "$PORT:$PORT" \
     -e GEMINI_API_KEY=dummy \
     -e OPENAI_API_KEY=dummy \
+    -e ANTHROPIC_API_KEY=dummy \
     -e BRAVE_API_KEY=dummy \
     -e HOMEASSISTANT_API_KEY=dummy \
     -e GOOGLE_MAPS_API_KEY=dummy \


### PR DESCRIPTION
Change the complex_tasks service profile model from Claude Opus 4.7
(anthropic) to OpenAI gpt-5.6-sol, and update the profile description,
system prompt, and AGENTS.md documentation to match.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015r9gxmgvefiDS9RUFiK6aJ