### PR TITLE
Invalidate tool caches when an MCP server (re)connects

### DIFF
--- a/src/family_assistant/tools/infrastructure.py
+++ b/src/family_assistant/tools/infrastructure.py
@@ -377,6 +377,30 @@ async def get_tool_definitions_for_advertisement(
     return await method()
 
 
+def resolve_descriptors_version(provider: ToolsProvider) -> int:
+    """Return a monotonic version of the descriptor set ``provider`` exposes.
+
+    Providers whose descriptor set can change at runtime (currently
+    ``MCPToolsProvider``, whose servers connect/reconnect/disconnect) expose a
+    ``descriptors_version`` that increments on every change. Wrappers forward
+    their inner provider's version; composites combine their children's.
+    Providers without the attribute are treated as static (version 0).
+
+    Consumers that cache policy-filtered tool listings for the process lifetime
+    compare this against the version their cache was built at, so a server that
+    was down at startup and later reconnects invalidates the stale cache instead
+    of staying permanently unadvertisable.
+    """
+    version = getattr(provider, "descriptors_version", None)
+    if isinstance(version, int):
+        return version
+    if isinstance(provider, ToolProviderWrapper):
+        return resolve_descriptors_version(provider.wrapped_provider)
+    if isinstance(provider, ToolProviderComposite):
+        return sum(resolve_descriptors_version(sub) for sub in provider.get_providers())
+    return 0
+
+
 class LocalToolsProvider:
     """Provides and executes locally defined Python functions as tools."""
 
@@ -804,6 +828,7 @@ class PolicyEnforcingToolsProvider(ToolsProvider):
         self._policy_engine = policy_engine
         self.confirmation_timeout = confirmation_timeout
         self._tool_definitions_by_confirmation: dict[bool, list[ToolDefinition]] = {}
+        self._cached_descriptors_version: int | None = None
 
     async def get_tool_definitions(
         self,
@@ -811,6 +836,14 @@ class PolicyEnforcingToolsProvider(ToolsProvider):
         can_confirm: bool = True,
     ) -> list[ToolDefinition]:
         """Return tool definitions that are advertisable in this interaction."""
+        current_version = resolve_descriptors_version(self._descriptor_provider)
+        if current_version != self._cached_descriptors_version:
+            # An MCP server connected, reconnected, or disconnected since this
+            # cache was built. Drop it so the newly available (or removed) tools
+            # are re-evaluated instead of serving a stale advertised set.
+            self._tool_definitions_by_confirmation.clear()
+            self._cached_descriptors_version = current_version
+
         if can_confirm in self._tool_definitions_by_confirmation:
             return self._tool_definitions_by_confirmation[can_confirm]
 

--- a/src/family_assistant/tools/infrastructure.py
+++ b/src/family_assistant/tools/infrastructure.py
@@ -857,11 +857,20 @@ class PolicyEnforcingToolsProvider(ToolsProvider):
             is not ToolPolicyDecision.DENY
         }
 
-        self._tool_definitions_by_confirmation[can_confirm] = [
-            definition
-            for definition in await self.wrapped_provider.get_tool_definitions()
-            if definition.get("function", {}).get("name") in allowed_names
-        ]
+        # Dedupe by function name (first occurrence wins, matching the
+        # first-registered precedence the root composite and MCP _tool_map use).
+        # A server that was down at startup can reconnect with a name that
+        # collides with a local/root tool; advertising both would send duplicate
+        # function declarations, which some LLM APIs reject.
+        advertised: list[ToolDefinition] = []
+        seen_names: set[str] = set()
+        for definition in await self.wrapped_provider.get_tool_definitions():
+            name = definition.get("function", {}).get("name")
+            if name not in allowed_names or name in seen_names:
+                continue
+            seen_names.add(name)
+            advertised.append(definition)
+        self._tool_definitions_by_confirmation[can_confirm] = advertised
         return self._tool_definitions_by_confirmation[can_confirm]
 
     async def get_tool_descriptors(self) -> list[ToolDescriptor]:

--- a/src/family_assistant/tools/mcp.py
+++ b/src/family_assistant/tools/mcp.py
@@ -96,6 +96,7 @@ class MCPToolsProvider:
         self._tool_map: dict[str, str] = {}  # Map tool name -> server_id
         self._definitions: list[ToolDefinition] = []
         self._descriptors: list[ToolDescriptor] = []
+        self._descriptors_version = 0
         self._initialized = False
         self._connection_contexts: dict[str, contextlib.AsyncExitStack] = {}
         self._server_statuses: dict[str, str] = {
@@ -618,6 +619,7 @@ class MCPToolsProvider:
                         self._server_statuses[server_id] = MCP_SERVER_STATUS_FAILED
 
         self._initialized = True
+        self._bump_descriptors_version()
         # Summarize outcomes based on statuses
         connected_count = sum(
             1
@@ -692,6 +694,23 @@ class MCPToolsProvider:
         if not self._initialized:
             await self.initialize()
         return self._definitions
+
+    @property
+    def descriptors_version(self) -> int:
+        """Monotonic counter that changes whenever the descriptor set changes.
+
+        Downstream wrappers cache policy-filtered tool listings for the process
+        lifetime. They compare this counter against the version their cache was
+        built at, so a server connecting, reconnecting, or disconnecting forces
+        a rebuild instead of serving a stale list. Without this, an MCP server
+        that is down at startup stays unadvertisable even after the health-check
+        loop reconnects it.
+        """
+        return self._descriptors_version
+
+    def _bump_descriptors_version(self) -> None:
+        """Signal that the discovered descriptor set has changed."""
+        self._descriptors_version += 1
 
     async def get_tool_descriptors(self) -> list[ToolDescriptor]:
         """Return descriptors for discovered MCP tools."""
@@ -860,6 +879,8 @@ class MCPToolsProvider:
             for descriptor in self._descriptors
             if descriptor.mcp_server_id != server_id
         ]
+        # The descriptor set shrank; a failed reconnect below leaves it that way.
+        self._bump_descriptors_version()
 
         # Attempt reconnection
         try:
@@ -889,6 +910,7 @@ class MCPToolsProvider:
                     self._definitions.append(tool_def)
                     self._descriptors.append(descriptor)
                     self._tool_map[tool_name] = server_id
+                self._bump_descriptors_version()
                 logger.info(
                     f"Successfully reconnected MCP server '{server_id}' with {len(discovered_tools)} tools"
                 )
@@ -1092,5 +1114,6 @@ class MCPToolsProvider:
         self._tool_map.clear()
         self._definitions.clear()
         self._descriptors.clear()
+        self._bump_descriptors_version()
         self._initialized = False
         logger.info("MCPToolsProvider closed.")

--- a/src/family_assistant/tools/on_demand.py
+++ b/src/family_assistant/tools/on_demand.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, cast
 from family_assistant.tools.infrastructure import (
     ToolDescriptorProvider,
     ToolsProvider,
+    resolve_descriptors_version,
 )
 from family_assistant.tools.metadata import ToolDescriptor, extract_tool_summary
 
@@ -166,6 +167,7 @@ class OnDemandToolsView:
         self._on_demand_tool_names = on_demand_tool_names
         self._on_demand_mcp_server_ids = on_demand_mcp_server_ids or set()
         self._all_descriptors: list[ToolDescriptor] | None = None
+        self._descriptors_version: int | None = None
         # Cache whether the wrapped provider's get_tool_definitions accepts
         # ``can_confirm``. The wrapped provider does not change for the lifetime
         # of this object, so doing the inspect.signature reflection once in
@@ -196,8 +198,17 @@ class OnDemandToolsView:
         meta-tool. If the wrapped provider already exposes a real tool with
         that name it would be silently shadowed, so refuse to wrap such a
         provider and fail loudly instead.
+
+        The cache is rebuilt when the wrapped descriptor set changes (an MCP
+        server connecting, reconnecting, or disconnecting), so on-demand
+        activation of a server that was down at startup works once the
+        health-check loop reconnects it.
         """
-        if self._all_descriptors is None:
+        current_version = resolve_descriptors_version(self._descriptor_provider)
+        if (
+            self._all_descriptors is None
+            or current_version != self._descriptors_version
+        ):
             descriptors = await self._descriptor_provider.get_tool_descriptors()
             collisions = [d for d in descriptors if d.name == "activate_tools"]
             if collisions:
@@ -208,6 +219,7 @@ class OnDemandToolsView:
                 )
                 raise ValueError(msg)
             self._all_descriptors = descriptors
+            self._descriptors_version = current_version
         return self._all_descriptors
 
     async def _fetch_wrapped_definitions(

--- a/tests/functional/integration/test_mcp_sse_restart.py
+++ b/tests/functional/integration/test_mcp_sse_restart.py
@@ -128,6 +128,7 @@ async def test_mcp_sse_restart(mcp_proxy_controller: MCPProxyController) -> None
     logger.info("Executing tool before restart...")
     result1 = await mcp_provider.execute_tool("convert_time", args, context)
     assert "Error" not in result1
+    version_before_restart = mcp_provider.descriptors_version
 
     # 3. Restart Server
     logger.info("Restarting MCP Proxy Server...")
@@ -139,5 +140,9 @@ async def test_mcp_sse_restart(mcp_proxy_controller: MCPProxyController) -> None
 
     # 5. Verify success
     assert "Error" not in result2
+
+    # 6. Reconnecting must advance the descriptors version so downstream caches
+    #    (policy/on-demand) rebuild instead of serving a stale tool list.
+    assert mcp_provider.descriptors_version > version_before_restart
 
     await mcp_provider.close()

--- a/tests/unit/tools/test_mcp_tool_filtering.py
+++ b/tests/unit/tools/test_mcp_tool_filtering.py
@@ -399,7 +399,9 @@ async def test_mcp_reconnect_preserves_existing_duplicate_tool_mapping() -> None
 
 
 @pytest.mark.asyncio
-async def test_reconnect_bumps_descriptors_version_and_restores_tools() -> None:
+async def test_reconnect_bumps_descriptors_version_and_restores_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Reconnecting a server that was down at startup must signal a change.
 
     Regression test: a server that failed to connect at startup exposes no
@@ -420,7 +422,7 @@ async def test_reconnect_bumps_descriptors_version_and_restores_tools() -> None:
     async def fake_connect_and_discover_mcp(
         server_id: str,
         server_conf: MCPServerConfig,
-    ) -> tuple[object, list[ToolDefinition], list, dict[str, str]]:
+    ) -> tuple[object, list[ToolDefinition], list[ToolDescriptor], dict[str, str]]:
         del server_conf
         return (
             object(),
@@ -436,11 +438,10 @@ async def test_reconnect_bumps_descriptors_version_and_restores_tools() -> None:
             {"execute_python": server_id},
         )
 
-    # Assigning a plain async function over the bound method is how this file
-    # drives the reconnect path without a live MCP server; basedpyright flags
-    # the method reassignment, which is exactly what we intend here.
-    provider._connect_and_discover_mcp = fake_connect_and_discover_mcp  # type: ignore[method-assign]
-    provider._close_server_connections = AsyncMock()
+    monkeypatch.setattr(
+        provider, "_connect_and_discover_mcp", fake_connect_and_discover_mcp
+    )
+    monkeypatch.setattr(provider, "_close_server_connections", AsyncMock())
 
     reconnected = await provider._reconnect_server("code-execution")
 

--- a/tests/unit/tools/test_mcp_tool_filtering.py
+++ b/tests/unit/tools/test_mcp_tool_filtering.py
@@ -399,6 +399,55 @@ async def test_mcp_reconnect_preserves_existing_duplicate_tool_mapping() -> None
 
 
 @pytest.mark.asyncio
+async def test_reconnect_bumps_descriptors_version_and_restores_tools() -> None:
+    """Reconnecting a server that was down at startup must signal a change.
+
+    Regression test: a server that failed to connect at startup exposes no
+    descriptors, so downstream caches (policy/on-demand) omit its tools. When
+    the health-check loop later reconnects it, ``descriptors_version`` must
+    advance so those caches rebuild instead of serving a stale list; otherwise
+    the tools stay unadvertisable until the process restarts.
+    """
+    provider = MCPToolsProvider({
+        "code-execution": {"transport": "stdio", "command": "echo"},
+    })
+    # Simulate "down at startup": initialised, but no descriptors discovered.
+    provider._initialized = True
+    version_while_down = provider.descriptors_version
+
+    recovered_definition = _tool_definition("execute_python")
+
+    async def fake_connect_and_discover_mcp(
+        server_id: str,
+        server_conf: MCPServerConfig,
+    ) -> tuple[object, list[ToolDefinition], list, dict[str, str]]:
+        del server_conf
+        return (
+            object(),
+            [recovered_definition],
+            [
+                build_tool_descriptor(
+                    recovered_definition,
+                    frozenset({ToolTag.CODE_EXECUTION, ToolTag.OUTPUT_UNTRUSTED}),
+                    origin="mcp",
+                    mcp_server_id=server_id,
+                )
+            ],
+            {"execute_python": server_id},
+        )
+
+    provider._connect_and_discover_mcp = fake_connect_and_discover_mcp  # type: ignore[method-assign]
+    provider._close_server_connections = AsyncMock()
+
+    reconnected = await provider._reconnect_server("code-execution")
+
+    assert reconnected is True
+    assert provider.descriptors_version > version_while_down
+    descriptor_names = {descriptor.name for descriptor in provider._descriptors}
+    assert "execute_python" in descriptor_names
+
+
+@pytest.mark.asyncio
 async def test_health_check_retries_failed_and_cancelled_servers() -> None:
     """Health check loop retries servers that failed or timed out during init."""
     all_retried = asyncio.Event()

--- a/tests/unit/tools/test_mcp_tool_filtering.py
+++ b/tests/unit/tools/test_mcp_tool_filtering.py
@@ -436,6 +436,9 @@ async def test_reconnect_bumps_descriptors_version_and_restores_tools() -> None:
             {"execute_python": server_id},
         )
 
+    # Assigning a plain async function over the bound method is how this file
+    # drives the reconnect path without a live MCP server; basedpyright flags
+    # the method reassignment, which is exactly what we intend here.
     provider._connect_and_discover_mcp = fake_connect_and_discover_mcp  # type: ignore[method-assign]
     provider._close_server_connections = AsyncMock()
 

--- a/tests/unit/tools/test_on_demand.py
+++ b/tests/unit/tools/test_on_demand.py
@@ -365,3 +365,57 @@ class TestOnDemandActivateToolsCollision:
 
         with pytest.raises(ValueError, match="reserved for the on-demand meta-tool"):
             await on_demand.get_tool_definitions()
+
+
+class _VersionedMCPDescriptorProvider(_StubMCPDescriptorProvider):
+    """Stub MCP provider whose descriptor set (and version) can change.
+
+    Models a server that was down at startup and later reconnects: ``reconnect``
+    adds the server's descriptors and bumps ``descriptors_version`` exactly as
+    the real ``MCPToolsProvider`` does.
+    """
+
+    def __init__(self, descriptors: list[ToolDescriptor]) -> None:
+        super().__init__(descriptors)
+        self._descriptors_version = 0
+
+    @property
+    def descriptors_version(self) -> int:
+        return self._descriptors_version
+
+    def reconnect(self, descriptors: list[ToolDescriptor]) -> None:
+        self._descriptors.extend(descriptors)
+        self._definitions.extend(d.definition for d in descriptors)
+        self._descriptors_version += 1
+
+
+class TestOnDemandDescriptorCacheInvalidation:
+    """On-demand activation reflects MCP servers that reconnect after startup."""
+
+    @pytest.mark.asyncio
+    async def test_server_down_at_startup_is_activatable_after_reconnect(self) -> None:
+        """Regression: a server down at startup is unactivatable until reconnect.
+
+        The descriptor cache was populated once on first access and never
+        refreshed, so an MCP server that failed to connect at startup stayed
+        unactivatable even after the health-check loop reconnected it.
+        """
+        # Server down at startup: no code-execution descriptors present.
+        wrapped = _VersionedMCPDescriptorProvider([])
+        on_demand = OnDemandToolsView(
+            wrapped_provider=wrapped,
+            on_demand_tool_names=set(),
+            on_demand_mcp_server_ids={"code-execution"},
+        )
+
+        before = await on_demand.activate_tools(mcp_server_ids=["code-execution"])
+        assert before.newly_activated == frozenset()
+
+        # Health-check loop reconnects the server; its tools appear.
+        wrapped.reconnect([
+            _make_mcp_descriptor("execute_python", "code-execution"),
+            _make_mcp_descriptor("execute_shell", "code-execution"),
+        ])
+
+        after = await on_demand.activate_tools(mcp_server_ids=["code-execution"])
+        assert after.newly_activated == frozenset({"execute_python", "execute_shell"})

--- a/tests/unit/tools/test_tools_infrastructure.py
+++ b/tests/unit/tools/test_tools_infrastructure.py
@@ -13,9 +13,11 @@ import pytest
 
 from family_assistant.storage.context import DatabaseContext
 from family_assistant.tools.infrastructure import (
+    CompositeToolsProvider,
     LocalToolsProvider,
     PolicyEnforcingToolsProvider,
     ToolPolicyDeniedError,
+    resolve_descriptors_version,
 )
 from family_assistant.tools.metadata import ToolDescriptor, ToolTag
 from family_assistant.tools.policy import (
@@ -1145,3 +1147,150 @@ class TestPolicyEnforcingToolsProvider:
                 {"title": "hello"},
                 self._make_context(),
             )
+
+
+class _VersionedDescriptorProvider:
+    """Descriptor provider whose descriptor set (and version) can change.
+
+    Models an ``MCPToolsProvider`` whose server was down at startup and later
+    reconnects: ``add_descriptor`` mutates the descriptor set and bumps
+    ``descriptors_version`` exactly as the real provider does.
+    """
+
+    def __init__(self, descriptors: list[ToolDescriptor]) -> None:
+        self._descriptors = list(descriptors)
+        self._descriptors_version = 0
+
+    @property
+    def descriptors_version(self) -> int:
+        return self._descriptors_version
+
+    def add_descriptor(self, descriptor: ToolDescriptor) -> None:
+        self._descriptors.append(descriptor)
+        self._descriptors_version += 1
+
+    async def get_tool_definitions(self) -> list[ToolDefinition]:
+        return [descriptor.definition for descriptor in self._descriptors]
+
+    async def get_tool_descriptors(self) -> list[ToolDescriptor]:
+        return list(self._descriptors)
+
+    async def get_tool_descriptor(self, name: str) -> ToolDescriptor | None:
+        for descriptor in self._descriptors:
+            if descriptor.name == name:
+                return descriptor
+        return None
+
+    async def execute_tool(
+        self,
+        name: str,
+        arguments: dict[str, object],
+        context: ToolExecutionContext,
+        call_id: str | None = None,
+    ) -> str:
+        del arguments, context, call_id
+        return f"executed:{name}"
+
+    async def close(self) -> None:
+        return None
+
+
+def _make_mcp_descriptor(name: str, server_id: str) -> ToolDescriptor:
+    return ToolDescriptor(
+        name=name,
+        definition={
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} description",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        tags=frozenset(),
+        origin="mcp",
+        mcp_server_id=server_id,
+    )
+
+
+class TestResolveDescriptorsVersion:
+    """The version resolver aggregates through wrappers and composites."""
+
+    def test_static_provider_is_version_zero(self) -> None:
+        provider = LocalToolsProvider(registrations=[])
+        assert resolve_descriptors_version(provider) == 0
+
+    def test_reads_descriptors_version_attribute(self) -> None:
+        provider = _VersionedDescriptorProvider([])
+        provider.add_descriptor(_make_mcp_descriptor("t", "srv"))
+        assert resolve_descriptors_version(provider) == 1
+
+    def test_composite_sums_child_versions(self) -> None:
+        versioned = _VersionedDescriptorProvider([])
+        versioned.add_descriptor(_make_mcp_descriptor("a", "srv"))
+        versioned.add_descriptor(_make_mcp_descriptor("b", "srv"))
+        composite = CompositeToolsProvider(
+            providers=[LocalToolsProvider(registrations=[]), versioned]
+        )
+        # Static child contributes 0; versioned child contributes 2.
+        assert resolve_descriptors_version(composite) == 2
+
+    def test_wrapper_forwards_inner_version(self) -> None:
+        versioned = _VersionedDescriptorProvider([])
+        versioned.add_descriptor(_make_mcp_descriptor("a", "srv"))
+        wrapper = PolicyEnforcingToolsProvider(
+            wrapped_provider=versioned,
+            policy_engine=PolicyEngine.from_policy_config(
+                ToolPolicyConfig(default_decision=ToolPolicyDecision.ALLOW)
+            ),
+        )
+        assert resolve_descriptors_version(wrapper) == 1
+
+
+class TestPolicyEnforcingCacheInvalidation:
+    """The advertised-definitions cache rebuilds when descriptors change."""
+
+    @staticmethod
+    def _allow_all_engine() -> PolicyEngine:
+        return PolicyEngine.from_policy_config(
+            ToolPolicyConfig(default_decision=ToolPolicyDecision.ALLOW)
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconnected_server_tools_become_advertisable(self) -> None:
+        """A server down at startup becomes advertisable once it reconnects.
+
+        Regression test for the indefinite ``get_tool_definitions`` cache: the
+        first call (server down) cached an advertised set without the MCP
+        tools, and nothing invalidated it when the tools later appeared.
+        """
+        wrapped = _VersionedDescriptorProvider([])
+        provider = PolicyEnforcingToolsProvider(
+            wrapped_provider=wrapped,
+            policy_engine=self._allow_all_engine(),
+        )
+
+        # Server down at startup: nothing advertised, cache warmed empty.
+        assert await provider.get_tool_definitions() == []
+
+        # Health-check loop reconnects the server and its tool appears.
+        wrapped.add_descriptor(_make_mcp_descriptor("execute_python", "code-execution"))
+
+        names = [d["function"]["name"] for d in await provider.get_tool_definitions()]
+        assert names == ["execute_python"]
+
+    @pytest.mark.asyncio
+    async def test_cache_served_while_descriptors_unchanged(self) -> None:
+        """Without a descriptor change the cached result is reused as-is."""
+        wrapped = _VersionedDescriptorProvider([
+            _make_mcp_descriptor("execute_python", "code-execution")
+        ])
+        provider = PolicyEnforcingToolsProvider(
+            wrapped_provider=wrapped,
+            policy_engine=self._allow_all_engine(),
+        )
+
+        first = await provider.get_tool_definitions()
+        second = await provider.get_tool_definitions()
+
+        # Same cached list object is returned when nothing changed.
+        assert first is second

--- a/tests/unit/tools/test_tools_infrastructure.py
+++ b/tests/unit/tools/test_tools_infrastructure.py
@@ -1294,3 +1294,55 @@ class TestPolicyEnforcingCacheInvalidation:
 
         # Same cached list object is returned when nothing changed.
         assert first is second
+
+    @pytest.mark.asyncio
+    async def test_colliding_names_are_deduped_in_advertised_list(self) -> None:
+        """A reconnected tool colliding with a local name is not advertised twice.
+
+        A server down at startup can reconnect exposing a tool whose name
+        matches a local/root tool. The rebuilt advertised list must not contain
+        duplicate function declarations (some LLM APIs reject them).
+        """
+
+        collide_def: ToolDefinition = {
+            "type": "function",
+            "function": {
+                "name": "execute_python",
+                "description": "execute_python description",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+        class _CollidingProvider:
+            async def get_tool_definitions(self) -> list[ToolDefinition]:
+                # Same name from two providers (e.g. local + reconnected MCP).
+                return [collide_def, collide_def]
+
+            async def get_tool_descriptors(self) -> list[ToolDescriptor]:
+                return [_make_mcp_descriptor("execute_python", "code-execution")]
+
+            async def get_tool_descriptor(self, name: str) -> ToolDescriptor | None:
+                if name == "execute_python":
+                    return _make_mcp_descriptor("execute_python", "code-execution")
+                return None
+
+            async def execute_tool(
+                self,
+                name: str,
+                arguments: dict[str, object],
+                context: ToolExecutionContext,
+                call_id: str | None = None,
+            ) -> str:
+                del arguments, context, call_id
+                return f"executed:{name}"
+
+            async def close(self) -> None:
+                return None
+
+        provider = PolicyEnforcingToolsProvider(
+            wrapped_provider=_CollidingProvider(),
+            policy_engine=self._allow_all_engine(),
+        )
+
+        names = [d["function"]["name"] for d in await provider.get_tool_definitions()]
+        assert names == ["execute_python"]


### PR DESCRIPTION
## Summary

An on-demand MCP server that is unreachable at startup stays permanently unadvertisable — even after the health-check loop reconnects it — until the process restarts. This is the real cause of `activate_tools` reporting **"No matching tools found"** for the `code-execution` server while diagnostics show it `"connected"`.

Two process-lifetime caches were never invalidated after startup:

- `PolicyEnforcingToolsProvider._tool_definitions_by_confirmation` — warmed once during `setup_dependencies` and reused for every turn. When a server was down at that moment, its tools were absent from the advertised set forever.
- `OnDemandToolsView._all_descriptors` — populated on first access and never refreshed, so `activate_tools(mcp_server_ids=["code-execution"])` matched nothing.

`MCPToolsProvider._reconnect_server` rebuilds its *own* descriptor list (which is why global diagnostics report the server healthy with all its tools), but it has no reference to the per-profile caches above, so they keep serving a stale list. The engineer profile's `reconnect_mcp_server` tool has the same blind spot — it only refreshes the MCP layer, so a manual reconnect makes the server *look* recovered without restoring the tools.

## Root cause

This is **not** the `operator_tools_policy` / `exclude=True` serialization issue originally suspected. That path is exercised by an existing passing test (`test_operator_default_profile_tools_policy_extends_defaults`), and a live diagnostic confirmed the policy merge works: a tool allowed via the same merged policy (`execute_script`) activated fine while the code-execution MCP tools did not — ruling out a wholesale policy fallback. The fault is a cache-invalidation gap between the MCP connection lifecycle and the downstream tool-listing caches.

## Fix

Version-token invalidation:

- `MCPToolsProvider` exposes a monotonic `descriptors_version` that bumps on connect, reconnect (both the pre-connect removal and the successful re-add), and disconnect.
- A `resolve_descriptors_version()` helper aggregates that version through wrappers (forward the inner version) and composites (sum children), so callers don't need back-references into the root provider — no layering violation.
- `PolicyEnforcingToolsProvider` and `OnDemandToolsView` record the version their cache was built at and rebuild when it changes. Unchanged descriptor sets still serve the cache as before.

## Tests

- `test_reconnect_bumps_descriptors_version_and_restores_tools` — reconnect after a startup failure advances the version and restores descriptors.
- `test_resolve_descriptors_version` cases — static → 0, wrapper forwards, composite sums, MCP counter read.
- `TestPolicyEnforcingCacheInvalidation` — a reconnected server's tools become advertisable; an unchanged set still serves the cache.
- `TestOnDemandDescriptorCacheInvalidation` — a server down at startup becomes activatable after reconnect.
- Extended the real-reconnect integration test (`test_mcp_sse_restart`) to assert the version advances across a server restart.

The two cache-rebuild regression tests were each verified to **fail without the fix** and pass with it.

## Verification

- `scripts/format-and-lint.sh` passes on all changed files.
- `tests/unit/tools/`, `tests/unit/processing/`, `tests/unit/test_tool_inventory.py` — 605 passed.
- `tests/functional/web/api/test_debug_profile_tools.py` passed. (Unrelated `test_browser_dom.py` failures under parallel load are pre-existing Playwright resource contention — they pass in isolation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rUsm4a1BbkWtat7ivZenL

---
_Generated by [Claude Code](https://claude.ai/code/session_012rUsm4a1BbkWtat7ivZenL)_