### PR TITLE
Engineer profile: self-aware limitations, tool-policy introspection, and confirm-gated AI workers

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1646,7 +1646,7 @@ service_profiles:
           - You CAN delegate to another profile to hand off a fix or follow-up action, but only after the user confirms (so a human always approves before the engineer reaches outside its read-only sandbox)
           - You CAN create GitHub issues to report bugs (requires confirmation)
           - You CAN reconnect a failed MCP server (requires confirmation)
-          - You CAN spawn isolated AI coding workers (spawn_worker, requires confirmation). A worker's sandbox contains ONLY the task description you write (it produces output files); it has NO access to Family Assistant tools or data, and NO copy of this application's source checkout. Use workers for self-contained computation or drafting — e.g. writing a script, analysis, or patch from details you paste into the description — and include everything the worker needs in the description itself. Reading worker results needs no confirmation; cancelling a worker (cancel_worker_task) requires confirmation.
+          - You CAN spawn isolated AI coding workers (spawn_worker, requires confirmation) to take on self-contained coding tasks, including work on this application's own code: the worker has network access and checks the code out itself by cloning the public repository (github.com/werdnum/family-assistant). Its sandbox is NOT given a mounted copy of the running app's files, its database, or any Family Assistant tools/data. A worker returns its results as output files (e.g. a patch or a written analysis) that you read back with read_task_result; it cannot change the running application directly. Put everything the worker needs — repo URL, branch, the change to make, and how to report back — in the task description. Reading worker results needs no confirmation; cancelling a worker (cancel_worker_task) requires confirmation.
 
           ## Investigation Approach
 
@@ -1660,7 +1660,7 @@ service_profiles:
           6b. For "tool missing" / "tool call denied" reports: use resolve_tool_policy to see the live allow/deny/confirm decision and the matching policy rule for the affected profile before concluding anything is broken
           7. Summarize findings and recommend fixes
           8. If appropriate, create a GitHub issue with your findings
-          9. For self-contained computation or drafting that needs no access to the application's checkout or data, offer to spawn an isolated AI coding worker (requires confirmation); its sandbox contains only the task description, so include everything it needs there
+          9. For a self-contained coding task — including a fix or investigation against this repo, which the worker clones itself from GitHub — offer to spawn an isolated AI coding worker (requires confirmation); it returns a patch/analysis as output files rather than changing the running app, so describe the change and how to report back in the task description
     tools_policy:
       default_decision: "deny"
       rules:

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1646,7 +1646,7 @@ service_profiles:
           - You CAN delegate to another profile to hand off a fix or follow-up action, but only after the user confirms (so a human always approves before the engineer reaches outside its read-only sandbox)
           - You CAN create GitHub issues to report bugs (requires confirmation)
           - You CAN reconnect a failed MCP server (requires confirmation)
-          - You CAN spawn isolated AI coding workers (spawn_worker, requires confirmation) to implement or verify a code fix. Workers run in sandboxed containers with NO access to Family Assistant tools or data, so hand them self-contained coding tasks, not tasks needing user data. Reading worker results needs no confirmation; cancelling a worker (cancel_worker_task) requires confirmation.
+          - You CAN spawn isolated AI coding workers (spawn_worker, requires confirmation). A worker's sandbox contains ONLY the task description you write (it produces output files); it has NO access to Family Assistant tools or data, and NO copy of this application's source checkout. Use workers for self-contained computation or drafting — e.g. writing a script, analysis, or patch from details you paste into the description — and include everything the worker needs in the description itself. Reading worker results needs no confirmation; cancelling a worker (cancel_worker_task) requires confirmation.
 
           ## Investigation Approach
 
@@ -1660,7 +1660,7 @@ service_profiles:
           6b. For "tool missing" / "tool call denied" reports: use resolve_tool_policy to see the live allow/deny/confirm decision and the matching policy rule for the affected profile before concluding anything is broken
           7. Summarize findings and recommend fixes
           8. If appropriate, create a GitHub issue with your findings
-          9. For a self-contained code fix or verification task, offer to spawn an isolated AI coding worker (requires confirmation)
+          9. For self-contained computation or drafting that needs no access to the application's checkout or data, offer to spawn an isolated AI coding worker (requires confirmation); its sandbox contains only the task description, so include everything it needs there
     tools_policy:
       default_decision: "deny"
       rules:

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1629,19 +1629,24 @@ service_profiles:
           - **Automations**: View automation configurations and statistics
           - **Events**: Query recent system events
           - **Configuration**: Inspect the live AppConfig and individual service profile configs (with secrets redacted)
+          - **Tool policy**: Resolve the live tool-policy decision (allow/deny/confirm) for any tool against any profile, including which rule matched and why (resolve_tool_policy)
           - **MCP servers**: View live MCP server connection status and the tools each server provides
           - **System info**: Python version, OS platform, database dialect
           - **Runtime taint diagnostics**: Query the taint audit and message-history metadata tables
             to distinguish distinct legacy rows from repeated warning-log accesses
+          - **Worker tasks**: List AI worker tasks and read their results (read_task_result, list_worker_tasks)
 
-          ## Your Limitations
+          ## Your Limitations (deliberate, not bugs)
+
+          Your tool set is intentionally restricted to keep this profile read-only: you handle trusted requests and read sensitive data (source code, database, logs), so you must not change state or communicate externally without a human approving. Tools that other profiles have — editing notes, calendar changes, sending messages, browsing, Home Assistant control, scripts, image generation, and so on — are deliberately NOT available here. A missing tool or a policy-denied tool call is therefore expected configuration, not an application bug: do not report it as an error or tell the user something is broken. When in doubt, use resolve_tool_policy to see the exact policy decision and matching rule for your profile (or any other profile).
 
           - You CANNOT modify any data (no INSERT, UPDATE, DELETE)
-          - You CANNOT execute code or scripts
+          - You CANNOT execute code or scripts inside the application
           - You CANNOT send messages to users
           - You CAN delegate to another profile to hand off a fix or follow-up action, but only after the user confirms (so a human always approves before the engineer reaches outside its read-only sandbox)
           - You CAN create GitHub issues to report bugs (requires confirmation)
           - You CAN reconnect a failed MCP server (requires confirmation)
+          - You CAN spawn isolated AI coding workers (spawn_worker, requires confirmation) to implement or verify a code fix. Workers run in sandboxed containers with NO access to Family Assistant tools or data, so hand them self-contained coding tasks, not tasks needing user data. Reading worker results needs no confirmation; cancelling a worker (cancel_worker_task) requires confirmation.
 
           ## Investigation Approach
 
@@ -1652,8 +1657,10 @@ service_profiles:
           5. For MCP/tool issues: use get_mcp_server_status to confirm each MCP server is connected and exposes the expected tool names
           6. For config issues: use get_resolved_config and get_profile_config to inspect the live runtime config
           6a. For tool-bloat / prompt-size issues: use get_profile_tool_inventory to see how many tools each profile advertises per turn (eager vs on-demand) and which source (local vs each MCP server) dominates the token cost
+          6b. For "tool missing" / "tool call denied" reports: use resolve_tool_policy to see the live allow/deny/confirm decision and the matching policy rule for the affected profile before concluding anything is broken
           7. Summarize findings and recommend fixes
           8. If appropriate, create a GitHub issue with your findings
+          9. For a self-contained code fix or verification task, offer to spawn an isolated AI coding worker (requires confirmation)
     tools_policy:
       default_decision: "deny"
       rules:
@@ -1670,8 +1677,11 @@ service_profiles:
               - "get_resolved_config"
               - "get_profile_config"
               - "get_profile_tool_inventory"
+              - "resolve_tool_policy"
               - "get_system_info"
               - "get_message_history"
+              - "read_task_result"
+              - "list_worker_tasks"
               - "list_notes"
               - "get_note"
               - "search_documents"
@@ -1719,6 +1729,13 @@ service_profiles:
               - "reconnect_mcp_server"
           decision: "confirm"
           priority: 20
+        - match:
+            names:
+              - "spawn_worker"
+              - "cancel_worker_task"
+          decision: "confirm"
+          priority: 20
+          description: "The engineer may launch or cancel isolated AI coding workers (sandboxed, no Family Assistant data access), but a human must approve each state-changing worker action to preserve the profile's read-only posture."
     slash_commands:
       - "/engineer"
   - id: "ops_automation"

--- a/docs/design/engineer_profile.md
+++ b/docs/design/engineer_profile.md
@@ -147,10 +147,13 @@ The engineer profile and `spawn_worker` serve complementary but distinct purpose
 They do not overlap in capability: workers cannot access the database, error logs, or any Family
 Assistant tools or data; the engineer cannot execute code or modify files itself. The engineer
 profile *can* invoke `spawn_worker` directly (behind user confirmation) so an investigation can hand
-a self-contained coding task — implement this fix, verify this hypothesis against the repo — to a
-sandboxed worker without leaving the engineer conversation. Because the worker sandbox has no access
-to Family Assistant data, this crosses no Rule-of-Two boundary beyond the state change of launching
-the worker, which is what the confirmation covers.
+a self-contained computation or drafting task to a sandboxed worker without leaving the engineer
+conversation. The worker sandbox mounts only the task's own directory — it receives the task
+description and produces output files, with no copy of the application's source checkout and no
+`context_paths` mounts (both backends document that parameter as unused) — so everything the worker
+needs must be included in the task description, and the engineer's system prompt says so. Because
+the worker sandbox has no access to Family Assistant data, this crosses no Rule-of-Two boundary
+beyond the state change of launching the worker, which is what the confirmation covers.
 
 ## Usage
 

--- a/docs/design/engineer_profile.md
+++ b/docs/design/engineer_profile.md
@@ -147,13 +147,15 @@ The engineer profile and `spawn_worker` serve complementary but distinct purpose
 They do not overlap in capability: workers cannot access the database, error logs, or any Family
 Assistant tools or data; the engineer cannot execute code or modify files itself. The engineer
 profile *can* invoke `spawn_worker` directly (behind user confirmation) so an investigation can hand
-a self-contained computation or drafting task to a sandboxed worker without leaving the engineer
-conversation. The worker sandbox mounts only the task's own directory — it receives the task
-description and produces output files, with no copy of the application's source checkout and no
-`context_paths` mounts (both backends document that parameter as unused) — so everything the worker
-needs must be included in the task description, and the engineer's system prompt says so. Because
-the worker sandbox has no access to Family Assistant data, this crosses no Rule-of-Two boundary
-beyond the state change of launching the worker, which is what the confirmation covers.
+a self-contained coding task to a sandboxed worker without leaving the engineer conversation. The
+worker sandbox is given only the task's own directory, but it has network access and can clone the
+public repository itself, so it *can* work on this application's code — it just receives no mounted
+local checkout and no `context_paths` mounts (both backends document that parameter as unused), and
+returns its work as output files (e.g. a patch) rather than modifying the running application.
+Everything the worker needs therefore goes in the task description, and the engineer's system prompt
+says so. Because the worker sandbox has no access to Family Assistant data, this crosses no
+Rule-of-Two boundary beyond the state change of launching the worker, which is what the confirmation
+covers.
 
 ## Usage
 

--- a/docs/design/engineer_profile.md
+++ b/docs/design/engineer_profile.md
@@ -88,23 +88,47 @@ is where the trust boundary is actually crossed.
 
 ### Confirmation for Side Effects
 
-`create_github_issue` is the only tool that has external side effects (creating an issue on GitHub).
-The engineer profile's `tools_policy` requires confirmation for that tool so the user must approve
-before execution.
+Every engineer tool with side effects is gated behind user confirmation rather than allowed
+outright: `create_github_issue` (creates an issue on GitHub), `reconnect_mcp_server` (tears down and
+re-establishes an MCP session), and the state-changing worker actions `spawn_worker` /
+`cancel_worker_task` (launch or stop an isolated AI coding worker). This keeps the profile's
+effective posture read-only: a human approves before anything outside the sandbox changes.
+
+### Self-Awareness of Restrictions
+
+The engineer's tool set is deliberately narrow, and its system prompt says so explicitly: a missing
+tool or a policy-denied call is expected configuration, not an application bug, and the prompt
+instructs the profile not to report such denials as errors. To make that checkable rather than an
+article of faith, the `resolve_tool_policy` tool resolves the live policy decision (allow / deny /
+confirm) for any tool name against any profile's policy engine and reports which rule matched
+(layer, priority, description) or that the default decision applied. It accepts hypothetical call
+arguments so argument-conditional rules (e.g. `delegate_to_service` targets) can be tested, and a
+`can_confirm` flag to model interactions that cannot prompt for confirmation. This is the intended
+first stop when diagnosing "tool missing" / "tool denied" reports for any profile — including the
+engineer itself.
 
 ## Tools
 
-| Tool                  | Purpose                                             | Side Effects                          |
-| --------------------- | --------------------------------------------------- | ------------------------------------- |
-| `read_source_file`    | Read project source files with optional line ranges | None                                  |
-| `search_source_code`  | Search codebase using ripgrep patterns              | None                                  |
-| `query_database`      | Execute read-only SQL SELECT queries                | None                                  |
-| `read_error_logs`     | Read application error/warning logs                 | None                                  |
-| `create_github_issue` | File bug reports on GitHub                          | Creates issue (requires confirmation) |
+| Tool                   | Purpose                                                | Side Effects                          |
+| ---------------------- | ------------------------------------------------------ | ------------------------------------- |
+| `read_source_file`     | Read project source files with optional line ranges    | None                                  |
+| `search_source_code`   | Search codebase using ripgrep patterns                 | None                                  |
+| `query_database`       | Execute read-only SQL SELECT queries                   | None                                  |
+| `read_error_logs`      | Read application error/warning logs                    | None                                  |
+| `resolve_tool_policy`  | Explain the live tool-policy decision for any profile  | None                                  |
+| `read_task_result`     | Read the result of an AI worker task                   | None                                  |
+| `list_worker_tasks`    | List AI worker tasks and their statuses                | None                                  |
+| `create_github_issue`  | File bug reports on GitHub                             | Creates issue (requires confirmation) |
+| `reconnect_mcp_server` | Re-establish a failed MCP server session               | Reconnects (requires confirmation)    |
+| `spawn_worker`         | Launch an isolated AI coding worker to implement a fix | Starts worker (requires confirmation) |
+| `cancel_worker_task`   | Cancel a running AI worker task                        | Stops worker (requires confirmation)  |
 
 The profile also includes existing read-only tools: `list_notes`, `get_note`, `search_documents`,
 `get_full_document_content`, `get_user_documentation_content`, `list_pending_callbacks`,
-`query_recent_events`, `list_automations`, `get_automation`, `get_automation_stats`.
+`query_recent_events`, `list_automations`, `get_automation`, `get_automation_stats`, plus the
+diagnostic tools `get_llm_request_history`, `get_mcp_server_status`, `get_resolved_config`,
+`get_profile_config`, `get_profile_tool_inventory`, `get_system_info`, `get_message_history`,
+`get_delegation_status`, and `list_delegations`.
 
 ## Relationship with spawn_worker
 
@@ -113,8 +137,13 @@ The engineer profile and `spawn_worker` serve complementary but distinct purpose
 - **Engineer profile**: Diagnoses issues by reading application state (DB, error logs, source code)
 - **spawn_worker**: Implements fixes by executing code in an isolated container
 
-They do not overlap: workers cannot access the database or error logs; the engineer cannot execute
-code or modify files.
+They do not overlap in capability: workers cannot access the database, error logs, or any Family
+Assistant tools or data; the engineer cannot execute code or modify files itself. The engineer
+profile *can* invoke `spawn_worker` directly (behind user confirmation) so an investigation can hand
+a self-contained coding task — implement this fix, verify this hypothesis against the repo — to a
+sandboxed worker without leaving the engineer conversation. Because the worker sandbox has no access
+to Family Assistant data, this crosses no Rule-of-Two boundary beyond the state change of launching
+the worker, which is what the confirmation covers.
 
 ## Usage
 

