### PR TITLE
Default video generation to Gemini Omni Flash instead of Veo

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1215,7 +1215,7 @@ service_profiles:
           2. **Visual Style**: Define the visual aesthetic (e.g., "cinematic", "grainy 8mm film", "crisp 4k").
           3. **Duration**: Default to 8 seconds for most generations unless specified otherwise (Veo).
           4. **Consistency**: When using `first_frame_image` or `images` (reference), ensure the prompt aligns with the provided visual content.
-          5. **Model choice**: The default model (Gemini Omni Flash) produces fast, low-cost short clips and ignores Veo-only options (`negative_prompt`, `duration_seconds`, `last_frame_image`). For higher-quality cinematic clips, pass a `veo-*` model id (e.g. `model="veo-3.1-generate-preview"`) to use Veo instead.
+          5. **Model choice**: The default model (Gemini Omni Flash) produces fast, low-cost short clips. Requests with Veo-only options (`negative_prompt` or `last_frame_image`) automatically use Veo. For higher-quality cinematic clips, pass a `veo-*` model id (e.g. `model="veo-3.1-generate-preview"`) to use Veo explicitly.
 
           ## Workflow
           1. **Understand**: Clarify the user's vision. What is the subject? What is the mood?
@@ -1845,4 +1845,3 @@ browser_handoff_config:
 # OpenAI-compatible endpoint, with embedding_base_url (EMBEDDING_BASE_URL) and
 # embedding_api_key (EMBEDDING_API_KEY). For OpenRouter use
 # embedding_base_url=https://openrouter.ai/api/v1. See AGENTS.md "Embedding Providers".
-

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1215,7 +1215,7 @@ service_profiles:
           2. **Visual Style**: Define the visual aesthetic (e.g., "cinematic", "grainy 8mm film", "crisp 4k").
           3. **Duration**: Default to 8 seconds for most generations unless specified otherwise (Veo).
           4. **Consistency**: When using `first_frame_image` or `images` (reference), ensure the prompt aligns with the provided visual content.
-          5. **Model choice**: The default model produces high-quality cinematic clips. For fast, low-cost short clips (or when the user wants a quick draft), pass `model="gemini-omni-flash-preview"` to use Gemini Omni Flash instead. Omni Flash ignores Veo-only options (`negative_prompt`, `duration_seconds`, `last_frame_image`).
+          5. **Model choice**: The default model (Gemini Omni Flash) produces fast, low-cost short clips and ignores Veo-only options (`negative_prompt`, `duration_seconds`, `last_frame_image`). For higher-quality cinematic clips, pass a `veo-*` model id (e.g. `model="veo-3.1-generate-preview"`) to use Veo instead.
 
           ## Workflow
           1. **Understand**: Clarify the user's vision. What is the subject? What is the mood?

--- a/docs/user/FEATURES.md
+++ b/docs/user/FEATURES.md
@@ -404,7 +404,8 @@ ______________________________________________________________________
 
 ### Video Generation
 
-Create short videos from text descriptions using Google's Veo model.
+Create short videos from text descriptions using Gemini Omni Flash by default, or Google's Veo model
+for higher-quality cinematic clips.
 
 **Capabilities:**
 
@@ -423,7 +424,7 @@ Create short videos from text descriptions using Google's Veo model.
 - "Create a video of ocean waves crashing on rocks"
 - "Make a 4-second video of a puppy playing"
 
