### PR TITLE
Key tool advertisement off the descriptor execution resolves to

### DIFF
--- a/src/family_assistant/tools/infrastructure.py
+++ b/src/family_assistant/tools/infrastructure.py
@@ -847,9 +847,17 @@ class PolicyEnforcingToolsProvider(ToolsProvider):
         if can_confirm in self._tool_definitions_by_confirmation:
             return self._tool_definitions_by_confirmation[can_confirm]
 
+        # Execution resolves a name to the *first* descriptor with that name
+        # (composite order, local-before-MCP), so advertisement must evaluate
+        # policy against that same descriptor. Treating a name as allowed when
+        # *any* same-named descriptor passes would advertise a tool whose
+        # execution is denied (and hide the allowed one behind it).
+        first_descriptor_by_name: dict[str, ToolDescriptor] = {}
+        for descriptor in await self._descriptor_provider.get_tool_descriptors():
+            first_descriptor_by_name.setdefault(descriptor.name, descriptor)
         allowed_names = {
-            descriptor.name
-            for descriptor in await self._descriptor_provider.get_tool_descriptors()
+            name
+            for name, descriptor in first_descriptor_by_name.items()
             if self._policy_engine.evaluate_for_advertisement(
                 descriptor,
                 can_confirm=can_confirm,

--- a/src/family_assistant/tools/infrastructure.py
+++ b/src/family_assistant/tools/infrastructure.py
@@ -807,6 +807,13 @@ class CompositeToolsProvider(ToolsProvider):
         logger.info("CompositeToolsProvider closed.")
 
 
+def _describe_descriptor_origin(descriptor: ToolDescriptor) -> str:
+    """Return a log-friendly description of where a descriptor comes from."""
+    if descriptor.origin == "mcp":
+        return f"MCP (server {descriptor.mcp_server_id!r})"
+    return descriptor.origin
+
+
 class PolicyEnforcingToolsProvider(ToolsProvider):
     """Wraps another provider and enforces policy allow/deny/confirm decisions."""
 
@@ -854,7 +861,20 @@ class PolicyEnforcingToolsProvider(ToolsProvider):
         # execution is denied (and hide the allowed one behind it).
         first_descriptor_by_name: dict[str, ToolDescriptor] = {}
         for descriptor in await self._descriptor_provider.get_tool_descriptors():
-            first_descriptor_by_name.setdefault(descriptor.name, descriptor)
+            winner = first_descriptor_by_name.setdefault(descriptor.name, descriptor)
+            if winner is not descriptor:
+                # A collision is almost always operator misconfiguration or a
+                # misbehaving MCP server; the shadowed tool silently loses
+                # otherwise, so make it loud (ERROR reaches the persistent
+                # error log surfaced by the diagnostics endpoints).
+                logger.error(
+                    "Tool name collision on %r: %s descriptor is shadowed by "
+                    "the first-registered %s descriptor and is unreachable. "
+                    "Rename the tool or deny the shadowed origin by policy.",
+                    descriptor.name,
+                    _describe_descriptor_origin(descriptor),
+                    _describe_descriptor_origin(winner),
+                )
         allowed_names = {
             name
             for name, descriptor in first_descriptor_by_name.items()

--- a/tests/unit/tools/test_tools_infrastructure.py
+++ b/tests/unit/tools/test_tools_infrastructure.py
@@ -1346,3 +1346,92 @@ class TestPolicyEnforcingCacheInvalidation:
 
         names = [d["function"]["name"] for d in await provider.get_tool_definitions()]
         assert names == ["execute_python"]
+
+
+def _make_local_descriptor(name: str) -> ToolDescriptor:
+    return ToolDescriptor(
+        name=name,
+        definition={
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"local {name}",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        tags=frozenset(),
+        origin="local",
+    )
+
+
+class TestAdvertisementFollowsExecutionResolution:
+    """Advertisement evaluates policy on the descriptor execution resolves to.
+
+    Execution resolves a tool name to the *first* descriptor with that name,
+    so when two descriptors share a name and policy decides them differently,
+    the advertisement decision must come from the first descriptor — not from
+    "any descriptor with that name passes policy".
+    """
+
+    @pytest.mark.asyncio
+    async def test_name_not_advertised_when_first_descriptor_denied(self) -> None:
+        """An allowed tool shadowed by a denied one is not advertised.
+
+        The local descriptor comes first and is denied; the MCP descriptor
+        with the same name is allowed but unreachable (execution resolves the
+        name to the local descriptor). Advertising the name would offer the
+        LLM a tool that is always denied on execution.
+        """
+        wrapped = _VersionedDescriptorProvider([
+            _make_local_descriptor("foo"),
+            _make_mcp_descriptor("foo", "srv"),
+        ])
+        provider = PolicyEnforcingToolsProvider(
+            wrapped_provider=wrapped,
+            policy_engine=PolicyEngine.from_policy_config(
+                ToolPolicyConfig(
+                    default_decision=ToolPolicyDecision.DENY,
+                    rules=[
+                        PolicyRule(
+                            match=ToolMatcher(mcp_server_ids=["srv"]),
+                            decision=ToolPolicyDecision.ALLOW,
+                            priority=10,
+                        )
+                    ],
+                )
+            ),
+        )
+
+        assert await provider.get_tool_definitions() == []
+
+    @pytest.mark.asyncio
+    async def test_name_advertised_when_first_descriptor_allowed(self) -> None:
+        """A denied later descriptor does not suppress the allowed first one.
+
+        The local descriptor comes first and is allowed; a same-named MCP
+        descriptor is denied. The name is advertised once, with the first
+        (executable) definition.
+        """
+        wrapped = _VersionedDescriptorProvider([
+            _make_local_descriptor("foo"),
+            _make_mcp_descriptor("foo", "srv"),
+        ])
+        provider = PolicyEnforcingToolsProvider(
+            wrapped_provider=wrapped,
+            policy_engine=PolicyEngine.from_policy_config(
+                ToolPolicyConfig(
+                    default_decision=ToolPolicyDecision.ALLOW,
+                    rules=[
+                        PolicyRule(
+                            match=ToolMatcher(mcp_server_ids=["srv"]),
+                            decision=ToolPolicyDecision.DENY,
+                            priority=10,
+                        )
+                    ],
+                )
+            ),
+        )
+
+        definitions = await provider.get_tool_definitions()
+        assert [d["function"]["name"] for d in definitions] == ["foo"]
+        assert definitions[0]["function"]["description"] == "local foo"

--- a/tests/unit/tools/test_tools_infrastructure.py
+++ b/tests/unit/tools/test_tools_infrastructure.py
@@ -1435,3 +1435,63 @@ class TestAdvertisementFollowsExecutionResolution:
         definitions = await provider.get_tool_definitions()
         assert [d["function"]["name"] for d in definitions] == ["foo"]
         assert definitions[0]["function"]["description"] == "local foo"
+
+    @pytest.mark.asyncio
+    async def test_collision_logs_error_naming_both_origins(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A shadowed descriptor is reported loudly, not dropped silently.
+
+        Collisions are almost always misconfiguration or a misbehaving MCP
+        server; the ERROR record reaches the persistent error log surfaced by
+        the diagnostics endpoints.
+        """
+        wrapped = _VersionedDescriptorProvider([
+            _make_local_descriptor("foo"),
+            _make_mcp_descriptor("foo", "srv"),
+        ])
+        provider = PolicyEnforcingToolsProvider(
+            wrapped_provider=wrapped,
+            policy_engine=PolicyEngine.from_policy_config(
+                ToolPolicyConfig(default_decision=ToolPolicyDecision.ALLOW)
+            ),
+        )
+
+        with caplog.at_level("ERROR", logger="family_assistant.tools.infrastructure"):
+            await provider.get_tool_definitions()
+
+        collision_records = [
+            record
+            for record in caplog.records
+            if "Tool name collision" in record.getMessage()
+        ]
+        assert len(collision_records) == 1
+        message = collision_records[0].getMessage()
+        assert "'foo'" in message
+        assert "MCP (server 'srv')" in message
+        assert "local" in message
+
+    @pytest.mark.asyncio
+    async def test_no_collision_logs_no_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unique tool names never produce a collision error."""
+        wrapped = _VersionedDescriptorProvider([
+            _make_local_descriptor("foo"),
+            _make_mcp_descriptor("bar", "srv"),
+        ])
+        provider = PolicyEnforcingToolsProvider(
+            wrapped_provider=wrapped,
+            policy_engine=PolicyEngine.from_policy_config(
+                ToolPolicyConfig(default_decision=ToolPolicyDecision.ALLOW)
+            ),
+        )
+
+        with caplog.at_level("ERROR", logger="family_assistant.tools.infrastructure"):
+            await provider.get_tool_definitions()
+
+        assert not [
+            record
+            for record in caplog.records
+            if "Tool name collision" in record.getMessage()
+        ]


### PR DESCRIPTION
## Summary

Fixes #1023.

`PolicyEnforcingToolsProvider.get_tool_definitions` computed `allowed_names` name-keyed: a name counted as allowed if *any* descriptor with that name passed advertisement policy. But execution always resolves a name to the **first** descriptor with that name (composite order, local-before-MCP) via `get_tool_descriptor(name)`. When two descriptors share a name and policy decides them differently, a tool could be advertised to the LLM yet always denied on execution, while the genuinely-allowed same-named tool stayed hidden behind it.

## Fix

Build a first-descriptor-per-name map and evaluate the advertisement decision against that descriptor, so a name is advertised iff the descriptor that would actually run is allowed. This matches `get_tool_descriptor` / execution semantics exactly; unique names are unaffected.

## Tests

- `test_name_not_advertised_when_first_descriptor_denied` — local `foo` denied, MCP `foo` allowed → nothing advertised. Verified this fails against the old code.
- `test_name_advertised_when_first_descriptor_allowed` — local `foo` allowed, MCP `foo` denied → advertised once, with the first (executable) definition.

`scripts/format-and-lint.sh` passes; all 705 tests under `tests/unit/tools` and `tests/functional/tools` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPQkwBesXKhfQgonKBncYp

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPQkwBesXKhfQgonKBncYp)_