### PR TITLE
fix(ios): bound chat lifecycle and exit layout

### DIFF
--- a/docs/design/ios-chat-layout-watchdog-crash.md
+++ b/docs/design/ios-chat-layout-watchdog-crash.md
@@ -320,9 +320,14 @@ could still consume the full scene-update allowance.
 - Stop encoding activity into the message list's `followTrigger`. `StickyBottomScroll` instead
   checks an injected `canFollow` closure when a passive trigger changes; production reads
   `UIApplication.shared.applicationState` without creating a SwiftUI environment dependency. The
-  force-follow signal remains unconditional because it is emitted only by an active user send.
+  force-follow signal remains unconditional because it is emitted only by an active user send. If
+  lifecycle suppression defers an otherwise-allowed passive follow, the shared scroll container
+  preserves it and retries on `UIApplication.didBecomeActiveNotification`; the content that arrived
+  in the background is therefore visible immediately on foregrounding without invalidating the heavy
+  parent view.
 - Cover the lifecycle suppression at the hosted scroll-view layer: an otherwise-allowed passive
-  follow is denied while `canFollow` is false and leaves the scroll position untouched.
+  follow is denied while `canFollow` is false and leaves the scroll position untouched, then the
+  same pending follow runs when the lifecycle gate reopens.
 
 ### M9 — Eager-window process-exit layout (foreground recurrence, build 39)
 