-**Requirements:** Gemini API key with Veo access
+**Requirements:** Gemini API key (with Veo access for the cinematic model)
 
 **Documentation:**
 [User Guide - Video Generation](USER_GUIDE.md#3-what-can-the-assistant-do-for-you-core-features)

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -280,9 +280,9 @@ You can ask the assistant a wide variety of things:
   - "Create a video of a puppy playing in the grass, 16:9 aspect ratio."
   - "Make a 4-second video of ocean waves crashing on rocks." *The assistant will generate the video
     and provide a link to view it.*
-  - *By default the assistant uses Google's Veo models for cinematic, high-quality clips. Ask for a
-    "quick" or "fast" video and it can switch to Gemini Omni Flash, which trades some polish for
-    much faster, lower-cost generation.*
+  - *By default the assistant uses Gemini Omni Flash for fast, low-cost video generation. Ask for a
+    "cinematic" or "high-quality" video and it can switch to Google's Veo models, which trade some
+    speed for more polished, film-like output.*
 
 - **Search Your Gmail and Drive:** If you have connected a Google account (see
   [Connect your Google account](#connect-your-google-account) below), the assistant can search and

--- a/src/family_assistant/config_models.py
+++ b/src/family_assistant/config_models.py
@@ -1299,7 +1299,8 @@ class AppConfig(BaseSettings):
     gemini_image: GeminiImageConfig = Field(default_factory=GeminiImageConfig)
 
     # Video generation. When backend is None it is inferred from the requested
-    # model (``veo-*`` -> Veo, otherwise Gemini Omni Flash), defaulting to Veo.
+    # model (``veo-*`` -> Veo, otherwise Gemini Omni Flash), defaulting to
+    # Gemini Omni Flash.
     video_generation_backend: Literal["veo", "gemini_omni", "mock"] | None = None
     veo_video: VeoVideoConfig = Field(default_factory=VeoVideoConfig)
     gemini_omni_video: GeminiOmniVideoConfig = Field(

--- a/src/family_assistant/tools/video_backends.py
+++ b/src/family_assistant/tools/video_backends.py
@@ -74,10 +74,10 @@ type _ContentBlock = _ImageBlock | _TextBlock
 
 
 class _VideoResponseFormat(TypedDict):
-    """Interactions ``response_format`` requesting inline video output."""
+    """Interactions ``response_format`` requesting URI video output."""
 
     type: Literal["video"]
-    delivery: Literal["inline"]
+    delivery: Literal["uri"]
     aspect_ratio: str
     duration: NotRequired[str]
 
@@ -342,12 +342,22 @@ class GeminiOmniVideoBackend:
         self, request: VideoGenerationRequest
     ) -> VideoGenerationResult:
         """Generate a video with Gemini Omni Flash via the Interactions API."""
+        unsupported_features: list[str] = []
+        if request.last_frame is not None:
+            unsupported_features.append("last_frame")
+        if request.negative_prompt is not None:
+            unsupported_features.append("negative_prompt")
+        if unsupported_features:
+            raise VideoGenerationError(
+                "Gemini Omni Flash does not support "
+                f"{', '.join(unsupported_features)}; use a Veo model instead."
+            )
+
         async with _create_genai_client(self.api_key).aio as client:
-            # response_format requests inline video output (the Interactions
-            # response_modalities enum only covers text/image/audio).
+            # URI delivery avoids the Interactions API's 4 MB inline limit.
             response_format: _VideoResponseFormat = {
                 "type": "video",
-                "delivery": "inline",
+                "delivery": "uri",
                 "aspect_ratio": request.aspect_ratio,
             }
             if request.duration_seconds is not None:
@@ -417,5 +427,23 @@ class GeminiOmniVideoBackend:
             uri = getattr(output_video, "uri", None)
             if uri:
                 self.logger.info("Downloading Omni Flash video from URI...")
+                file_name = f"files/{uri.rstrip('/').rsplit('/', maxsplit=1)[-1]}"
+                start_time = time.time()
+                while True:
+                    file_info = await client.files.get(name=file_name)
+                    state = getattr(file_info, "state", None)
+                    state_name = getattr(state, "name", state)
+                    if state_name == "ACTIVE":
+                        break
+                    if state_name == "FAILED":
+                        raise VideoGenerationError(
+                            "Omni Flash generated video file processing failed."
+                        )
+                    if time.time() - start_time > self._TIMEOUT_SECONDS:
+                        raise VideoGenerationError(
+                            "Omni Flash generated video file processing timed out "
+                            f"after {self._TIMEOUT_SECONDS} seconds."
+                        )
+                    await asyncio.sleep(self._POLL_INTERVAL_SECONDS)
                 return await client.files.download(file=cast("Any", uri))
         raise VideoGenerationError("No video content found in Omni Flash response.")

--- a/src/family_assistant/tools/video_generation.py
+++ b/src/family_assistant/tools/video_generation.py
@@ -74,7 +74,7 @@ VIDEO_GENERATION_TOOLS_DEFINITION: list[ToolDefinition] = [
                     },
                     "model": {
                         "type": "string",
-                        "description": "Optional model override. Defaults to Gemini Omni Flash (gemini-omni-flash-preview) for fast conversational video. A `veo-*` id selects Veo for cinematic, higher-quality clips instead.",
+                        "description": "Optional model override. Defaults to Gemini Omni Flash (gemini-omni-flash-preview) for fast conversational video. A `veo-*` id, or use of `negative_prompt` or `last_frame_image` without a model override, selects Veo for cinematic, higher-quality clips instead.",
                     },
                 },
                 "required": ["prompt"],
@@ -131,7 +131,10 @@ def _is_veo_model(model: str | None) -> bool:
 
 
 def _create_video_backend(
-    exec_context: ToolExecutionContext, model_override: str | None
+    exec_context: ToolExecutionContext,
+    model_override: str | None,
+    *,
+    requires_veo_features: bool = False,
 ) -> VideoGenerationBackend:
     """Select a video generation backend from config (or infer from the model)."""
     if hasattr(exec_context, "video_backend"):
@@ -178,6 +181,13 @@ def _create_video_backend(
         logger.info("Inferring Veo backend from model %s", model_override)
         return VeoVideoBackend(api_key, model=model_override)
 
+    if requires_veo_features and model_override is None:
+        logger.info("Auto-selecting Veo backend for Veo-only request features")
+        return VeoVideoBackend(
+            api_key,
+            model=app_config.veo_video.model if app_config else None,
+        )
+
     logger.info("Auto-selecting Gemini Omni Flash video backend")
     return GeminiOmniVideoBackend(
         api_key,
@@ -208,14 +218,20 @@ async def generate_video_tool(
         last_frame_image: Optional last frame image (Veo interpolation).
         negative_prompt: Optional negative prompt (Veo only).
         aspect_ratio: Aspect ratio ("16:9" or "9:16").
-        duration_seconds: Duration in seconds ("4", "6", or "8"; Veo only).
+        duration_seconds: Duration in seconds ("4", "6", or "8").
         model: Optional model identifier override.
 
     Returns:
         ToolResult containing the video attachment.
     """
     try:
-        backend = _create_video_backend(exec_context, model)
+        backend = _create_video_backend(
+            exec_context,
+            model,
+            requires_veo_features=(
+                last_frame_image is not None or negative_prompt is not None
+            ),
+        )
     except ValueError as e:
         # ast-grep-ignore: toolresult-text-literal-with-data - Error message is sufficient
         return ToolResult(text=f"Error: {e}", data={"error": str(e)})

--- a/src/family_assistant/tools/video_generation.py
+++ b/src/family_assistant/tools/video_generation.py
@@ -74,7 +74,7 @@ VIDEO_GENERATION_TOOLS_DEFINITION: list[ToolDefinition] = [
                     },
                     "model": {
                         "type": "string",
-                        "description": "Optional model override. Defaults to the configured backend's model (Veo for cinematic clips, or gemini-omni-flash-preview for fast conversational video). A `veo-*` id selects Veo; otherwise Gemini Omni Flash is used.",
+                        "description": "Optional model override. Defaults to Gemini Omni Flash (gemini-omni-flash-preview) for fast conversational video. A `veo-*` id selects Veo for cinematic, higher-quality clips instead.",
                     },
                 },
                 "required": ["prompt"],
@@ -166,21 +166,23 @@ def _create_video_backend(
         )
         return GeminiOmniVideoBackend(api_key, model=omni_model)
 
-    # No explicit backend — infer from the requested model, defaulting to Veo.
+    # No explicit backend — infer from the requested model, defaulting to
+    # Gemini Omni Flash.
     if not api_key:
         logger.info(
             "No video_generation_backend or GEMINI_API_KEY configured, using mock"
         )
         return MockVideoBackend()
 
-    if model_override and not _is_veo_model(model_override):
-        logger.info("Inferring Gemini Omni Flash backend from model %s", model_override)
-        return GeminiOmniVideoBackend(api_key, model=model_override)
+    if model_override and _is_veo_model(model_override):
+        logger.info("Inferring Veo backend from model %s", model_override)
+        return VeoVideoBackend(api_key, model=model_override)
 
-    logger.info("Auto-selecting Veo video backend")
-    return VeoVideoBackend(
+    logger.info("Auto-selecting Gemini Omni Flash video backend")
+    return GeminiOmniVideoBackend(
         api_key,
-        model=model_override or (app_config.veo_video.model if app_config else None),
+        model=model_override
+        or (app_config.gemini_omni_video.model if app_config else None),
     )
 
 

--- a/tests/unit/tools/test_video_backends.py
+++ b/tests/unit/tools/test_video_backends.py
@@ -91,6 +91,27 @@ def test_auto_select_infers_veo_from_model() -> None:
     assert backend.model == "veo-3.1-fast"
 
 
+def test_auto_select_uses_veo_for_veo_only_features() -> None:
+    config = AppConfig(gemini_api_key="key")
+    backend = _create_video_backend(
+        _ctx_with_config(config),
+        model_override=None,
+        requires_veo_features=True,
+    )
+    assert isinstance(backend, VeoVideoBackend)
+    assert backend.model == "veo-3.1-generate-preview"
+
+
+def test_omni_model_override_remains_authoritative_for_veo_only_features() -> None:
+    config = AppConfig(gemini_api_key="key")
+    backend = _create_video_backend(
+        _ctx_with_config(config),
+        model_override="gemini-omni-flash-preview",
+        requires_veo_features=True,
+    )
+    assert isinstance(backend, GeminiOmniVideoBackend)
+
+
 def test_auto_select_falls_back_to_mock_without_key() -> None:
     config = AppConfig()
     with patch.dict("os.environ", {}, clear=True):
@@ -316,6 +337,9 @@ def omni_async_client() -> Generator[MagicMock]:
         return_value=_omni_interaction(output_video=_video_output(b"omni-video"))
     )
     async_client.interactions.get = AsyncMock()
+    async_client.files.get = AsyncMock(
+        return_value=SimpleNamespace(state=SimpleNamespace(name="ACTIVE"))
+    )
     async_client.files.download = AsyncMock(return_value=b"uri-video")
 
     with (
@@ -329,7 +353,7 @@ def omni_async_client() -> Generator[MagicMock]:
 
 
 @pytest.mark.asyncio
-async def test_omni_returns_inline_video_bytes(omni_async_client: MagicMock) -> None:
+async def test_omni_returns_video_bytes(omni_async_client: MagicMock) -> None:
     backend = GeminiOmniVideoBackend("key")
     result = await backend.generate_video(
         VideoGenerationRequest(prompt="a dancing robot", aspect_ratio="9:16")
@@ -344,7 +368,7 @@ async def test_omni_returns_inline_video_bytes(omni_async_client: MagicMock) -> 
     assert kwargs["input"] == "a dancing robot"
     assert kwargs["response_format"] == {
         "type": "video",
-        "delivery": "inline",
+        "delivery": "uri",
         "aspect_ratio": "9:16",
     }
 
@@ -419,7 +443,30 @@ async def test_omni_downloads_uri_when_no_inline_data(
     result = await backend.generate_video(VideoGenerationRequest(prompt="big video"))
 
     assert result.content == b"uri-video"
+    omni_async_client.files.get.assert_called_once_with(name="files/video")
     omni_async_client.files.download.assert_called_once_with(file="https://files/video")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "video_request",
+    [
+        VideoGenerationRequest(
+            prompt="interpolate",
+            last_frame=VideoReferenceImage(content=b"last"),
+        ),
+        VideoGenerationRequest(prompt="exclude rain", negative_prompt="rain"),
+    ],
+)
+async def test_omni_rejects_unsupported_veo_features(
+    omni_async_client: MagicMock, video_request: VideoGenerationRequest
+) -> None:
+    backend = GeminiOmniVideoBackend("key")
+
+    with pytest.raises(VideoGenerationError, match="use a Veo model"):
+        await backend.generate_video(video_request)
+
+    omni_async_client.interactions.create.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_video_backends.py
+++ b/tests/unit/tools/test_video_backends.py
@@ -66,11 +66,11 @@ def test_explicit_backend_requires_api_key() -> None:
         _create_video_backend(_ctx_with_config(config), model_override=None)
 
 
-def test_auto_select_defaults_to_veo() -> None:
+def test_auto_select_defaults_to_gemini_omni() -> None:
     config = AppConfig(gemini_api_key="key")
     backend = _create_video_backend(_ctx_with_config(config), model_override=None)
-    assert isinstance(backend, VeoVideoBackend)
-    assert backend.model == "veo-3.1-generate-preview"
+    assert isinstance(backend, GeminiOmniVideoBackend)
+    assert backend.model == "gemini-omni-flash-preview"
 
 
 def test_auto_select_infers_omni_from_model() -> None:


### PR DESCRIPTION
## Summary
- When no `video_generation_backend` or `model` override is configured, `generate_video` now auto-selects Gemini Omni Flash (fast, low-cost) instead of Veo (cinematic, slower).
- Explicit `veo-*` model overrides, or an explicit `video_generation_backend: veo` config, still select Veo as before.
- Updated the `generate_video` tool description, the video-generation system prompt guidance, and user-facing docs (`USER_GUIDE.md`, `FEATURES.md`) to describe the new default.

## Test plan
- [x] `pytest tests/unit/tools/test_video_backends.py tests/unit/tools/test_video_generation_tools.py -q` — 28 passed
- [x] `pytest tests/unit/tools/ -q` — 440 passed
- [x] `scripts/format-and-lint.sh` on changed files — passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4d6dhUBxwTnz6MXYHrcMR)_