### PR TITLE
Install gcloud CLI in devcontainer/k8s-agent image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,6 +43,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs
 
+# Google Cloud SDK (gcloud CLI)
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list > /dev/null && \
+    apt-get update && apt-get install -y google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin
+
 # Binary tools
 COPY --from=gh-token-builder /go/bin/gh-token /usr/local/bin/gh-token
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/


### PR DESCRIPTION
## Summary
- The k8s-agent pod (`.devcontainer/k8s/dev-pod.yaml`) runs the image built from `.devcontainer/Dockerfile`, which had no way to talk to GKE/GCP.
- Adds the Google Cloud SDK apt repository and installs `google-cloud-cli` plus `google-cloud-cli-gke-gcloud-auth-plugin` (needed for `kubectl`/`gcloud` auth against GKE clusters) in the `base` stage, alongside the existing PostgreSQL/Node.js repo setup.

## Test plan
- [ ] Rebuild the devcontainer image and confirm `gcloud --version` and `gcloud components list` succeed.
- [ ] Confirm existing tooling (Playwright, uv, etc.) still installs correctly after the added apt step.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BcNkWgD99itFNPxXgFa7aN)_