--- a/docs/design/ios-chat-layout-watchdog-crash.md
+++ b/docs/design/ios-chat-layout-watchdog-crash.md
@@ -6,7 +6,9 @@ M1–M3 shipped (PR #920, 2026-06-18). M4 (suspend-watchdog recurrence) shipped 
 #955) bounded per-message markdown layout after a **foreground** recurrence on build 23. M6 added
 after a **foreground** recurrence on build 36 traced to the auto-follow scroll yanking a user who
 had scrolled up. M7 covers the follow-up build 36 recurrence where the user manually scrolled while
-waiting for a streamed reply; the remaining hot path was LazyStack placement itself.
+waiting for a streamed reply; the remaining hot path was LazyStack placement itself. M8 covers a
+build 39 background recurrence where the heavy thread itself observed `scenePhase`, invalidating the
+bounded eager stack during the scene update.
 
 ## Summary
 
@@ -220,19 +222,19 @@ markdown subtree (the sampled per-bubble subtree is normal depth, and the per-me
 is intact). `WatchdogCPUStatistics` show only ~17 % app CPU across the window: the main thread was
 not pegged in one hot loop, it was re-running placement passes that never settled.
 
-**Root cause.** `messageScrollArea` fired `proxy.scrollTo(lastID, anchor: .bottom)` on *every* change
-of the newest bubble's id, gated only on `scenePhase == .active`. When a reply lands while the user
-has scrolled up (or is mid-drag), that bottom-anchored `scrollTo` forces the `LazyVStack` to
-re-resolve its bottom anchor and `measureBackwards` over the visible rows while fighting the user's
-scroll position — it never converges, and the 10 s scene-update watchdog kills the app. This is the
-unanimated cousin of M5's second cause (animated scroll-to-bottom): M5 dropped the animation, which
-fixed the *send-while-idle* case, but not *reply-arrives-while-reading-history*.
+**Root cause.** `messageScrollArea` fired `proxy.scrollTo(lastID, anchor: .bottom)` on *every*
+change of the newest bubble's id, gated only on `scenePhase == .active`. When a reply lands while
+the user has scrolled up (or is mid-drag), that bottom-anchored `scrollTo` forces the `LazyVStack`
+to re-resolve its bottom anchor and `measureBackwards` over the visible rows while fighting the
+user's scroll position — it never converges, and the 10 s scene-update watchdog kills the app. This
+is the unanimated cousin of M5's second cause (animated scroll-to-bottom): M5 dropped the animation,
+which fixed the *send-while-idle* case, but not *reply-arrives-while-reading-history*.
 
 **Related case found (no separate report yet).** The voice transcript (`VoiceView.swift`) had the
 *same* class of bug in a different shape: it scrolled `withAnimation` on **every streamed token**
 (`onChange(of: entries.last?.text)`) — animated follow (M5 cause #2) fired at partial-transcript
-frequency, a latent live-voice wedge. Two hand-rolled auto-followers, each unsafe in a different way,
-with no shared invariant.
+frequency, a latent live-voice wedge. Two hand-rolled auto-followers, each unsafe in a different
+way, with no shared invariant.
 
 **Fix (single choke point for auto-follow).** Introduce `StickyBottomScroll` (in `ChatViews.swift`)
 and route **both** the chat thread and the voice transcript through it — mirroring how
@@ -242,9 +244,9 @@ place:
 - **Never animate the follow scroll** (kills the M5-cause-#2 shape wherever it recurs, including
   voice).
 - **Only follow a passive arrival when near the bottom.** A zero-height bottom sentinel tracks "is
-  the user at the bottom" (`onAppear`/`onDisappear`); a *passive* arrival (streamed reply, tool step,
-  synced message; `followTrigger` = the newest bubble's id) follows only when they are near the
-  bottom — so a reply never yanks a reader who scrolled up.
+  the user at the bottom" (`onAppear`/`onDisappear`); a *passive* arrival (streamed reply, tool
+  step, synced message; `followTrigger` = the newest bubble's id) follows only when they are near
+  the bottom — so a reply never yanks a reader who scrolled up.
 - **A local send always pins to the bottom, signalled explicitly.** Sending is a user-initiated
   event and must scroll into view even from scrolled-up. It can *not* be inferred from the last
   bubble's role: `sendDraft()` appends the user bubble **and** an assistant loading placeholder, so
@@ -256,15 +258,16 @@ place:
   the yank.
 
 **Coverage.** `ChatViewModelTests.testSendDraftRequestsScrollToLatest…` asserts a send bumps the
-force signal (the local-send case a role heuristic misses). `ChatLayoutBudgetTests.testStickyBottomScroll*`
-hosts the real `StickyBottomScroll`, scrolls it up, and asserts: a *denied* passive follow does not
-jump to the bottom, an *allowed* one does, and a *force* trigger scrolls even when the gate denies
-(the deny/allow pair is mutually validating — the allow case proves the follow mechanism fires, so
-the deny case is non-vacuous). These UIKit-hosted tests wait on the observed scroll state via a
-run-loop poll (`waitUntil`), never a fixed sleep, and wait for the initial land to settle before
-scrolling up so a late `onAppear` scroll can't masquerade as a follow. The existing
-`testFollowUpAfterToolTurnStaysResponsive` / `testNativeChatSendsAndStreamsResponse` UI tests
-continue to cover open-lands-at-bottom and send-follows in the real app.
+force signal (the local-send case a role heuristic misses).
+`ChatLayoutBudgetTests.testStickyBottomScroll*` hosts the real `StickyBottomScroll`, scrolls it up,
+and asserts: a *denied* passive follow does not jump to the bottom, an *allowed* one does, and a
+*force* trigger scrolls even when the gate denies (the deny/allow pair is mutually validating — the
+allow case proves the follow mechanism fires, so the deny case is non-vacuous). These UIKit-hosted
+tests wait on the observed scroll state via a run-loop poll (`waitUntil`), never a fixed sleep, and
+wait for the initial land to settle before scrolling up so a late `onAppear` scroll can't masquerade
+as a follow. The existing `testFollowUpAfterToolTurnStaysResponsive` /
+`testNativeChatSendsAndStreamsResponse` UI tests continue to cover open-lands-at-bottom and
+send-follows in the real app.
 
 ### M7 — Manual scroll during streaming (foreground recurrence, build 36)
 
@@ -274,25 +277,50 @@ Unlike M6, the chat follow trigger was already gated and only changed on newest-
 streamed text, so the app was not firing a `scrollTo` per token.
 
 The main thread was still in the same SwiftUI lazy-list placement family:
-`_ViewList_TemporarySublistTransform.apply` → `_LazyLayout_Subviews.apply` →
-`LazyStack.place` / `LazySubviewPlacements.updateValue`. That points at the remaining lazy stack
-itself: while the user scrolls, the streamed tail row mutates every flush, and SwiftUI keeps
-recomputing lazy placements for the bounded visible window until the scene-update watchdog kills the
-app.
+`_ViewList_TemporarySublistTransform.apply` → `_LazyLayout_Subviews.apply` → `LazyStack.place` /
+`LazySubviewPlacements.updateValue`. That points at the remaining lazy stack itself: while the user
+scrolls, the streamed tail row mutates every flush, and SwiftUI keeps recomputing lazy placements
+for the bounded visible window until the scene-update watchdog kills the app.
 
 **Fix.**
 
 - Keep the thread-level and per-message bounds from M3/M5, but render the already-bounded visible
-  window with an eager `VStack` instead of `LazyVStack`. The initial window is 30 grouped bubbles and
-  "Load earlier messages" widens it by explicit user action up to a fixed 120-bubble ceiling, then
-  slides that bounded window through older history with a matching "Load newer messages" affordance,
-  so eager layout is bounded while avoiding the LazyStack placement path that appears in every
-  recurrence and history beyond the ceiling remains reachable.
+  window with an eager `VStack` instead of `LazyVStack`. The initial window is 30 grouped bubbles
+  and "Load earlier messages" widens it by explicit user action up to a fixed 120-bubble ceiling,
+  then slides that bounded window through older history with a matching "Load newer messages"
+  affordance, so eager layout is bounded while avoiding the LazyStack placement path that appears in
+  every recurrence and history beyond the ceiling remains reachable.
 - Apply the same eager-stack choice to the voice transcript, whose streaming-tail behavior shares
   the same sticky-bottom container.
 - Add `ChatLayoutBudgetTests.testStickyBottomScrollHandlesTailMutationWhileUserIsScrolledUp`, which
   hosts the real sticky scroll view, scrolls away from the bottom, mutates the tail repeatedly, and
   asserts it neither yanks to bottom nor spends watchdog-scale time in layout.
+
+### M8 — Scene-phase environment invalidation (background recurrence, build 39)
+
+`scratch/FamilyAssistant-2026-07-15-151118.ips` is a build 39 background `scene-update` watchdog
+kill (`0x8BADF00D`, 10 s). The two copied reports are byte-identical. Unlike M7, the faulting main
+thread is no longer in `LazyStack` placement; it is in Swift generic metadata instantiation from
+`EnvironmentBox.update(property:phase:)` → `_DynamicPropertyBuffer.update` →
+`DynamicBody.updateValue` while SwiftUI flushes a view-graph transaction.
+
+M7 removed the unbounded lazy-placement path, but `ChatThreadView` still directly declared
+`@Environment(\.scenePhase)`. Every active/background transition therefore invalidated the parent
+whose body owns the eager message stack (up to 120 complex bubbles). Keeping that stack mounted
+avoided M4's teardown transaction, but recomputing its dynamic-property graph during backgrounding
+could still consume the full scene-update allowance.
+
+**Fix.**
+
+- Move `scenePhase` observation into a zero-sized `ChatScenePhaseObserver` below a mount gate. The
+  observer handles the one-time foreground mount and reconnect callback, while later phase changes
+  do not invalidate `ChatThreadView` or reconstruct its message closure.
+- Stop encoding activity into the message list's `followTrigger`. `StickyBottomScroll` instead
+  checks an injected `canFollow` closure when a passive trigger changes; production reads
+  `UIApplication.shared.applicationState` without creating a SwiftUI environment dependency. The
+  force-follow signal remains unconditional because it is emitted only by an active user send.
+- Cover the lifecycle suppression at the hosted scroll-view layer: an otherwise-allowed passive
+  follow is denied while `canFollow` is false and leaves the scroll position untouched.
 
 ## Verification
 

--- a/docs/design/ios-chat-layout-watchdog-crash.md
+++ b/docs/design/ios-chat-layout-watchdog-crash.md
@@ -298,11 +298,13 @@ for the bounded visible window until the scene-update watchdog kills the app.
 
 ### M8 — Scene-phase environment invalidation (background recurrence, build 39)
 
-`scratch/FamilyAssistant-2026-07-15-151118.ips` is a build 39 background `scene-update` watchdog
-kill (`0x8BADF00D`, 10 s). The two copied reports are byte-identical. Unlike M7, the faulting main
-thread is no longer in `LazyStack` placement; it is in Swift generic metadata instantiation from
+Two distinct build 39 reports are background `scene-update` watchdog kills (`0x8BADF00D`, 10 s):
+`scratch/FamilyAssistant-2026-07-15-083505.ips` and `scratch/FamilyAssistant-2026-07-15-151118.ips`.
+(The file named `151118 1.ips` is byte-identical to `151118.ips`, so it is one incident rather than
+a third.) The `083505` main thread is flushing an AttributeGraph view transaction; `151118` provides
+the more specific sample inside Swift generic metadata instantiation from
 `EnvironmentBox.update(property:phase:)` → `_DynamicPropertyBuffer.update` →
-`DynamicBody.updateValue` while SwiftUI flushes a view-graph transaction.
+`DynamicBody.updateValue`. Neither report returns to the M7 `LazyStack` placement path.
 
 M7 removed the unbounded lazy-placement path, but `ChatThreadView` still directly declared
 `@Environment(\.scenePhase)`. Every active/background transition therefore invalidated the parent
@@ -321,6 +323,26 @@ could still consume the full scene-update allowance.
   force-follow signal remains unconditional because it is emitted only by an active user send.
 - Cover the lifecycle suppression at the hosted scroll-view layer: an otherwise-allowed passive
   follow is denied while `canFollow` is false and leaves the scroll position untouched.
+
+### M9 — Eager-window process-exit layout (foreground recurrence, build 39)
+
+`scratch/FamilyAssistant-2026-07-15-163058.ips` is the third distinct July 15 incident. It is not a
+background scene update: FrontBoard killed the app after it failed to terminate within the 5 s
+`process-exit` allowance (`WatchdogVisibility: Foreground`). The main thread is synchronously
+placing the eager message stack through `StackLayout.UnmanagedImplementation.placeChildren`,
+`explicitAlignment`, and `ViewLayoutEngine.sizeThatFits`.
+
+M7 correctly removed the repeatedly non-settling `LazyVStack` path, but its eager replacement could
+grow from 30 to 120 complex bubbles after repeated "Load earlier messages" actions. A 120-bubble
+tree is bounded in the mathematical sense but is still too large for synchronous placement or
+teardown under the shorter process-exit watchdog.
+
+**Fix.** Keep the eager renderer, but make its window a fixed 30 grouped bubbles. "Load earlier
+messages" and "Load newer messages" slide that fixed window instead of growing it, so all history
+remains reachable and SwiftUI never realizes four pages simultaneously. A view-model regression test
+enforces the fixed-size paging behavior, and
+`ChatLayoutBudgetTests.testMaximumThreadWindowLayoutStaysUnderExitWatchdogBudget` hosts the maximum
+production window as one layout pass against a budget below the 5 s exit allowance.
 
 ## Verification
 

--- a/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViewModel.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViewModel.swift
@@ -7,12 +7,11 @@ import os
 final class ChatViewModel {
     var conversations: [ChatConversationSummary] = []
     var messages: [ChatMessage] = []
-    // Requested upper bound on how many grouped bubbles are realized into the
-    // chat view at once. The full thread is still loaded into `messages`; only a
-    // recent window is shown, and older bubbles page in via
-    // `showEarlierMessages()` up to the fixed eager-render ceiling. See
-    // `visibleGroupedMessages`.
-    var displayedMessageLimit = ChatViewModel.initialDisplayedMessageCount
+    // Fixed upper bound on how many grouped bubbles are realized into the chat
+    // view at once. The full thread is still loaded into `messages`; only a
+    // recent window is shown, and `showEarlierMessages()` /
+    // `showNewerMessages()` slide that fixed eager-render window through
+    // history. See `visibleGroupedMessages`.
     var displayedMessageNewerOffset = 0
     var profiles: [ChatProfile] = []
     var defaultProfileID = "default_assistant"
@@ -145,14 +144,14 @@ final class ChatViewModel {
     static let conversationRestoreWindow: TimeInterval = 15 * 60
 
     // Windowing for the chat thread. A long thread is loaded in full, but only a
-    // recent window of grouped bubbles is realized into the view at once. The
-    // view intentionally uses an eager VStack for that bounded window: the
+    // fixed recent window of grouped bubbles is realized into the view at once.
+    // The view intentionally uses an eager VStack for that bounded window: the
     // LazyStack placement path is the recurring watchdog hot spot when the user
-    // scrolls while the streaming tail mutates. An unbounded eager stack would be
-    // unsafe too, so `showEarlierMessages()` grows the window a page at a time
-    // only up to `maxDisplayedMessageCount`.
-    static let initialDisplayedMessageCount = 30
-    static let maxDisplayedMessageCount = 120
+    // scrolls while the streaming tail mutates. The eager window must not grow:
+    // placing or tearing down 120 complex bubbles can itself overrun the shorter
+    // process-exit watchdog. Earlier/newer controls slide this fixed window so
+    // the whole thread remains reachable.
+    static let displayedMessageWindowCount = 30
     private static let displayedMessagePageSize = 30
 
     // Max characters of an optimistic conversation-list preview, matching the
@@ -489,7 +488,6 @@ final class ChatViewModel {
         endedTurnIDs.removeAll()
         endedTurnStatusByTurnID.removeAll()
         resetTurnControlState()
-        displayedMessageLimit = Self.initialDisplayedMessageCount
         displayedMessageNewerOffset = 0
         if isSwitchingConversation {
             draftText = ""
@@ -552,7 +550,6 @@ final class ChatViewModel {
         endedTurnIDs.removeAll()
         endedTurnStatusByTurnID.removeAll()
         resetTurnControlState()
-        displayedMessageLimit = Self.initialDisplayedMessageCount
         displayedMessageNewerOffset = 0
         conversationID = Self.generateConversationID()
         conversationSelection = conversationID
@@ -2989,7 +2986,7 @@ final class ChatViewModel {
     /// The bounded window of `groupedMessages` actually rendered by the chat
     /// view. It starts as the newest suffix so streamed messages stay visible,
     /// then can page backward/forward in fixed chunks without ever realizing
-    /// more than `maxDisplayedMessageCount` bubbles into the eager stack.
+    /// more than `displayedMessageWindowCount` bubbles into the eager stack.
     var visibleGroupedMessages: [ChatMessage] {
         let grouped = groupedMessages
         let range = visibleGroupedMessageRange(in: grouped)
@@ -3009,19 +3006,12 @@ final class ChatViewModel {
         return visibleGroupedMessageRange(in: grouped).upperBound < grouped.endIndex
     }
 
-    /// Reveal another page of older bubbles, first by growing the suffix up to
-    /// the eager ceiling and then by sliding the bounded window backward.
+    /// Reveal another page of older bubbles by sliding the fixed render window
+    /// backward. The window never grows because eager teardown and placement
+    /// must also stay below the process-exit watchdog budget.
     func showEarlierMessages() {
-        if displayedMessageLimit < Self.maxDisplayedMessageCount {
-            displayedMessageLimit = min(
-                displayedMessageLimit + Self.displayedMessagePageSize,
-                Self.maxDisplayedMessageCount
-            )
-            return
-        }
-
         let groupedCount = groupedMessages.count
-        let windowSize = min(displayedMessageLimit, Self.maxDisplayedMessageCount, groupedCount)
+        let windowSize = min(Self.displayedMessageWindowCount, groupedCount)
         let maxOffset = max(0, groupedCount - windowSize)
         displayedMessageNewerOffset = min(
             displayedMessageNewerOffset + Self.displayedMessagePageSize,
@@ -3039,7 +3029,7 @@ final class ChatViewModel {
             return grouped.startIndex..<grouped.endIndex
         }
 
-        let windowSize = min(displayedMessageLimit, Self.maxDisplayedMessageCount, grouped.count)
+        let windowSize = min(Self.displayedMessageWindowCount, grouped.count)
         let maxOffset = max(0, grouped.count - windowSize)
         let newerOffset = min(displayedMessageNewerOffset, maxOffset)
         let end = grouped.index(grouped.endIndex, offsetBy: -newerOffset)
@@ -3079,7 +3069,7 @@ final class ChatViewModel {
 
         let newGroupedCount = groupedMessages.count
         let appendedGroupedCount = max(0, newGroupedCount - oldGroupedCount)
-        let windowSize = min(displayedMessageLimit, Self.maxDisplayedMessageCount, newGroupedCount)
+        let windowSize = min(Self.displayedMessageWindowCount, newGroupedCount)
         let maxOffset = max(0, newGroupedCount - windowSize)
         displayedMessageNewerOffset = min(displayedMessageNewerOffset + appendedGroupedCount, maxOffset)
     }

--- a/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViews.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViews.swift
@@ -430,7 +430,8 @@ private struct MessageBubble: View {
 /// Test seam for the chat-layout budget/fuzz harness (`ChatLayoutBudgetTests`).
 /// Renders the production message-list layout — `ScrollView` + bounded `VStack` +
 /// `MessageBubble` — over an explicit message array so a hosting controller can
-/// force a content-sizing pass and time it. Mirrors
+/// force a content-sizing pass and time it. This also covers the fixed maximum
+/// eager window used to stay below the process-exit watchdog. Mirrors
 /// `ChatThreadView.messageScrollArea` without the scroll-position plumbing. The
 /// invariant the harness enforces is that this layout stays bounded (well under
 /// the scene-update watchdog) for any message shape; see

--- a/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViews.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViews.swift
@@ -1,3 +1,4 @@
+import Combine
 import Markdown
 import PhotosUI
 import SwiftUI
@@ -498,6 +499,7 @@ struct StickyBottomScroll<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
     @State private var isNearBottom = true
+    @State private var hasPendingFollow = false
 
     init(
         followTrigger: AnyHashable?,
@@ -535,15 +537,28 @@ struct StickyBottomScroll<Content: View>: View {
                 proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
             }
             .onChange(of: followTrigger) {
-                guard followTrigger != nil, canFollow(), shouldFollow(isNearBottom) else {
+                guard followTrigger != nil, shouldFollow(isNearBottom) else {
                     return
                 }
+                guard canFollow() else {
+                    hasPendingFollow = true
+                    return
+                }
+                hasPendingFollow = false
+                proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+                guard hasPendingFollow, canFollow() else {
+                    return
+                }
+                hasPendingFollow = false
                 proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
             }
             .onChange(of: forceFollowTrigger) {
                 guard forceFollowTrigger != nil else {
                     return
                 }
+                hasPendingFollow = false
                 proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
             }
         }

--- a/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViews.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Chat/ChatViews.swift
@@ -177,58 +177,16 @@ private struct ConversationRow: View {
 
 private struct ChatThreadView: View {
     var viewModel: ChatViewModel
-    @Environment(\.scenePhase) private var scenePhase
-    // Latches true the first time the scene is active, then stays true. Gates the
-    // thread between two competing watchdog hazards (see
-    // `ChatViewModel.shouldRenderThread`): keep the message stack OUT of the tree on
-    // an offscreen background launch, but keep it mounted across later
-    // background transitions once it has been realized.
-    @State private var hasMountedThread = false
 
     var body: some View {
         VStack(spacing: 0) {
             PendingConfirmationsBanner(viewModel: viewModel)
-            if viewModel.shouldRenderThread(
-                isActive: scenePhase == .active,
-                hasMountedBefore: hasMountedThread
-            ) {
+            ChatScenePhaseMountGate(viewModel: viewModel) {
                 messageScrollArea
-            } else {
-                // Offscreen background launch (push / state restoration /
-                // snapshot): SwiftUI reports .background/.inactive before the
-                // thread has ever been active. Laying out a restored thread here
-                // overruns the ~10s scene-update watchdog (0x8BADF00D). The real
-                // list renders when the scene first becomes active and then stays
-                // mounted. See docs/design/ios-chat-layout-watchdog-crash.md.
-                Color.clear
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
 
             Divider()
             ChatComposerView(viewModel: viewModel)
-        }
-        .onChange(of: scenePhase, initial: true) { oldPhase, newPhase in
-            if newPhase == .active {
-                hasMountedThread = true
-            }
-            // Returning to the foreground from the BACKGROUND: re-establish the
-            // live-updates follow stream and catch up persisted history. A turn
-            // that finished while the app was backgrounded (the follow Task is
-            // suspended/torn down by the OS) would otherwise strand until a manual
-            // refresh. With the SSE-independent catch-up in `reconnectLiveUpdates`,
-            // the thread recovers even if the fresh SSE connect itself fails.
-            //
-            // Gate on a real return from the background so a transient
-            // `.inactive → .active` blip (Control Center, the app switcher, a
-            // notification banner) does not needlessly tear down and restart a
-            // healthy follow connection. The decision lives on the view model so
-            // it is unit-testable.
-            if viewModel.shouldReconnectOnForeground(
-                cameFromBackground: oldPhase == .background,
-                isNowActive: newPhase == .active
-            ) {
-                Task { await viewModel.reconnectLiveUpdates() }
-            }
         }
     }
 
@@ -241,14 +199,15 @@ private struct ChatThreadView: View {
         // Sending a message is a user-initiated event that always pins to the
         // bottom, signalled explicitly via `scrollToLatestRequestID` (it can't be
         // inferred from the last bubble, which is the assistant loading
-        // placeholder right after a send). `followTrigger` is gated on the active
-        // scene so a background layout pass never scrolls; `forceFollowTrigger` is
-        // not — it only ever changes on a user send (always active), and gating it
-        // would make it fire on the nil→value flip when returning to the
-        // foreground, yanking a user who had scrolled up.
+        // placeholder right after a send). Passive follow is gated on application
+        // state inside `StickyBottomScroll`, without making this heavy parent
+        // observe `scenePhase`; a background phase change must not invalidate the
+        // eager message stack. `forceFollowTrigger` is not gated — it only ever
+        // changes on an active user send.
         StickyBottomScroll(
-            followTrigger: scenePhase == .active ? viewModel.visibleGroupedMessages.last?.id : nil,
-            forceFollowTrigger: viewModel.scrollToLatestRequestID
+            followTrigger: viewModel.visibleGroupedMessages.last?.id,
+            forceFollowTrigger: viewModel.scrollToLatestRequestID,
+            canFollow: { UIApplication.shared.applicationState == .active }
         ) {
             VStack(spacing: 14) {
                 if viewModel.messages.isEmpty && !viewModel.isLoadingMessages {
@@ -288,6 +247,65 @@ private struct ChatThreadView: View {
                 ProgressView("Loading messages...")
             }
         }
+    }
+}
+
+/// Keeps scene lifecycle observation out of `ChatThreadView`, whose body owns the
+/// bounded eager message stack. A phase change should update only a lightweight
+/// observer; invalidating the parent while backgrounding can spend the entire
+/// scene-update watchdog budget rebuilding dynamic properties for every row.
+private struct ChatScenePhaseMountGate<Content: View>: View {
+    var viewModel: ChatViewModel
+    @ViewBuilder let content: () -> Content
+
+    @State private var hasMountedContent = false
+
+    var body: some View {
+        Group {
+            if hasMountedContent {
+                content()
+            } else {
+                // Offscreen background launch (push / state restoration /
+                // snapshot): laying out a restored thread before the scene has
+                // ever been active overruns the scene-update watchdog.
+                Color.clear
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .background {
+            ChatScenePhaseObserver { oldPhase, newPhase in
+                if !hasMountedContent, viewModel.shouldRenderThread(
+                    isActive: newPhase == .active,
+                    hasMountedBefore: false
+                ) {
+                    hasMountedContent = true
+                }
+
+                // A turn can finish while the app is suspended. Reconnect and
+                // catch up only after a real background → active transition;
+                // transient inactive states keep the healthy stream intact.
+                if viewModel.shouldReconnectOnForeground(
+                    cameFromBackground: oldPhase == .background,
+                    isNowActive: newPhase == .active
+                ) {
+                    Task { await viewModel.reconnectLiveUpdates() }
+                }
+            }
+        }
+    }
+}
+
+private struct ChatScenePhaseObserver: View {
+    @Environment(\.scenePhase) private var scenePhase
+    let phaseChanged: (_ oldPhase: ScenePhase, _ newPhase: ScenePhase) -> Void
+
+    var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .accessibilityHidden(true)
+            .onChange(of: scenePhase, initial: true) { oldPhase, newPhase in
+                phaseChanged(oldPhase, newPhase)
+            }
     }
 }
 
@@ -464,9 +482,7 @@ struct ChatMessageListLayoutProbe: View {
 /// See docs/design/ios-chat-layout-watchdog-crash.md.
 struct StickyBottomScroll<Content: View>: View {
     /// Changes whenever new content that may warrant a follow has arrived (the
-    /// newest row's id, its streamed text, …). A `nil` value never follows, so
-    /// callers can suppress following (e.g. while the scene is inactive) by
-    /// passing `nil`.
+    /// newest row's id, its streamed text, …). A `nil` value never follows.
     let followTrigger: AnyHashable?
     /// Changes whenever a user-initiated event should scroll to the bottom
     /// unconditionally (ignoring `shouldFollow`) — e.g. the user just sent a
@@ -475,6 +491,9 @@ struct StickyBottomScroll<Content: View>: View {
     /// Given whether the user is currently near the bottom, whether to follow a
     /// `followTrigger` change. Defaults to "only when near the bottom".
     let shouldFollow: (_ isNearBottom: Bool) -> Bool
+    /// Read at trigger time so lifecycle suppression does not require an
+    /// `@Environment(\.scenePhase)` dependency in the heavy scrolling subtree.
+    let canFollow: () -> Bool
     @ViewBuilder let content: () -> Content
 
     @State private var isNearBottom = true
@@ -483,11 +502,13 @@ struct StickyBottomScroll<Content: View>: View {
         followTrigger: AnyHashable?,
         forceFollowTrigger: AnyHashable? = nil,
         shouldFollow: @escaping (_ isNearBottom: Bool) -> Bool = { $0 },
+        canFollow: @escaping () -> Bool = { true },
         @ViewBuilder content: @escaping () -> Content
     ) {
         self.followTrigger = followTrigger
         self.forceFollowTrigger = forceFollowTrigger
         self.shouldFollow = shouldFollow
+        self.canFollow = canFollow
         self.content = content
     }
 
@@ -513,7 +534,7 @@ struct StickyBottomScroll<Content: View>: View {
                 proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
             }
             .onChange(of: followTrigger) {
-                guard followTrigger != nil, shouldFollow(isNearBottom) else {
+                guard followTrigger != nil, canFollow(), shouldFollow(isNearBottom) else {
                     return
                 }
                 proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)

--- a/ios/FamilyAssistant/FamilyAssistant/Voice/VoiceView.swift
+++ b/ios/FamilyAssistant/FamilyAssistant/Voice/VoiceView.swift
@@ -141,7 +141,8 @@ private struct VoiceSessionContent: View {
         // eager stack; LazyVStack's placement path is the recurring watchdog hot
         // spot when the tail mutates during a user scroll.
         StickyBottomScroll(
-            followTrigger: model.transcript.entries.last.map { AnyHashable([$0.id.uuidString, $0.text]) }
+            followTrigger: model.transcript.entries.last.map { AnyHashable([$0.id.uuidString, $0.text]) },
+            canFollow: { UIApplication.shared.applicationState == .active }
         ) {
             VStack(alignment: .leading, spacing: 12) {
                 ForEach(model.transcript.entries) { entry in

--- a/ios/FamilyAssistant/FamilyAssistantTests/ChatLayoutBudgetTests.swift
+++ b/ios/FamilyAssistant/FamilyAssistantTests/ChatLayoutBudgetTests.swift
@@ -58,6 +58,25 @@ final class ChatLayoutBudgetTests: XCTestCase {
         )
     }
 
+    /// The build-39 process-exit watchdog sampled the eager chat stack while it
+    /// was placing rows. Exercise the maximum production window as one hosted
+    /// layout pass: paging must never grow the eager subtree beyond this count,
+    /// and a representative complex window must remain below the 5s exit
+    /// allowance with margin.
+    func testMaximumThreadWindowLayoutStaysUnderExitWatchdogBudget() {
+        let messages = (0..<ChatViewModel.displayedMessageWindowCount).map { index in
+            assistantMessage(MarkdownShapes.everything(repeats: 3), id: "window-\(index)")
+        }
+
+        let seconds = layoutSeconds(for: messages)
+
+        XCTAssertLessThan(
+            seconds,
+            Self.budgetSeconds,
+            "The maximum eager message window took \(String(format: "%.3f", seconds))s to lay out; process exit allows only 5s."
+        )
+    }
+
     /// Large adversarial content shapes. Sizes are large enough that an
     /// *unbounded* renderer blows the budget (by seconds) yet still terminates —
     /// so a future regression that removes a cap fails loudly instead of wedging

--- a/ios/FamilyAssistant/FamilyAssistantTests/ChatLayoutBudgetTests.swift
+++ b/ios/FamilyAssistant/FamilyAssistantTests/ChatLayoutBudgetTests.swift
@@ -326,6 +326,21 @@ final class ChatLayoutBudgetTests: XCTestCase {
         )
     }
 
+    func testStickyBottomScrollDoesNotFollowWhenLifecycleGateDenies() {
+        let harness = hostStickyScroll(gate: true, canFollow: false)
+        defer { harness.teardown() }
+        harness.waitUntil { self.isAtBottom(harness.scrollView) }
+
+        harness.scrollToTop()
+        XCTAssertFalse(isAtBottom(harness.scrollView), "precondition: scroll-to-top did not take effect")
+
+        harness.change(follow: 1)
+        XCTAssertFalse(
+            isAtBottom(harness.scrollView),
+            "A passive arrival while backgrounded must not start a layout-driving follow scroll."
+        )
+    }
+
     func testStickyBottomScrollForceFollowScrollsEvenWhenGateWouldDeny() {
         // A user-initiated force (e.g. sending a message) must scroll to the
         // bottom even when the near-bottom gate would deny — the local-send case
@@ -502,12 +517,13 @@ final class ChatLayoutBudgetTests: XCTestCase {
         }
     }
 
-    private func hostStickyScroll(gate: Bool) -> StickyScrollHarness {
+    private func hostStickyScroll(gate: Bool, canFollow: Bool = true) -> StickyScrollHarness {
         let makeRoot: (Int, Int, String) -> StickyBottomScroll<AnyView> = { followToken, forceToken, tailText in
             StickyBottomScroll(
                 followTrigger: AnyHashable(followToken),
                 forceFollowTrigger: AnyHashable(forceToken),
-                shouldFollow: { _ in gate }
+                shouldFollow: { _ in gate },
+                canFollow: { canFollow }
             ) {
                 AnyView(
                     VStack(spacing: 14) {

--- a/ios/FamilyAssistant/FamilyAssistantTests/ChatLayoutBudgetTests.swift
+++ b/ios/FamilyAssistant/FamilyAssistantTests/ChatLayoutBudgetTests.swift
@@ -360,6 +360,23 @@ final class ChatLayoutBudgetTests: XCTestCase {
         )
     }
 
+    func testStickyBottomScrollRetriesPendingFollowWhenLifecycleReopens() {
+        let harness = hostStickyScroll(gate: true, canFollow: false)
+        defer { harness.teardown() }
+        harness.waitUntil { self.isAtBottom(harness.scrollView) }
+
+        harness.scrollToTop()
+        harness.change(follow: 1)
+        XCTAssertFalse(isAtBottom(harness.scrollView), "The inactive follow must remain pending without scrolling.")
+
+        harness.reopenLifecycleGate()
+        harness.waitUntil { self.isAtBottom(harness.scrollView) }
+        XCTAssertTrue(
+            isAtBottom(harness.scrollView),
+            "An allowed follow suppressed while inactive must retry when the application becomes active."
+        )
+    }
+
     func testStickyBottomScrollForceFollowScrollsEvenWhenGateWouldDeny() {
         // A user-initiated force (e.g. sending a message) must scroll to the
         // bottom even when the near-bottom gate would deny — the local-send case
@@ -420,6 +437,7 @@ final class ChatLayoutBudgetTests: XCTestCase {
         let scrollView: UIScrollView
         let makeRoot: (_ followToken: Int, _ forceToken: Int, _ tailText: String) -> StickyBottomScroll<AnyView>
         let pumpFor: (TimeInterval) -> Void
+        let followAvailability: FollowAvailability
         private var followToken = 0
         private var forceToken = 0
         private var tailText = ""
@@ -429,13 +447,15 @@ final class ChatLayoutBudgetTests: XCTestCase {
             host: UIHostingController<StickyBottomScroll<AnyView>>,
             scrollView: UIScrollView,
             makeRoot: @escaping (_ followToken: Int, _ forceToken: Int, _ tailText: String) -> StickyBottomScroll<AnyView>,
-            pumpFor: @escaping (TimeInterval) -> Void
+            pumpFor: @escaping (TimeInterval) -> Void,
+            followAvailability: FollowAvailability
         ) {
             self.window = window
             self.host = host
             self.scrollView = scrollView
             self.makeRoot = makeRoot
             self.pumpFor = pumpFor
+            self.followAvailability = followAvailability
         }
 
         /// Spin the run loop until `predicate` holds or `timeout` elapses, so a
@@ -463,6 +483,11 @@ final class ChatLayoutBudgetTests: XCTestCase {
         func change(force token: Int) {
             forceToken = token
             reapplyAndWaitForScrollSettled()
+        }
+
+        func reopenLifecycleGate() {
+            followAvailability.value = true
+            NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
         }
 
         /// Mutate the newest row without changing scroll triggers, matching a
@@ -536,13 +561,22 @@ final class ChatLayoutBudgetTests: XCTestCase {
         }
     }
 
+    private final class FollowAvailability {
+        var value: Bool
+
+        init(_ value: Bool) {
+            self.value = value
+        }
+    }
+
     private func hostStickyScroll(gate: Bool, canFollow: Bool = true) -> StickyScrollHarness {
+        let followAvailability = FollowAvailability(canFollow)
         let makeRoot: (Int, Int, String) -> StickyBottomScroll<AnyView> = { followToken, forceToken, tailText in
             StickyBottomScroll(
                 followTrigger: AnyHashable(followToken),
                 forceFollowTrigger: AnyHashable(forceToken),
                 shouldFollow: { _ in gate },
-                canFollow: { canFollow }
+                canFollow: { followAvailability.value }
             ) {
                 AnyView(
                     VStack(spacing: 14) {
@@ -582,7 +616,8 @@ final class ChatLayoutBudgetTests: XCTestCase {
             host: host,
             scrollView: scrollView,
             makeRoot: makeRoot,
-            pumpFor: pumpFor
+            pumpFor: pumpFor,
+            followAvailability: followAvailability
         )
     }
 

--- a/ios/FamilyAssistant/FamilyAssistantTests/ChatViewModelTests.swift
+++ b/ios/FamilyAssistant/FamilyAssistantTests/ChatViewModelTests.swift
@@ -352,58 +352,53 @@ final class ChatViewModelTests: XCTestCase {
 
     func testVisibleMessagesCapToRecentWindow() {
         let model = makeViewModel(conversationID: "web_conv_window")
-        let total = ChatViewModel.initialDisplayedMessageCount + 15
+        let total = ChatViewModel.displayedMessageWindowCount + 15
         model.messages = (0..<total).map(plainMessage(index:))
 
         let visible = model.visibleGroupedMessages
-        XCTAssertEqual(visible.count, ChatViewModel.initialDisplayedMessageCount)
+        XCTAssertEqual(visible.count, ChatViewModel.displayedMessageWindowCount)
         XCTAssertTrue(model.hasEarlierMessages)
         // The window is the most-recent suffix: newest is shown, oldest is hidden.
         XCTAssertEqual(visible.last?.id, "msg_\(total - 1)")
-        XCTAssertEqual(visible.first?.id, "msg_\(total - ChatViewModel.initialDisplayedMessageCount)")
+        XCTAssertEqual(visible.first?.id, "msg_\(total - ChatViewModel.displayedMessageWindowCount)")
     }
 
-    func testShowEarlierMessagesWidensWindowToWholeThread() {
+    func testShowEarlierMessagesSlidesFixedWindowToStartOfShortThread() {
         let model = makeViewModel(conversationID: "web_conv_window")
-        let total = ChatViewModel.initialDisplayedMessageCount + 15
+        let total = ChatViewModel.displayedMessageWindowCount + 15
         model.messages = (0..<total).map(plainMessage(index:))
 
         let initialVisible = model.visibleGroupedMessages.count
         model.showEarlierMessages()
-        XCTAssertGreaterThan(model.visibleGroupedMessages.count, initialVisible)
+        XCTAssertEqual(model.visibleGroupedMessages.count, initialVisible)
 
-        // Widening enough reveals the whole thread and clears the earlier flag.
-        while model.hasEarlierMessages {
-            model.showEarlierMessages()
-        }
-        XCTAssertEqual(model.visibleGroupedMessages.count, total)
+        // The final older page is clamped to the start and overlaps the prior
+        // page rather than widening the eager stack.
+        XCTAssertEqual(model.visibleGroupedMessages.count, ChatViewModel.displayedMessageWindowCount)
         XCTAssertEqual(model.visibleGroupedMessages.first?.id, "msg_0")
+        XCTAssertFalse(model.hasEarlierMessages)
+        XCTAssertTrue(model.hasNewerMessages)
     }
 
-    func testShowEarlierMessagesStopsAtEagerRenderCeiling() {
+    func testPagingKeepsFixedEagerRenderWindow() {
         let model = makeViewModel(conversationID: "web_conv_window")
-        let total = ChatViewModel.maxDisplayedMessageCount + 75
+        let total = ChatViewModel.displayedMessageWindowCount + 75
         model.messages = (0..<total).map(plainMessage(index:))
 
-        while model.displayedMessageLimit < ChatViewModel.maxDisplayedMessageCount {
-            model.showEarlierMessages()
-        }
-
-        XCTAssertEqual(model.displayedMessageLimit, ChatViewModel.maxDisplayedMessageCount)
-        XCTAssertEqual(model.visibleGroupedMessages.count, ChatViewModel.maxDisplayedMessageCount)
+        XCTAssertEqual(model.visibleGroupedMessages.count, ChatViewModel.displayedMessageWindowCount)
         XCTAssertEqual(
             model.visibleGroupedMessages.first?.id,
-            "msg_\(total - ChatViewModel.maxDisplayedMessageCount)"
+            "msg_\(total - ChatViewModel.displayedMessageWindowCount)"
         )
         XCTAssertEqual(model.visibleGroupedMessages.last?.id, "msg_\(total - 1)")
         XCTAssertTrue(model.hasEarlierMessages)
 
         model.showEarlierMessages()
 
-        XCTAssertEqual(model.visibleGroupedMessages.count, ChatViewModel.maxDisplayedMessageCount)
+        XCTAssertEqual(model.visibleGroupedMessages.count, ChatViewModel.displayedMessageWindowCount)
         XCTAssertEqual(
             model.visibleGroupedMessages.first?.id,
-            "msg_\(total - ChatViewModel.maxDisplayedMessageCount - 30)"
+            "msg_\(total - ChatViewModel.displayedMessageWindowCount - 30)"
         )
         XCTAssertEqual(model.visibleGroupedMessages.last?.id, "msg_\(total - 31)")
         XCTAssertTrue(model.hasEarlierMessages)
@@ -414,7 +409,7 @@ final class ChatViewModelTests: XCTestCase {
         }
 
         XCTAssertEqual(model.visibleGroupedMessages.first?.id, "msg_0")
-        XCTAssertEqual(model.visibleGroupedMessages.count, ChatViewModel.maxDisplayedMessageCount)
+        XCTAssertEqual(model.visibleGroupedMessages.count, ChatViewModel.displayedMessageWindowCount)
         XCTAssertTrue(model.hasNewerMessages)
         XCTAssertFalse(model.hasEarlierMessages)
 
@@ -427,7 +422,7 @@ final class ChatViewModelTests: XCTestCase {
 
     func testPagedBackWindowStaysAnchoredWhenNewMessagesAppend() {
         let model = makeViewModel(conversationID: "web_conv_window")
-        let total = ChatViewModel.maxDisplayedMessageCount + 75
+        let total = ChatViewModel.displayedMessageWindowCount + 75
         model.messages = (0..<total).map(plainMessage(index:))
 
         while model.hasEarlierMessages {
@@ -435,12 +430,12 @@ final class ChatViewModelTests: XCTestCase {
         }
 
         XCTAssertEqual(model.visibleGroupedMessages.first?.id, "msg_0")
-        XCTAssertEqual(model.visibleGroupedMessages.last?.id, "msg_119")
+        XCTAssertEqual(model.visibleGroupedMessages.last?.id, "msg_29")
 
         model.appendMessagePreservingPagedBackWindow(plainMessage(index: total))
 
         XCTAssertEqual(model.visibleGroupedMessages.first?.id, "msg_0")
-        XCTAssertEqual(model.visibleGroupedMessages.last?.id, "msg_119")
+        XCTAssertEqual(model.visibleGroupedMessages.last?.id, "msg_29")
         XCTAssertFalse(model.hasEarlierMessages)
         XCTAssertTrue(model.hasNewerMessages)
     }
@@ -455,13 +450,13 @@ final class ChatViewModelTests: XCTestCase {
 
     func testStartingNewConversationResetsTheWindow() {
         let model = makeViewModel(conversationID: "web_conv_window")
-        model.messages = (0..<(ChatViewModel.initialDisplayedMessageCount + 15)).map(plainMessage(index:))
+        model.messages = (0..<(ChatViewModel.displayedMessageWindowCount + 15)).map(plainMessage(index:))
         model.showEarlierMessages()
-        XCTAssertGreaterThan(model.displayedMessageLimit, ChatViewModel.initialDisplayedMessageCount)
+        XCTAssertTrue(model.hasNewerMessages)
 
         model.startNewConversation()
 
-        XCTAssertEqual(model.displayedMessageLimit, ChatViewModel.initialDisplayedMessageCount)
+        XCTAssertEqual(model.displayedMessageNewerOffset, 0)
         XCTAssertFalse(model.hasNewerMessages)
     }
 


### PR DESCRIPTION
## Summary
- isolate scene-phase observation from the eager native chat message subtree
- suppress passive chat and voice auto-follow while inactive without a SwiftUI environment dependency, then retry an allowed pending follow on activation
- keep the eager chat renderer fixed at 30 grouped bubbles while paging all history backward and forward
- add hosted lifecycle and maximum-window layout regression coverage

## Crash evidence
- 083505 and 151118 are distinct build 39 background scene-update watchdog kills in SwiftUI view-graph and environment-property updates
- 163058 is a distinct build 39 foreground process-exit watchdog kill in eager StackLayout placement
- 151118 1.ips is byte-identical to 151118.ips and is not a fourth incident

## Fix
The lightweight scene observer no longer invalidates ChatThreadView during background transitions. Passive auto-follow checks UIApplication state without adding a scenePhase dependency to the scrolling subtree, preserves an otherwise-allowed follow while inactive, and retries it on activation. The eager renderer no longer grows from 30 to 120 bubbles; earlier and newer controls slide a fixed 30-bubble window so history remains reachable while layout and teardown remain bounded for the 5-second exit watchdog.

## Validation
- scripts/format-and-lint.sh
- focused ChatViewModelTests and ChatLayoutBudgetTests: 143 passed, 0 failed across the two suites
- maximum production-window hosted layout: 0.281 seconds under a 3-second regression budget
- current-head iOS CI: build, unit tests, and UI tests passed
- current-head native Codex review: no major issues
- git diff --check