--- a/docs/design/engineer_profile.md
+++ b/docs/design/engineer_profile.md
@@ -94,6 +94,13 @@ re-establishes an MCP session), and the state-changing worker actions `spawn_wor
 `cancel_worker_task` (launch or stop an isolated AI coding worker). This keeps the profile's
 effective posture read-only: a human approves before anything outside the sandbox changes.
 
+The worker actions carry custom confirmation renderers so the approver reviews the actual payload,
+not a bare tool name: `spawn_worker` shows the agent, the **complete** task description (refusing,
+like delegation, any description over `MAX_WORKER_TASK_DESCRIPTION_CHARS` = 3000 or a
+`context_paths` rendering over the generic 1200-char bound, rather than truncating what the approver
+sees), the context paths, and the timeout; `cancel_worker_task` looks the task up and shows its
+status and description alongside the id.
+
 ### Self-Awareness of Restrictions
 
 The engineer's tool set is deliberately narrow, and its system prompt says so explicitly: a missing

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -862,6 +862,15 @@ various tasks with dark mode support and mobile optimization.
   web **Error Logs** page (`/errors`) or in the diagnostics export. This only files a report; it
   doesn't fix the problem on its own.
 
+- **Engineering diagnostics mode (`/engineer`):** For "why did the assistant do that?" questions,
+  `/engineer` switches to a read-only diagnostic mode that can read the application's source code,
+  query its database, inspect error logs and configuration, and explain which tools each mode is
+  allowed to use (and why a particular tool call was allowed, denied, or needed confirmation). It
+  deliberately cannot change any data or send messages — every action with side effects (filing a
+  GitHub issue, reconnecting an MCP server, launching or cancelling an isolated AI coding worker, or
+  handing work to another mode) asks for your approval first. If it says a tool isn't available to
+  it, that's the intended safety configuration, not a malfunction.
+
 - **Reviewing runtime taint rollout:** Administrators can call `GET /api/diagnostics/taint-audit`
   with a normal authenticated session/API token or the confined `DIAGNOSTICS_READONLY_TOKEN`. The
   response summarizes recent taint policy decisions by tool, sink, tier, outcome, and source

--- a/src/family_assistant/tools/__init__.py
+++ b/src/family_assistant/tools/__init__.py
@@ -119,6 +119,7 @@ from family_assistant.tools.engineering import (
     read_error_logs,
     read_source_file,
     reconnect_mcp_server,
+    resolve_tool_policy,
     search_source_code,
 )
 from family_assistant.tools.events import (
@@ -466,6 +467,7 @@ __all__ = [
     "get_profile_config",
     "get_profile_tool_inventory",
     "get_system_info",
+    "resolve_tool_policy",
     # On-demand tool activation
     "ACTIVATE_TOOLS_DEFINITION",
     "OnDemandCatalogEntry",
@@ -684,6 +686,7 @@ _LOCAL_TOOL_IMPLEMENTATIONS: dict[str, ToolImplementation] = {
     "get_profile_config": get_profile_config,
     "get_profile_tool_inventory": get_profile_tool_inventory,
     "get_system_info": get_system_info,
+    "resolve_tool_policy": resolve_tool_policy,
     # MQTT tools
     "mqtt_publish": mqtt_publish_tool,
     # Shopping/UCP tools
@@ -1405,6 +1408,11 @@ LOCAL_TOOL_METADATA_BY_NAME: dict[str, LocalToolMetadata] = {
         ToolTag.OUTPUT_TRUSTED,
     ),
     "get_profile_tool_inventory": _metadata(
+        ToolTag.READ_ONLY,
+        ToolTag.SENSITIVE_DATA,
+        ToolTag.OUTPUT_TRUSTED,
+    ),
+    "resolve_tool_policy": _metadata(
         ToolTag.READ_ONLY,
         ToolTag.SENSITIVE_DATA,
         ToolTag.OUTPUT_TRUSTED,

--- a/src/family_assistant/tools/confirmation.py
+++ b/src/family_assistant/tools/confirmation.py
@@ -39,8 +39,10 @@ MAX_DELEGATION_REQUEST_CHARS = 3000
 
 # Approving spawn_worker launches a code-running agent against the shared
 # workspace, so the approver must see the ENTIRE task description — the same
-# full-review contract as delegation, with the same Telegram-budget cap. Bulk
-# content belongs in a workspace file referenced via context_paths.
+# full-review contract as delegation, with the same Telegram-budget cap. There
+# is no side channel for bulk content (the worker sandbox mounts only its own
+# task directory; backends do not mount context_paths), so a longer brief must
+# be shortened or split into smaller worker tasks.
 MAX_WORKER_TASK_DESCRIPTION_CHARS = 3000
 
 # The per-field caps alone cannot guarantee the WHOLE spawn_worker prompt fits
@@ -579,7 +581,7 @@ def _spawn_worker_confirmation_prompt(arguments: Mapping[str, object]) -> str:
             f"- Task description: ⚠️ This description is {len(task_description)} characters, "
             f"longer than the {MAX_WORKER_TASK_DESCRIPTION_CHARS}-character limit that keeps it "
             "fully reviewable here. The worker will not be launched — shorten the task "
-            "description or move bulk content into a workspace file referenced via context_paths."
+            "description or split the work into smaller worker tasks."
         )
     else:
         description_field = (
@@ -704,8 +706,8 @@ def confirmation_payload_block_reason(
             return (
                 f"Error: the worker task_description is {len(task_description)} characters, "
                 f"which exceeds the {MAX_WORKER_TASK_DESCRIPTION_CHARS}-character limit that "
-                "keeps it fully reviewable in a confirmation prompt. Shorten it, or move bulk "
-                "content into a workspace file and reference it via context_paths."
+                "keeps it fully reviewable in a confirmation prompt. Shorten it or split "
+                "the work into smaller worker tasks."
             )
         # The context paths scope what the worker can read, so they must be
         # fully reviewable too. Script callers bypass JSON-schema validation,
@@ -739,8 +741,7 @@ def confirmation_payload_block_reason(
                 f"{len(rendered_prompt)} characters, which exceeds the "
                 f"{MAX_WORKER_CONFIRMATION_PROMPT_CHARS}-character limit that keeps the "
                 "whole prompt reviewable in a single confirmation message. Shorten the "
-                "task description or pass fewer context paths (bulk content belongs in "
-                "a workspace file referenced via context_paths)."
+                "task description or pass fewer context paths."
             )
     if tool_name == "gmail_create_draft":
         for field in ("to", "cc", "bcc", "subject", "body", "attachment_ids"):

--- a/src/family_assistant/tools/confirmation.py
+++ b/src/family_assistant/tools/confirmation.py
@@ -615,10 +615,10 @@ def _spawn_worker_confirmation_prompt(arguments: Mapping[str, object]) -> str:
     )
     return (
         "Do you want to launch an isolated AI coding worker? It executes code in a "
-        "sandboxed container that contains only this task's own directory — the "
-        "task description below and the output files it produces. It has no access "
-        "to Family Assistant tools or data and no copy of the application's source "
-        "checkout:\n" + "\n".join(fields)
+        "sandboxed container with network access — it can clone public git "
+        "repositories, including this application's — but has no access to Family "
+        "Assistant tools or data. It works from the task description below and "
+        "returns output files:\n" + "\n".join(fields)
     )
 
 

--- a/src/family_assistant/tools/confirmation.py
+++ b/src/family_assistant/tools/confirmation.py
@@ -37,6 +37,12 @@ CONFIRMATION_VALUE_MAX_CHARS = 1200
 # and code fences. Bulk content belongs in an attachment, not the request string.
 MAX_DELEGATION_REQUEST_CHARS = 3000
 
+# Approving spawn_worker launches a code-running agent against the shared
+# workspace, so the approver must see the ENTIRE task description — the same
+# full-review contract as delegation, with the same Telegram-budget cap. Bulk
+# content belongs in a workspace file referenced via context_paths.
+MAX_WORKER_TASK_DESCRIPTION_CHARS = 3000
+
 
 def _markdown_code_block(text: str) -> str:
     """Render text as inert markdown using a fence longer than any content fence."""
@@ -548,6 +554,80 @@ async def render_delegate_to_service_confirmation(
     return "Do you want to delegate this task to another profile?\n" + "\n".join(fields)
 
 
+async def render_spawn_worker_confirmation(
+    args: ToolArgumentsView,
+    context: ToolExecutionContext,
+) -> str:
+    """Render a confirmation prompt for launching an isolated AI coding worker."""
+    _ = context
+    task_description = str(args.get("task_description", "")).strip()
+
+    if len(task_description) > MAX_WORKER_TASK_DESCRIPTION_CHARS:
+        # An over-length spawn is refused before it runs (see
+        # confirmation_payload_block_reason), so never show a partial body the
+        # approver might rubber-stamp — say plainly that it will be refused.
+        description_field = (
+            f"- Task description: ⚠️ This description is {len(task_description)} characters, "
+            f"longer than the {MAX_WORKER_TASK_DESCRIPTION_CHARS}-character limit that keeps it "
+            "fully reviewable here. The worker will not be launched — shorten the task "
+            "description or move bulk content into a workspace file referenced via context_paths."
+        )
+    else:
+        description_field = (
+            f"- Task description:\n{_markdown_code_block(task_description)}"
+        )
+
+    fields = [
+        _confirmation_field("Agent", args.get("agent", "claude")),
+        description_field,
+    ]
+    raw_context_paths = args.get("context_paths")
+    if isinstance(raw_context_paths, (list, tuple)) and raw_context_paths:
+        fields.append(
+            _confirmation_field(
+                "Context paths", ", ".join(str(path) for path in raw_context_paths)
+            )
+        )
+    fields.append(
+        _confirmation_field("Timeout (minutes)", args.get("timeout_minutes", 30))
+    )
+    return (
+        "Do you want to launch an isolated AI coding worker? It executes code in a "
+        "sandboxed container with access to the shared workspace (it has no access "
+        "to Family Assistant tools or data):\n" + "\n".join(fields)
+    )
+
+
+async def render_cancel_worker_task_confirmation(
+    args: ToolArgumentsView,
+    context: ToolExecutionContext,
+) -> str:
+    """Render a confirmation prompt for cancelling a worker task.
+
+    Looks the task up so the approver sees what they are stopping, not just an
+    opaque id.
+    """
+    task_id = str(args.get("task_id", "")).strip()
+    fields = [_confirmation_field("Task ID", task_id)]
+
+    task = None
+    db_context = getattr(context, "db_context", None)
+    if task_id and db_context is not None:
+        task = await db_context.worker_tasks.get_task(task_id)
+
+    if task is not None:
+        fields.append(_confirmation_field("Status", task.get("status")))
+        fields.append(
+            _confirmation_field("Task description", task.get("task_description"))
+        )
+    else:
+        fields.append(
+            "- Task details: not found — the task may have already finished or the "
+            "id may be wrong."
+        )
+    return "Do you want to *cancel* this worker task?\n" + "\n".join(fields)
+
+
 def over_length_delegation_block_reason(user_request: str) -> str | None:
     """Return an error if a delegation request is too long to confirm, else None.
 
@@ -577,13 +657,33 @@ def confirmation_payload_block_reason(
     could not show the approver the full payload they would be approving,
     instead of rendering a truncated or misleading prompt. Only invoked once a
     call is known to be confirm-gated, so it never constrains unconfirmed calls.
-    Delegations, authored Google writes, and every executable computer-use
-    argument must remain fully reviewable.
+    Delegations, worker spawns, authored Google writes, and every executable
+    computer-use argument must remain fully reviewable.
     """
     if tool_name == "delegate_to_service":
         return over_length_delegation_block_reason(
             str(arguments.get("user_request", ""))
         )
+    if tool_name == "spawn_worker":
+        task_description = str(arguments.get("task_description", ""))
+        if len(task_description) > MAX_WORKER_TASK_DESCRIPTION_CHARS:
+            return (
+                f"Error: the worker task_description is {len(task_description)} characters, "
+                f"which exceeds the {MAX_WORKER_TASK_DESCRIPTION_CHARS}-character limit that "
+                "keeps it fully reviewable in a confirmation prompt. Shorten it, or move bulk "
+                "content into a workspace file and reference it via context_paths."
+            )
+        # The context paths scope what the worker can read, so they must be
+        # fully reviewable too.
+        raw_context_paths = arguments.get("context_paths")
+        if isinstance(raw_context_paths, (list, tuple)):
+            rendered_paths = ", ".join(str(path) for path in raw_context_paths)
+            if len(rendered_paths) > CONFIRMATION_VALUE_MAX_CHARS:
+                return (
+                    f"Error: the worker context_paths render to {len(rendered_paths)} "
+                    f"characters, which exceeds the {CONFIRMATION_VALUE_MAX_CHARS}-character "
+                    "confirmation limit. Pass fewer paths (e.g. a shared parent directory)."
+                )
     if tool_name == "gmail_create_draft":
         for field in ("to", "cc", "bcc", "subject", "body", "attachment_ids"):
             rendered = str(arguments.get(field, ""))
@@ -677,6 +777,8 @@ _base_renderers: dict[str, ConfirmationRenderer] = {
     "drive_write_file": render_drive_write_file_confirmation,
     "ingest_document_from_url": render_ingest_document_from_url_confirmation,
     "delegate_to_service": render_delegate_to_service_confirmation,
+    "spawn_worker": render_spawn_worker_confirmation,
+    "cancel_worker_task": render_cancel_worker_task_confirmation,
 }
 
 TOOL_CONFIRMATION_RENDERERS: dict[str, ConfirmationRenderer] = {

--- a/src/family_assistant/tools/confirmation.py
+++ b/src/family_assistant/tools/confirmation.py
@@ -591,11 +591,22 @@ def _spawn_worker_confirmation_prompt(arguments: Mapping[str, object]) -> str:
         description_field,
     ]
     raw_context_paths = arguments.get("context_paths")
-    if isinstance(raw_context_paths, (list, tuple)) and raw_context_paths:
-        fields.append(
-            _confirmation_field(
-                "Context paths", ", ".join(str(path) for path in raw_context_paths)
+    if isinstance(raw_context_paths, (list, tuple)):
+        if raw_context_paths:
+            fields.append(
+                _confirmation_field(
+                    "Context paths", ", ".join(str(path) for path in raw_context_paths)
+                )
             )
+    elif raw_context_paths is not None:
+        # Script callers bypass JSON-schema validation, so a non-list value
+        # (e.g. a mapping whose keys the tool would later iterate as paths)
+        # must not be silently omitted from the prompt: the guard refuses the
+        # call (see confirmation_payload_block_reason), and the prompt says so.
+        fields.append(
+            f"- Context paths: ⚠️ Malformed value of type "
+            f"{type(raw_context_paths).__name__} — context_paths must be an array of "
+            "workspace path strings. The worker will not be launched."
         )
     fields.append(
         _confirmation_field("Timeout (minutes)", arguments.get("timeout_minutes", 30))
@@ -697,8 +708,19 @@ def confirmation_payload_block_reason(
                 "content into a workspace file and reference it via context_paths."
             )
         # The context paths scope what the worker can read, so they must be
-        # fully reviewable too.
+        # fully reviewable too. Script callers bypass JSON-schema validation,
+        # so a present-but-non-list value is refused outright: the tool would
+        # later iterate it (a mapping's keys would become paths) while the
+        # prompt showed the approver no paths at all.
         raw_context_paths = arguments.get("context_paths")
+        if raw_context_paths is not None and not isinstance(
+            raw_context_paths, (list, tuple)
+        ):
+            return (
+                f"Error: context_paths must be an array of workspace path strings, "
+                f"got {type(raw_context_paths).__name__}. Pass the paths as a JSON "
+                'array (e.g. ["shared/data/input.csv"]).'
+            )
         if isinstance(raw_context_paths, (list, tuple)):
             rendered_paths = ", ".join(str(path) for path in raw_context_paths)
             if len(rendered_paths) > CONFIRMATION_VALUE_MAX_CHARS:

--- a/src/family_assistant/tools/confirmation.py
+++ b/src/family_assistant/tools/confirmation.py
@@ -615,8 +615,10 @@ def _spawn_worker_confirmation_prompt(arguments: Mapping[str, object]) -> str:
     )
     return (
         "Do you want to launch an isolated AI coding worker? It executes code in a "
-        "sandboxed container with access to the shared workspace (it has no access "
-        "to Family Assistant tools or data):\n" + "\n".join(fields)
+        "sandboxed container that contains only this task's own directory — the "
+        "task description below and the output files it produces. It has no access "
+        "to Family Assistant tools or data and no copy of the application's source "
+        "checkout:\n" + "\n".join(fields)
     )
 
 

--- a/src/family_assistant/tools/confirmation.py
+++ b/src/family_assistant/tools/confirmation.py
@@ -43,6 +43,14 @@ MAX_DELEGATION_REQUEST_CHARS = 3000
 # content belongs in a workspace file referenced via context_paths.
 MAX_WORKER_TASK_DESCRIPTION_CHARS = 3000
 
+# The per-field caps alone cannot guarantee the WHOLE spawn_worker prompt fits
+# Telegram's single-message confirmation budget (3800 chars in telegram/ui.py):
+# a near-cap description plus context paths would render over it and be
+# truncated, letting an approver approve fields they never saw. The payload
+# guard therefore also refuses on the total rendered prompt, with headroom
+# under 3800 for the interface's own additions (e.g. the source prefix).
+MAX_WORKER_CONFIRMATION_PROMPT_CHARS = 3400
+
 
 def _markdown_code_block(text: str) -> str:
     """Render text as inert markdown using a fence longer than any content fence."""
@@ -554,13 +562,14 @@ async def render_delegate_to_service_confirmation(
     return "Do you want to delegate this task to another profile?\n" + "\n".join(fields)
 
 
-async def render_spawn_worker_confirmation(
-    args: ToolArgumentsView,
-    context: ToolExecutionContext,
-) -> str:
-    """Render a confirmation prompt for launching an isolated AI coding worker."""
-    _ = context
-    task_description = str(args.get("task_description", "")).strip()
+def _spawn_worker_confirmation_prompt(arguments: Mapping[str, object]) -> str:
+    """Build the full spawn_worker confirmation prompt.
+
+    Shared by the async renderer and the payload guard so the total-length
+    refusal in ``confirmation_payload_block_reason`` measures exactly the
+    prompt the approver would see.
+    """
+    task_description = str(arguments.get("task_description", "")).strip()
 
     if len(task_description) > MAX_WORKER_TASK_DESCRIPTION_CHARS:
         # An over-length spawn is refused before it runs (see
@@ -578,10 +587,10 @@ async def render_spawn_worker_confirmation(
         )
 
     fields = [
-        _confirmation_field("Agent", args.get("agent", "claude")),
+        _confirmation_field("Agent", arguments.get("agent", "claude")),
         description_field,
     ]
-    raw_context_paths = args.get("context_paths")
+    raw_context_paths = arguments.get("context_paths")
     if isinstance(raw_context_paths, (list, tuple)) and raw_context_paths:
         fields.append(
             _confirmation_field(
@@ -589,13 +598,22 @@ async def render_spawn_worker_confirmation(
             )
         )
     fields.append(
-        _confirmation_field("Timeout (minutes)", args.get("timeout_minutes", 30))
+        _confirmation_field("Timeout (minutes)", arguments.get("timeout_minutes", 30))
     )
     return (
         "Do you want to launch an isolated AI coding worker? It executes code in a "
         "sandboxed container with access to the shared workspace (it has no access "
         "to Family Assistant tools or data):\n" + "\n".join(fields)
     )
+
+
+async def render_spawn_worker_confirmation(
+    args: ToolArgumentsView,
+    context: ToolExecutionContext,
+) -> str:
+    """Render a confirmation prompt for launching an isolated AI coding worker."""
+    _ = context
+    return _spawn_worker_confirmation_prompt(args)
 
 
 async def render_cancel_worker_task_confirmation(
@@ -605,7 +623,10 @@ async def render_cancel_worker_task_confirmation(
     """Render a confirmation prompt for cancelling a worker task.
 
     Looks the task up so the approver sees what they are stopping, not just an
-    opaque id.
+    opaque id. Mirrors cancel_worker_task_tool's conversation scoping: a task
+    belonging to a different conversation is treated as not found, so the
+    prompt never leaks another conversation's task details for a cancel that
+    would be refused anyway.
     """
     task_id = str(args.get("task_id", "")).strip()
     fields = [_confirmation_field("Task ID", task_id)]
@@ -614,6 +635,8 @@ async def render_cancel_worker_task_confirmation(
     db_context = getattr(context, "db_context", None)
     if task_id and db_context is not None:
         task = await db_context.worker_tasks.get_task(task_id)
+        if task is not None and task.get("conversation_id") != context.conversation_id:
+            task = None
 
     if task is not None:
         fields.append(_confirmation_field("Status", task.get("status")))
@@ -684,6 +707,19 @@ def confirmation_payload_block_reason(
                     f"characters, which exceeds the {CONFIRMATION_VALUE_MAX_CHARS}-character "
                     "confirmation limit. Pass fewer paths (e.g. a shared parent directory)."
                 )
+        # The per-field caps can individually pass while the combined prompt
+        # still exceeds Telegram's single-message budget (and gets truncated),
+        # so also refuse on the total rendered prompt.
+        rendered_prompt = _spawn_worker_confirmation_prompt(arguments)
+        if len(rendered_prompt) > MAX_WORKER_CONFIRMATION_PROMPT_CHARS:
+            return (
+                f"Error: the spawn_worker confirmation prompt renders to "
+                f"{len(rendered_prompt)} characters, which exceeds the "
+                f"{MAX_WORKER_CONFIRMATION_PROMPT_CHARS}-character limit that keeps the "
+                "whole prompt reviewable in a single confirmation message. Shorten the "
+                "task description or pass fewer context paths (bulk content belongs in "
+                "a workspace file referenced via context_paths)."
+            )
     if tool_name == "gmail_create_draft":
         for field in ("to", "cc", "bcc", "subject", "body", "attachment_ids"):
             rendered = str(arguments.get(field, ""))

--- a/src/family_assistant/tools/engineering.py
+++ b/src/family_assistant/tools/engineering.py
@@ -9,6 +9,7 @@ for the engineer processing profile.
 from __future__ import annotations
 
 import asyncio
+import difflib
 import logging
 import os
 import platform
@@ -31,7 +32,11 @@ from family_assistant.tool_inventory import (
     TOKEN_ESTIMATE_NOTE,
     inventory_dict_for_service,
 )
-from family_assistant.tools.infrastructure import find_provider_by_type
+from family_assistant.tools.infrastructure import (
+    PolicyEnforcingToolsProvider,
+    ToolDescriptorProvider,
+    find_provider_by_type,
+)
 from family_assistant.tools.mcp import MCPToolsProvider
 from family_assistant.tools.types import ToolDefinition, ToolResult
 
@@ -40,6 +45,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from family_assistant.config_models import AppConfig
+    from family_assistant.tools.policy import PolicyEvaluation, ResolvedPolicyRule
     from family_assistant.tools.types import ToolExecutionContext
 
 logger = logging.getLogger(__name__)
@@ -822,6 +828,228 @@ async def get_profile_tool_inventory(
     )
 
 
+def _serialize_policy_rule(resolved_rule: ResolvedPolicyRule) -> dict[str, object]:
+    """Serialize a resolved policy rule for diagnostic output."""
+    return {
+        "layer": resolved_rule.layer,
+        "priority": resolved_rule.rule.priority,
+        "effective_priority": resolved_rule.effective_priority,
+        "decision": str(resolved_rule.decision),
+        "description": resolved_rule.description,
+        "match": resolved_rule.match.model_dump(mode="json", exclude_none=True),
+    }
+
+
+def _serialize_policy_evaluation(evaluation: PolicyEvaluation) -> dict[str, object]:
+    """Serialize a policy evaluation (decision, reason, matched rule)."""
+    return {
+        "decision": str(evaluation.decision),
+        "reason": evaluation.reason,
+        "matched_rule": (
+            _serialize_policy_rule(evaluation.matched_rule)
+            if evaluation.matched_rule is not None
+            else None
+        ),
+    }
+
+
+async def resolve_tool_policy(
+    exec_context: ToolExecutionContext,
+    tool_name: str,
+    profile_id: str | None = None,
+    arguments: dict[str, object] | None = None,
+    can_confirm: bool = True,
+) -> ToolResult:
+    """Resolve the live tool-policy decision for a tool name per profile.
+
+    For each targeted profile, evaluates the tool's descriptor against the
+    profile's live policy engine three ways (raw policy, advertisement, and
+    execution) and reports which rule matched, from which layer, with what
+    priority and description — answering "why can't profile X use tool Y"
+    from live state rather than guesswork.
+
+    Args:
+        exec_context: The tool execution context.
+        tool_name: Name of the tool to resolve policy for.
+        profile_id: Optional profile id; omit to evaluate every live profile.
+        arguments: Optional hypothetical call arguments for
+            argument-conditional (argument_equals) rules.
+        can_confirm: Whether the interaction can prompt for confirmation.
+
+    Returns:
+        ToolResult with per-profile policy resolutions or error.
+    """
+    # Script kwargs bypass schema coercion (same pattern as read_error_logs),
+    # so reject non-bool / non-dict values instead of silently coercing them.
+    if not isinstance(can_confirm, bool):
+        error_msg = (
+            "can_confirm must be a boolean (true/false), got "
+            f"{type(can_confirm).__name__}: {can_confirm!r}"
+        )
+        return ToolResult(text=f"Error: {error_msg}", data={"error": error_msg})
+
+    if arguments is not None and not isinstance(arguments, dict):
+        error_msg = (
+            "arguments must be an object mapping argument names to values, got "
+            f"{type(arguments).__name__}: {arguments!r}"
+        )
+        return ToolResult(text=f"Error: {error_msg}", data={"error": error_msg})
+
+    logger.info(
+        "resolve_tool_policy: tool_name=%s profile_id=%s can_confirm=%s arguments=%s",
+        tool_name,
+        profile_id,
+        can_confirm,
+        arguments,
+    )
+
+    registry = _resolve_services_registry(exec_context)
+    if registry is None:
+        return ToolResult(
+            data={
+                "error": (
+                    "No live processing-service registry available. This tool must "
+                    "be invoked from within a live processing flow."
+                )
+            }
+        )
+
+    if profile_id is not None and profile_id not in registry:
+        return ToolResult(
+            data={
+                "error": f"Profile {profile_id!r} not found in the live registry",
+                "profile_ids": sorted(registry.keys()),
+            }
+        )
+
+    target_ids = [profile_id] if profile_id is not None else sorted(registry.keys())
+
+    entries: list[dict[str, object]] = []
+    descriptor_found = False
+    known_names: set[str] = set()
+
+    for pid in target_ids:
+        service = registry[pid]
+        tools_provider = getattr(service, "tools_provider", None)
+        if tools_provider is None:
+            entries.append({
+                "profile_id": pid,
+                "error": "No tools provider wired into this profile's service.",
+            })
+            continue
+
+        policy_provider = find_provider_by_type(
+            tools_provider, PolicyEnforcingToolsProvider
+        )
+        if policy_provider is None:
+            entries.append({
+                "profile_id": pid,
+                "error": (
+                    "No policy-enforcing provider in this profile's tools "
+                    "provider chain."
+                ),
+            })
+            continue
+
+        # The pre-policy root provider: policy-DENIED tools are invisible on
+        # the policy provider itself, so the descriptor must come from the
+        # wrapped provider to explain a denial.
+        pre_policy_provider = policy_provider.wrapped_provider
+        if not isinstance(pre_policy_provider, ToolDescriptorProvider):
+            entries.append({
+                "profile_id": pid,
+                "error": (
+                    "The policy provider's wrapped provider does not expose "
+                    "tool descriptors."
+                ),
+            })
+            continue
+
+        descriptor = await pre_policy_provider.get_tool_descriptor(tool_name)
+        if descriptor is None:
+            known_names.update(
+                d.name for d in await pre_policy_provider.get_tool_descriptors()
+            )
+            entries.append({
+                "profile_id": pid,
+                "error": (
+                    f"Tool {tool_name!r} is not registered in this profile's "
+                    "provider (before policy filtering)."
+                ),
+            })
+            continue
+
+        descriptor_found = True
+        engine = policy_provider.policy_engine
+
+        on_demand_view = getattr(service, "on_demand_view", None)
+        on_demand = bool(
+            on_demand_view is not None
+            and (
+                descriptor.name in on_demand_view.on_demand_tool_names
+                or (
+                    descriptor.mcp_server_id is not None
+                    and descriptor.mcp_server_id
+                    in on_demand_view.on_demand_mcp_server_ids
+                )
+            )
+        )
+
+        entries.append({
+            "profile_id": pid,
+            "default_decision": str(engine.default_decision),
+            "origin": descriptor.origin,
+            "mcp_server_id": descriptor.mcp_server_id,
+            "tags": sorted(str(tag) for tag in descriptor.tags),
+            "on_demand": on_demand,
+            "raw": _serialize_policy_evaluation(
+                engine.evaluate(descriptor, arguments=arguments)
+            ),
+            "advertisement": _serialize_policy_evaluation(
+                engine.evaluate_for_advertisement(descriptor, can_confirm=can_confirm)
+            ),
+            "execution": _serialize_policy_evaluation(
+                engine.evaluate_for_execution(
+                    descriptor, arguments=arguments, can_confirm=can_confirm
+                )
+            ),
+        })
+
+    if not descriptor_found:
+        sorted_names = sorted(known_names)
+        similar = difflib.get_close_matches(tool_name, sorted_names, n=10, cutoff=0.5)
+        substring_matches = [
+            name
+            for name in sorted_names
+            if tool_name.lower() in name.lower() and name not in similar
+        ]
+        return ToolResult(
+            data={
+                "tool_name": tool_name,
+                "tool_exists": False,
+                "similar_tool_names": [*similar, *substring_matches][:10],
+                "profiles": entries,
+                "profile_count": len(entries),
+            }
+        )
+
+    data: dict[str, object] = {
+        "tool_name": tool_name,
+        "tool_exists": True,
+        "can_confirm": can_confirm,
+        "arguments": arguments,
+        "profiles": entries,
+        "profile_count": len(entries),
+    }
+    if arguments is None:
+        data["note"] = (
+            "No arguments were provided, so rules with argument_equals matchers "
+            "cannot match. Pass hypothetical call arguments to test "
+            "argument-conditional rules."
+        )
+    return ToolResult(data=data)
+
+
 async def get_system_info(
     exec_context: ToolExecutionContext,
 ) -> ToolResult:
@@ -1156,6 +1384,59 @@ ENGINEERING_TOOLS_DEFINITION: list[ToolDefinition] = [
                     },
                 },
                 "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "resolve_tool_policy",
+            "description": (
+                "Resolve the live tool-policy decision (allow/deny/confirm) for "
+                "a tool name against a profile's policy engine, explaining which "
+                "rule matched (layer, priority, description) and the resolved "
+                "default decision. Use it to check whether and why a tool is "
+                "available to the engineer or any other profile — e.g. before "
+                "reporting a tool as missing, or when a tool call was denied. "
+                "Pass arguments to test argument-conditional rules such as "
+                "delegate_to_service targets; omit profile_id to compare the "
+                "decision across all live profiles."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "tool_name": {
+                        "type": "string",
+                        "description": "Name of the tool to resolve policy for.",
+                    },
+                    "profile_id": {
+                        "type": "string",
+                        "description": (
+                            "Service profile id whose policy engine to evaluate. "
+                            "Omit to evaluate every live profile."
+                        ),
+                    },
+                    "arguments": {
+                        "type": "object",
+                        "additionalProperties": True,
+                        "description": (
+                            "Hypothetical call arguments, used to test "
+                            "argument-conditional rules (argument_equals "
+                            "matchers). Without arguments those rules cannot "
+                            "match."
+                        ),
+                    },
+                    "can_confirm": {
+                        "type": "boolean",
+                        "description": (
+                            "Whether the interaction can prompt the user for "
+                            "confirmation. When false, confirm-gated tools "
+                            "resolve to deny for advertisement/execution."
+                        ),
+                        "default": True,
+                    },
+                },
+                "required": ["tool_name"],
             },
         },
     },

--- a/src/family_assistant/tools/infrastructure.py
+++ b/src/family_assistant/tools/infrastructure.py
@@ -837,6 +837,14 @@ class PolicyEnforcingToolsProvider(ToolsProvider):
         self._tool_definitions_by_confirmation: dict[bool, list[ToolDefinition]] = {}
         self._cached_descriptors_version: int | None = None
 
+    @property
+    def policy_engine(self) -> PolicyEngine:
+        """Return the policy engine backing this provider.
+
+        Exposed for diagnostics (engineer profile policy resolution).
+        """
+        return self._policy_engine
+
     async def get_tool_definitions(
         self,
         *,

--- a/src/family_assistant/tools/on_demand.py
+++ b/src/family_assistant/tools/on_demand.py
@@ -185,6 +185,22 @@ class OnDemandToolsView:
         """Return the underlying provider this view filters."""
         return self._wrapped_provider
 
+    @property
+    def on_demand_tool_names(self) -> frozenset[str]:
+        """Return the configured on-demand tool names.
+
+        Exposed for diagnostics (engineer profile policy resolution).
+        """
+        return frozenset(self._on_demand_tool_names)
+
+    @property
+    def on_demand_mcp_server_ids(self) -> frozenset[str]:
+        """Return the configured on-demand MCP server ids.
+
+        Exposed for diagnostics (engineer profile policy resolution).
+        """
+        return frozenset(self._on_demand_mcp_server_ids)
+
     def has_on_demand_tools(self) -> bool:
         """Return True if there are any on-demand tool names configured."""
         return bool(self._on_demand_tool_names) or bool(self._on_demand_mcp_server_ids)

--- a/tests/functional/tools/test_defaults_tool_policy_parity.py
+++ b/tests/functional/tools/test_defaults_tool_policy_parity.py
@@ -330,3 +330,33 @@ def test_engineer_can_delegate_out_only_with_confirmation() -> None:
             can_confirm=True,
         )
         assert outbound_blocked.decision is ToolPolicyDecision.DENY, blocked_target
+
+
+def test_engineer_worker_tools_are_confirm_gated_and_reads_are_allowed() -> None:
+    """The engineer may use AI workers, but only with a human in the loop.
+
+    spawn_worker and cancel_worker_task change state (launch/stop a sandboxed
+    worker), so the engineer profile confirm-gates them; without a confirmation
+    channel they degrade to deny so no worker is ever launched unattended.
+    Reading worker results is side-effect free and allowed outright, as is
+    resolve_tool_policy (the engineer's policy-introspection tool).
+    """
+    _, profiles = _load_resolved_profiles()
+    engineer = {profile.id: profile for profile in profiles}["engineer"]
+    engine = PolicyEngine.from_policy_config(engineer.tools_policy)
+
+    for gated_name in ("spawn_worker", "cancel_worker_task"):
+        descriptor = _local_descriptor(gated_name)
+        attended = engine.evaluate_for_execution(descriptor, can_confirm=True)
+        assert attended.decision is ToolPolicyDecision.CONFIRM, gated_name
+        unattended = engine.evaluate_for_execution(descriptor, can_confirm=False)
+        assert unattended.decision is ToolPolicyDecision.DENY, gated_name
+
+    for allowed_name in (
+        "read_task_result",
+        "list_worker_tasks",
+        "resolve_tool_policy",
+    ):
+        descriptor = _local_descriptor(allowed_name)
+        decision = engine.evaluate_for_execution(descriptor, can_confirm=False).decision
+        assert decision is ToolPolicyDecision.ALLOW, allowed_name

--- a/tests/unit/tools/test_engineering.py
+++ b/tests/unit/tools/test_engineering.py
@@ -405,6 +405,7 @@ _ENGINEERING_TOOL_NAMES: frozenset[str] = frozenset({
     "get_resolved_config",
     "get_profile_config",
     "get_profile_tool_inventory",
+    "resolve_tool_policy",
     "get_system_info",
 })
 

--- a/tests/unit/tools/test_engineering_diagnostics.py
+++ b/tests/unit/tools/test_engineering_diagnostics.py
@@ -26,6 +26,7 @@ from family_assistant.tools.engineering import (
     get_resolved_config,
     get_system_info,
     reconnect_mcp_server,
+    resolve_tool_policy,
 )
 from family_assistant.tools.mcp import MCPToolsProvider
 from family_assistant.tools.metadata import ToolTag
@@ -462,3 +463,233 @@ async def test_get_profile_tool_inventory_without_registry_returns_error(
     data = result.get_data()
     assert isinstance(data, dict)
     assert "error" in data
+
+
+# --- resolve_tool_policy ---
+
+
+def _diagnostic_policy_provider() -> PolicyEnforcingToolsProvider:
+    """Policy provider with allow, confirm, and argument-conditional rules."""
+    return PolicyEnforcingToolsProvider(
+        wrapped_provider=LocalToolsProvider(registrations=LOCAL_TOOL_REGISTRATIONS),
+        policy_engine=PolicyEngine.from_policy_config(
+            ToolPolicyConfig(
+                default_decision=ToolPolicyDecision.DENY,
+                rules=[
+                    PolicyRule(
+                        match=ToolMatcher(names=["add_or_update_note"]),
+                        decision=ToolPolicyDecision.ALLOW,
+                        priority=10,
+                        description="notes tool allowed",
+                    ),
+                    PolicyRule(
+                        match=ToolMatcher(
+                            names=["add_or_update_note"],
+                            argument_equals={"title": "secret"},
+                        ),
+                        decision=ToolPolicyDecision.DENY,
+                        priority=20,
+                        description="secret titles denied",
+                    ),
+                    PolicyRule(
+                        match=ToolMatcher(names=["read_error_logs"]),
+                        decision=ToolPolicyDecision.CONFIRM,
+                        priority=10,
+                        description="error logs need confirmation",
+                    ),
+                ],
+            )
+        ),
+    )
+
+
+def _diagnostic_service(
+    on_demand_view: OnDemandToolsView | None = None,
+) -> Mock:
+    service = Mock()
+    service.tools_provider = _diagnostic_policy_provider()
+    service.on_demand_view = on_demand_view
+    return service
+
+
+@pytest.mark.anyio
+async def test_resolve_tool_policy_allowed_tool_reports_matched_rule() -> None:
+    ctx = _ctx_with_registry({"diag": _diagnostic_service()})
+
+    result = await resolve_tool_policy(ctx, tool_name="add_or_update_note")
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert data["tool_exists"] is True
+    assert data["can_confirm"] is True
+    assert data["profile_count"] == 1
+    entry = data["profiles"][0]
+    assert entry["profile_id"] == "diag"
+    assert entry["default_decision"] == "deny"
+    assert entry["origin"] == "local"
+    assert entry["mcp_server_id"] is None
+    assert entry["on_demand"] is False
+    raw = entry["raw"]
+    assert raw["decision"] == "allow"
+    rule = raw["matched_rule"]
+    assert rule["layer"] == "defaults"
+    assert rule["priority"] == 10
+    assert rule["effective_priority"] == 10
+    assert rule["decision"] == "allow"
+    assert rule["description"] == "notes tool allowed"
+    assert rule["match"] == {"names": ["add_or_update_note"]}
+    assert entry["advertisement"]["decision"] == "allow"
+    assert entry["execution"]["decision"] == "allow"
+    # Without arguments the caller is warned that argument-conditional rules
+    # cannot match.
+    assert "argument_equals" in data["note"]
+
+
+@pytest.mark.anyio
+async def test_resolve_tool_policy_default_deny_has_no_matched_rule() -> None:
+    ctx = _ctx_with_registry({"diag": _diagnostic_service()})
+
+    result = await resolve_tool_policy(ctx, tool_name="search_documents")
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert data["tool_exists"] is True
+    entry = data["profiles"][0]
+    raw = entry["raw"]
+    assert raw["decision"] == "deny"
+    assert raw["matched_rule"] is None
+    assert "default" in raw["reason"]
+    assert entry["execution"]["decision"] == "deny"
+
+
+@pytest.mark.anyio
+async def test_resolve_tool_policy_confirm_gated_tool_depends_on_can_confirm() -> None:
+    ctx = _ctx_with_registry({"diag": _diagnostic_service()})
+
+    confirmable = await resolve_tool_policy(
+        ctx, tool_name="read_error_logs", can_confirm=True
+    )
+    data = confirmable.get_data()
+    assert isinstance(data, dict)
+    entry = data["profiles"][0]
+    assert entry["raw"]["decision"] == "confirm"
+    assert entry["execution"]["decision"] == "confirm"
+    assert entry["advertisement"]["decision"] == "confirm"
+
+    unconfirmable = await resolve_tool_policy(
+        ctx, tool_name="read_error_logs", can_confirm=False
+    )
+    data = unconfirmable.get_data()
+    assert isinstance(data, dict)
+    entry = data["profiles"][0]
+    assert entry["raw"]["decision"] == "confirm"
+    assert entry["execution"]["decision"] == "deny"
+    assert "confirmation required but unavailable" in entry["execution"]["reason"]
+    assert entry["advertisement"]["decision"] == "deny"
+
+
+@pytest.mark.anyio
+async def test_resolve_tool_policy_argument_conditional_rule_needs_arguments() -> None:
+    ctx = _ctx_with_registry({"diag": _diagnostic_service()})
+
+    without_args = await resolve_tool_policy(ctx, tool_name="add_or_update_note")
+    data = without_args.get_data()
+    assert isinstance(data, dict)
+    assert data["profiles"][0]["raw"]["decision"] == "allow"
+    assert "note" in data
+
+    with_args = await resolve_tool_policy(
+        ctx,
+        tool_name="add_or_update_note",
+        arguments={"title": "secret"},
+    )
+    data = with_args.get_data()
+    assert isinstance(data, dict)
+    assert data["arguments"] == {"title": "secret"}
+    assert "note" not in data
+    entry = data["profiles"][0]
+    assert entry["raw"]["decision"] == "deny"
+    assert entry["raw"]["matched_rule"]["description"] == "secret titles denied"
+    assert entry["execution"]["decision"] == "deny"
+
+
+@pytest.mark.anyio
+async def test_resolve_tool_policy_unknown_tool_suggests_similar_names() -> None:
+    ctx = _ctx_with_registry({"diag": _diagnostic_service()})
+
+    result = await resolve_tool_policy(ctx, tool_name="add_or_update_notes")
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert data["tool_exists"] is False
+    assert "add_or_update_note" in data["similar_tool_names"]
+    assert len(data["similar_tool_names"]) <= 10
+    assert data["profiles"][0]["profile_id"] == "diag"
+    assert "error" in data["profiles"][0]
+
+
+@pytest.mark.anyio
+async def test_resolve_tool_policy_unknown_profile_returns_error() -> None:
+    ctx = _ctx_with_registry({"diag": _diagnostic_service()})
+
+    result = await resolve_tool_policy(
+        ctx, tool_name="add_or_update_note", profile_id="missing"
+    )
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "error" in data
+    assert data["profile_ids"] == ["diag"]
+
+
+@pytest.mark.anyio
+async def test_resolve_tool_policy_without_registry_returns_error(
+    exec_context_with_db: ToolExecutionContext,
+) -> None:
+    result = await resolve_tool_policy(
+        exec_context_with_db, tool_name="add_or_update_note"
+    )
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "error" in data
+
+
+@pytest.mark.anyio
+async def test_resolve_tool_policy_reports_on_demand_tools() -> None:
+    provider = _diagnostic_policy_provider()
+    service = Mock()
+    service.tools_provider = provider
+    service.on_demand_view = OnDemandToolsView(
+        wrapped_provider=provider,
+        on_demand_tool_names={"add_or_update_note"},
+    )
+    ctx = _ctx_with_registry({"diag": service})
+
+    result = await resolve_tool_policy(ctx, tool_name="add_or_update_note")
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert data["profiles"][0]["on_demand"] is True
+
+
+@pytest.mark.anyio
+async def test_resolve_tool_policy_rejects_non_bool_can_confirm() -> None:
+    ctx = _ctx_with_registry({"diag": _diagnostic_service()})
+
+    result = await resolve_tool_policy(
+        ctx,
+        tool_name="add_or_update_note",
+        can_confirm="true",  # type: ignore[arg-type]  # script kwargs bypass schema coercion
+    )
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "can_confirm must be a boolean" in data["error"]
+
+
+@pytest.mark.anyio
+async def test_resolve_tool_policy_rejects_non_dict_arguments() -> None:
+    ctx = _ctx_with_registry({"diag": _diagnostic_service()})
+
+    result = await resolve_tool_policy(
+        ctx,
+        tool_name="add_or_update_note",
+        arguments=["title"],  # type: ignore[arg-type]  # script kwargs bypass schema coercion
+    )
+    data = result.get_data()
+    assert isinstance(data, dict)
+    assert "arguments must be an object" in data["error"]

--- a/tests/unit/tools/test_worker_confirmation_renderer.py
+++ b/tests/unit/tools/test_worker_confirmation_renderer.py
@@ -16,6 +16,7 @@ import pytest
 
 from family_assistant.tools.confirmation import (
     CONFIRMATION_VALUE_MAX_CHARS,
+    MAX_WORKER_CONFIRMATION_PROMPT_CHARS,
     MAX_WORKER_TASK_DESCRIPTION_CHARS,
     TOOL_CONFIRMATION_RENDERERS,
     confirmation_payload_block_reason,
@@ -34,6 +35,7 @@ def _no_context() -> ToolExecutionContext:
 
 def _context_with_task(task: dict[str, object] | None) -> ToolExecutionContext:
     context = MagicMock()
+    context.conversation_id = "conv-1"
     context.db_context.worker_tasks.get_task = AsyncMock(return_value=task)
     return cast("ToolExecutionContext", context)
 
@@ -102,6 +104,7 @@ async def test_cancel_worker_task_confirmation_shows_task_details() -> None:
         {"task_id": "task-123"},
         _context_with_task({
             "task_id": "task-123",
+            "conversation_id": "conv-1",
             "status": "running",
             "task_description": "Build the report generator",
         }),
@@ -121,6 +124,24 @@ async def test_cancel_worker_task_confirmation_handles_unknown_task() -> None:
 
     assert "task-gone" in prompt
     assert "not found" in prompt
+
+
+@pytest.mark.asyncio
+async def test_cancel_worker_task_confirmation_hides_other_conversations_task() -> None:
+    # A task belonging to a different conversation is refused on cancel anyway,
+    # so the prompt must not leak its details to an approver in this one.
+    prompt = await render_cancel_worker_task_confirmation(
+        {"task_id": "task-999"},
+        _context_with_task({
+            "task_id": "task-999",
+            "conversation_id": "conv-other",
+            "status": "running",
+            "task_description": "Some other conversation's private task",
+        }),
+    )
+
+    assert "not found" in prompt
+    assert "Some other conversation's private task" not in prompt
 
 
 def test_spawn_worker_block_reason_fires_only_above_caps() -> None:
@@ -144,6 +165,20 @@ def test_spawn_worker_block_reason_fires_only_above_caps() -> None:
     reason = confirmation_payload_block_reason("spawn_worker", over_paths)
     assert reason is not None
     assert "context_paths" in reason
+
+
+def test_spawn_worker_block_reason_fires_on_combined_total_over_cap() -> None:
+    # Each field is individually under its own per-field cap, but the combined
+    # rendered prompt still exceeds Telegram's single-message confirmation
+    # budget, so the guard must catch the total rather than let it through.
+    within_field_caps = {
+        "task_description": "a" * 2900,
+        "context_paths": ["p" * 100 for _ in range(10)],
+    }
+    reason = confirmation_payload_block_reason("spawn_worker", within_field_caps)
+
+    assert reason is not None
+    assert str(MAX_WORKER_CONFIRMATION_PROMPT_CHARS) in reason
 
 
 def test_cancel_worker_task_is_not_size_capped() -> None:

--- a/tests/unit/tools/test_worker_confirmation_renderer.py
+++ b/tests/unit/tools/test_worker_confirmation_renderer.py
@@ -145,8 +145,18 @@ async def test_cancel_worker_task_confirmation_hides_other_conversations_task() 
 
 
 def test_spawn_worker_block_reason_fires_only_above_caps() -> None:
-    within = {
+    # A description at the per-field cap is spawnable on its own; combined
+    # payloads are additionally bounded by the total prompt cap, so the
+    # description must leave room for the other fields.
+    max_description_alone = {
         "task_description": "z" * MAX_WORKER_TASK_DESCRIPTION_CHARS,
+    }
+    assert confirmation_payload_block_reason("spawn_worker", max_description_alone) is (
+        None
+    )
+
+    within = {
+        "task_description": "z" * 2800,
         "context_paths": ["shared/data"],
     }
     assert confirmation_payload_block_reason("spawn_worker", within) is None

--- a/tests/unit/tools/test_worker_confirmation_renderer.py
+++ b/tests/unit/tools/test_worker_confirmation_renderer.py
@@ -181,6 +181,34 @@ def test_spawn_worker_block_reason_fires_on_combined_total_over_cap() -> None:
     assert str(MAX_WORKER_CONFIRMATION_PROMPT_CHARS) in reason
 
 
+def test_spawn_worker_block_reason_rejects_non_list_context_paths() -> None:
+    # Script callers bypass JSON-schema validation; a mapping's keys would be
+    # iterated as paths by the tool while the prompt showed no paths at all.
+    malformed = {
+        "task_description": "ok",
+        "context_paths": {"shared/secret": True},
+    }
+    reason = confirmation_payload_block_reason("spawn_worker", malformed)
+    assert reason is not None
+    assert "context_paths" in reason
+    assert "array" in reason
+
+
+@pytest.mark.asyncio
+async def test_spawn_worker_confirmation_flags_non_list_context_paths() -> None:
+    prompt = await render_spawn_worker_confirmation(
+        {
+            "task_description": "ok",
+            "context_paths": {"shared/secret": True},
+        },
+        _no_context(),
+    )
+
+    # The malformed value must be visible as a refusal, never silently omitted.
+    assert "Malformed" in prompt
+    assert "will not be launched" in prompt
+
+
 def test_cancel_worker_task_is_not_size_capped() -> None:
     # Cancelling only carries an id; the guard must not constrain it.
     assert (

--- a/tests/unit/tools/test_worker_confirmation_renderer.py
+++ b/tests/unit/tools/test_worker_confirmation_renderer.py
@@ -1,0 +1,154 @@
+"""Unit tests for the spawn_worker / cancel_worker_task confirmation renderers.
+
+Approving spawn_worker launches a code-running agent against the shared
+workspace, so the confirmation prompt must show the approver the full task
+description (refusing over-length payloads rather than truncating them), the
+agent, the context paths that scope what the worker reads, and the timeout.
+Cancelling a task must show what is being stopped, not just an opaque id.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from family_assistant.tools.confirmation import (
+    CONFIRMATION_VALUE_MAX_CHARS,
+    MAX_WORKER_TASK_DESCRIPTION_CHARS,
+    TOOL_CONFIRMATION_RENDERERS,
+    confirmation_payload_block_reason,
+    render_cancel_worker_task_confirmation,
+    render_spawn_worker_confirmation,
+)
+
+if TYPE_CHECKING:
+    from family_assistant.tools.types import ToolExecutionContext
+
+
+def _no_context() -> ToolExecutionContext:
+    # The spawn renderer ignores its context argument.
+    return cast("ToolExecutionContext", None)
+
+
+def _context_with_task(task: dict[str, object] | None) -> ToolExecutionContext:
+    context = MagicMock()
+    context.db_context.worker_tasks.get_task = AsyncMock(return_value=task)
+    return cast("ToolExecutionContext", context)
+
+
+def test_worker_tools_have_confirmation_renderers() -> None:
+    # The engineer profile confirm-gates these tools, so the fallback
+    # "Confirm execution of tool: <name>" prompt would hide the payload.
+    assert "spawn_worker" in TOOL_CONFIRMATION_RENDERERS
+    assert "cancel_worker_task" in TOOL_CONFIRMATION_RENDERERS
+
+
+@pytest.mark.asyncio
+async def test_spawn_worker_confirmation_shows_full_payload() -> None:
+    prompt = await render_spawn_worker_confirmation(
+        {
+            "task_description": "Refactor the parser to stream input",
+            "agent": "gemini",
+            "context_paths": ["shared/data/input.csv", "shared/scripts/"],
+            "timeout_minutes": 45,
+        },
+        _no_context(),
+    )
+
+    assert "Refactor the parser to stream input" in prompt
+    assert "gemini" in prompt
+    assert "shared/data/input.csv" in prompt
+    assert "shared/scripts/" in prompt
+    assert "45" in prompt
+    assert "sandboxed container" in prompt
+    assert "[truncated]" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_spawn_worker_confirmation_shows_description_above_generic_bound() -> (
+    None
+):
+    # The description must be shown in full up to the worker cap, not cut at
+    # the generic 1200-char field bound.
+    description = "x" * (CONFIRMATION_VALUE_MAX_CHARS + 200)
+    prompt = await render_spawn_worker_confirmation(
+        {"task_description": description},
+        _no_context(),
+    )
+
+    assert description in prompt
+    assert "[truncated]" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_spawn_worker_confirmation_refuses_over_limit_description() -> None:
+    description = "y" * (MAX_WORKER_TASK_DESCRIPTION_CHARS + 1)
+    prompt = await render_spawn_worker_confirmation(
+        {"task_description": description},
+        _no_context(),
+    )
+
+    # Never show a partial body the approver might rubber-stamp.
+    assert description not in prompt
+    assert "will not be launched" in prompt
+    assert str(MAX_WORKER_TASK_DESCRIPTION_CHARS) in prompt
+
+
+@pytest.mark.asyncio
+async def test_cancel_worker_task_confirmation_shows_task_details() -> None:
+    prompt = await render_cancel_worker_task_confirmation(
+        {"task_id": "task-123"},
+        _context_with_task({
+            "task_id": "task-123",
+            "status": "running",
+            "task_description": "Build the report generator",
+        }),
+    )
+
+    assert "task-123" in prompt
+    assert "running" in prompt
+    assert "Build the report generator" in prompt
+
+
+@pytest.mark.asyncio
+async def test_cancel_worker_task_confirmation_handles_unknown_task() -> None:
+    prompt = await render_cancel_worker_task_confirmation(
+        {"task_id": "task-gone"},
+        _context_with_task(None),
+    )
+
+    assert "task-gone" in prompt
+    assert "not found" in prompt
+
+
+def test_spawn_worker_block_reason_fires_only_above_caps() -> None:
+    within = {
+        "task_description": "z" * MAX_WORKER_TASK_DESCRIPTION_CHARS,
+        "context_paths": ["shared/data"],
+    }
+    assert confirmation_payload_block_reason("spawn_worker", within) is None
+
+    over_description = {
+        "task_description": "z" * (MAX_WORKER_TASK_DESCRIPTION_CHARS + 1)
+    }
+    reason = confirmation_payload_block_reason("spawn_worker", over_description)
+    assert reason is not None
+    assert "task_description" in reason
+
+    over_paths = {
+        "task_description": "ok",
+        "context_paths": ["p" * 100 for _ in range(20)],
+    }
+    reason = confirmation_payload_block_reason("spawn_worker", over_paths)
+    assert reason is not None
+    assert "context_paths" in reason
+
+
+def test_cancel_worker_task_is_not_size_capped() -> None:
+    # Cancelling only carries an id; the guard must not constrain it.
+    assert (
+        confirmation_payload_block_reason("cancel_worker_task", {"task_id": "task-123"})
+        is None
+    )


### PR DESCRIPTION
## Summary

Three related improvements to the engineer processing profile:

1. **Self-awareness of restrictions.** The engineer's system prompt now states explicitly that its tool set is deliberately restricted (Rule of Two: it handles trusted requests and reads sensitive data, so it must not change state or communicate externally without a human approving). It's instructed to treat missing tools and policy-denied calls as expected configuration rather than bugs, and to verify with `resolve_tool_policy` before reporting anything as broken.

2. **New `resolve_tool_policy` diagnostic tool.** Resolves the live tool-policy decision (allow / deny / confirm) for any tool name against any profile's policy engine, reporting the matched rule (layer, own + effective priority, description, matcher) or that the default decision applied. Supports hypothetical `arguments` for argument-conditional rules (e.g. `delegate_to_service` targets), a `can_confirm` flag to model unattended contexts, per-profile `on_demand` visibility, and close-match suggestions for unknown tool names. Without a `profile_id` it compares the decision across every live profile.

3. **AI worker access behind confirmation.** The engineer can now use the worker tools: `read_task_result` and `list_worker_tasks` are allowed outright (read-only), while `spawn_worker` and `cancel_worker_task` are confirm-gated (state-changing; degrade to deny without a confirmation channel, so workers are never launched unattended). Workers run in sandboxed containers with no access to Family Assistant data, so the confirmation covers the only boundary crossed — the state change of launching one.

## Implementation notes

- `PolicyEnforcingToolsProvider` gains a public read-only `policy_engine` property, and `OnDemandToolsView` gains `on_demand_tool_names` / `on_demand_mcp_server_ids` accessors, so the diagnostic doesn't reach into private state.
- The descriptor for policy resolution is fetched from the policy provider's *wrapped* (pre-policy) provider, so denied tools can still be explained.
- Strict runtime validation of `can_confirm` / `arguments` follows the existing `read_error_logs` pattern (script kwargs bypass schema coercion).

## Docs

- `docs/design/engineer_profile.md`: updated tools table, side-effect confirmation section, new "Self-Awareness of Restrictions" section, and revised `spawn_worker` relationship section.
- `docs/user/USER_GUIDE.md`: new troubleshooting entry describing `/engineer` mode, its deliberate limits, and its confirmation-gated actions.

## Testing

- 10 new unit tests for `resolve_tool_policy` (real `PolicyEngine` + `PolicyEnforcingToolsProvider` over `LocalToolsProvider`): allow/deny/confirm resolution, argument-conditional rules, unknown tool/profile handling, on-demand flag, missing registry.
- New parity test asserting the engineer's worker-tool gating (confirm attended, deny unattended; reads and `resolve_tool_policy` allowed without confirmation).
- Full `poe test` suite: **PASSED** (pytest, frontend-tests, basedpyright, pylint, frontend-lint, frontend-typecheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUG4xvDs94HvujUajctzhc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUG4xvDs94HvujUajctzhc)_