### PR TITLE
Fix worker lifecycle callbacks and reduce diagnostics noise

### DIFF
--- a/src/family_assistant/llm/providers/google_genai_client.py
+++ b/src/family_assistant/llm/providers/google_genai_client.py
@@ -70,6 +70,15 @@ from ..base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _system_prefixed_content(content: str) -> str:
+    """Prefix system content for Gemini without duplicating an existing marker."""
+    if content.startswith("System:"):
+        return content
+    return f"System: {content}"
+
+
 tracer = trace.get_tracer(__name__)
 T = TypeVar("T", bound=BaseModel)
 
@@ -622,10 +631,13 @@ class GoogleGenAIClient(BaseLLMClient):
 
             if role == "system":
                 # System messages can be included as user messages with a prefix
+                system_content = content if isinstance(content, str) else ""
                 contents.append(
                     types.Content(
                         role="user",
-                        parts=[types.Part(text=f"System: {content}")],
+                        parts=[
+                            types.Part(text=_system_prefixed_content(system_content))
+                        ],
                     )
                 )
             elif role == "user":
@@ -1484,7 +1496,7 @@ class GoogleGenAIClient(BaseLLMClient):
             system_prompt = ""
             for msg in messages:
                 if msg.role == "system" and msg.content:
-                    system_prompt += f"System: {msg.content}\n\n"
+                    system_prompt += f"{_system_prefixed_content(msg.content)}\n\n"
 
             if system_prompt:
                 input_text = system_prompt + input_text

--- a/src/family_assistant/services/backends/kubernetes.py
+++ b/src/family_assistant/services/backends/kubernetes.py
@@ -452,7 +452,11 @@ class KubernetesBackend:
                             V1Container(
                                 name="worker",
                                 image=self.image,
-                                args=["sh", "-c", 'run-task < "$TASK_INPUT"'],
+                                args=[
+                                    "sh",
+                                    "-c",
+                                    self._worker_start_command(webhook_url),
+                                ],
                                 env=env_vars,
                                 env_from=env_from,
                                 volume_mounts=volume_mounts,
@@ -563,6 +567,39 @@ class KubernetesBackend:
 
         # Job exists but no active/succeeded/failed - still pending
         return WorkerTaskResult(status=WorkerStatus.SUBMITTED)
+
+    def _worker_start_command(self, webhook_url: str) -> str:
+        """Build the container command that marks a Kubernetes worker running."""
+        separator = "&" if "?" in webhook_url else "?"
+        start_webhook_url = (
+            f"{webhook_url}{separator}event_type=worker_started&source=worker"
+        )
+        start_script = """
+import json
+import os
+import urllib.request
+
+url = __START_WEBHOOK_URL__
+data = {
+    "title": "Worker task started",
+    "message": f"Worker task {os.environ['TASK_ID']} started.",
+    "data": {
+        "task_id": os.environ["TASK_ID"],
+        "callback_token": os.environ.get("TASK_CALLBACK_TOKEN"),
+    },
+}
+body = json.dumps(data).encode("utf-8")
+request = urllib.request.Request(
+    url,
+    data=body,
+    headers={"Content-Type": "application/json"},
+)
+try:
+    urllib.request.urlopen(request, timeout=10).close()
+except Exception as exc:
+    print(f"worker start webhook failed: {exc}", flush=True)
+""".replace("__START_WEBHOOK_URL__", repr(start_webhook_url))
+        return f'python -c {start_script!r}\nrun-task < "$TASK_INPUT"'
 
     async def cancel_task(self, job_id: str) -> bool:
         """Cancel a running Kubernetes Job.

--- a/src/family_assistant/services/backends/kubernetes.py
+++ b/src/family_assistant/services/backends/kubernetes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import shlex
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -599,7 +600,7 @@ try:
 except Exception as exc:
     print(f"worker start webhook failed: {exc}", flush=True)
 """.replace("__START_WEBHOOK_URL__", repr(start_webhook_url))
-        return f'python -c {start_script!r}\nrun-task < "$TASK_INPUT"'
+        return f'python -c {shlex.quote(start_script)}\nrun-task < "$TASK_INPUT"'
 
     async def cancel_task(self, job_id: str) -> bool:
         """Cancel a running Kubernetes Job.

--- a/src/family_assistant/services/backends/kubernetes.py
+++ b/src/family_assistant/services/backends/kubernetes.py
@@ -572,9 +572,7 @@ class KubernetesBackend:
     def _worker_start_command(self, webhook_url: str) -> str:
         """Build the container command that marks a Kubernetes worker running."""
         separator = "&" if "?" in webhook_url else "?"
-        start_webhook_url = (
-            f"{webhook_url}{separator}event_type=worker_started&source=worker"
-        )
+        start_webhook_url = f"{webhook_url}{separator}event_type=worker_started"
         start_script = """
 import json
 import os
@@ -586,14 +584,17 @@ data = {
     "message": f"Worker task {os.environ['TASK_ID']} started.",
     "data": {
         "task_id": os.environ["TASK_ID"],
-        "callback_token": os.environ.get("TASK_CALLBACK_TOKEN"),
     },
 }
 body = json.dumps(data).encode("utf-8")
+headers = {"Content-Type": "application/json"}
+callback_token = os.environ.get("TASK_CALLBACK_TOKEN")
+if callback_token:
+    headers["X-Worker-Callback-Token"] = callback_token
 request = urllib.request.Request(
     url,
     data=body,
-    headers={"Content-Type": "application/json"},
+    headers=headers,
 )
 try:
     urllib.request.urlopen(request, timeout=10).close()

--- a/src/family_assistant/storage/repositories/worker_tasks.py
+++ b/src/family_assistant/storage/repositories/worker_tasks.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     String,
     Table,
     Text,
+    case,
     delete,
     insert,
     select,
@@ -287,6 +288,48 @@ class WorkerTasksRepository(BaseRepository):
             self._logger.warning(f"Worker task not found for update: {task_id}")
 
         return updated
+
+    async def record_task_submission(self, task_id: str, job_name: str) -> bool:
+        """Record a backend job ID and submit a task that is still pending.
+
+        A lifecycle callback may update the task before the backend spawn call
+        returns. The conditional status expression preserves that newer state.
+        """
+        stmt = (
+            update(worker_tasks_table)
+            .where(worker_tasks_table.c.task_id == task_id)
+            .values(
+                job_name=job_name,
+                status=case(
+                    (worker_tasks_table.c.status == "pending", "submitted"),
+                    else_=worker_tasks_table.c.status,
+                ),
+                updated_at=datetime.now(UTC),
+            )
+        )
+
+        result = await self._execute_with_logging("record_task_submission", stmt)
+        # CursorResult.rowcount returns int but type stubs don't reflect this for async
+        return result.rowcount > 0  # type: ignore[union-attr]
+
+    async def mark_task_running(self, task_id: str, started_at: datetime) -> bool:
+        """Mark a pending or submitted task as running."""
+        stmt = (
+            update(worker_tasks_table)
+            .where(
+                worker_tasks_table.c.task_id == task_id,
+                worker_tasks_table.c.status.in_(["pending", "submitted"]),
+            )
+            .values(
+                status="running",
+                started_at=started_at,
+                updated_at=datetime.now(UTC),
+            )
+        )
+
+        result = await self._execute_with_logging("mark_task_running", stmt)
+        # CursorResult.rowcount returns int but type stubs don't reflect this for async
+        return result.rowcount > 0  # type: ignore[union-attr]
 
     async def get_running_tasks_count(self) -> int:
         """Count currently running tasks (for concurrency limit).

--- a/src/family_assistant/tools/infrastructure.py
+++ b/src/family_assistant/tools/infrastructure.py
@@ -1173,9 +1173,9 @@ class TaintTrackingToolsProvider(ToolsProvider):
                 and evaluation.requested_outcome is not evaluation.effective_outcome
             ):
                 # Observe mode downgraded a gating outcome (confirm/deny/redact) to
-                # audit. Surface it at ERROR so a dry run can be reviewed from the
-                # error-log / diagnostics endpoints before enabling enforce mode.
-                logger.error(
+                # audit. Surface it at WARNING so dry-run diagnostics remain visible
+                # without polluting error-log triage.
+                logger.warning(
                     "Runtime taint WOULD ENFORCE (observe mode, not blocked): "
                     "tool=%s call_id=%s conversation=%s sink=%s would_be=%s "
                     "max_tier=%s reason=%s",

--- a/src/family_assistant/tools/worker.py
+++ b/src/family_assistant/tools/worker.py
@@ -499,6 +499,10 @@ async def spawn_worker_tool(
             task_id=task_id,
             job_name=job_id,
         )
+        submitted_task = await db_context.worker_tasks.get_task(task_id)
+        if submitted_task is None:
+            raise RuntimeError(f"Worker task {task_id} disappeared after submission")
+        current_status = submitted_task["status"]
 
         logger.info(f"Spawned worker task {task_id} with job {job_id}")
 
@@ -506,13 +510,10 @@ async def spawn_worker_tool(
         # ast-grep-ignore: no-dict-any - Tool result data is dynamic
         result_data: dict[str, Any] = {
             "task_id": task_id,
-            "status": "submitted",
+            "status": current_status,
             "agent": agent,
             "timeout_minutes": timeout_minutes,
-            "message": (
-                f"Worker task '{task_id}' has been submitted. "
-                "You will be notified when it completes."
-            ),
+            "message": _worker_submission_message(task_id, current_status),
         }
 
         if skipped_context_paths:
@@ -527,6 +528,24 @@ async def spawn_worker_tool(
     except Exception as e:
         logger.error(f"Failed to spawn worker task: {e}", exc_info=True)
         return ToolResult(data={"error": f"Failed to spawn worker: {e!s}"})
+
+
+def _worker_submission_message(task_id: str, status: str) -> str:
+    """Describe the lifecycle state observed after backend submission."""
+    if status == "running":
+        return (
+            f"Worker task '{task_id}' has started. "
+            "You will be notified when it completes."
+        )
+    if status in _TERMINAL_DB_STATUSES:
+        return (
+            f"Worker task '{task_id}' finished with status '{status}'. "
+            f"Use read_task_result('{task_id}') to see the results."
+        )
+    return (
+        f"Worker task '{task_id}' has been submitted. "
+        "You will be notified when it completes."
+    )
 
 
 async def read_task_result_tool(

--- a/src/family_assistant/tools/worker.py
+++ b/src/family_assistant/tools/worker.py
@@ -495,13 +495,8 @@ async def spawn_worker_tool(
                 )
             raise
 
-        # Record the backend job id without regressing a fast lifecycle callback
-        # that may already have marked the task running or terminal.
-        current_task = await db_context.worker_tasks.get_task(task_id)
-        current_status = current_task["status"] if current_task else "pending"
-        await db_context.worker_tasks.update_task_status(
+        await db_context.worker_tasks.record_task_submission(
             task_id=task_id,
-            status="submitted" if current_status == "pending" else current_status,
             job_name=job_id,
         )
 

--- a/src/family_assistant/tools/worker.py
+++ b/src/family_assistant/tools/worker.py
@@ -495,10 +495,13 @@ async def spawn_worker_tool(
                 )
             raise
 
-        # Update task status to submitted (started_at set later when task runs)
+        # Record the backend job id without regressing a fast lifecycle callback
+        # that may already have marked the task running or terminal.
+        current_task = await db_context.worker_tasks.get_task(task_id)
+        current_status = current_task["status"] if current_task else "pending"
         await db_context.worker_tasks.update_task_status(
             task_id=task_id,
-            status="submitted",
+            status="submitted" if current_status == "pending" else current_status,
             job_name=job_id,
         )
 

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -658,15 +658,14 @@ async def _handle_worker_started(
             )
             return
 
-    updated = await db_context.worker_tasks.update_task_status(
+    updated = await db_context.worker_tasks.mark_task_running(
         task_id=task_id,
-        status="running",
         started_at=datetime.now(UTC),
     )
     if updated:
         logger.info("Updated worker task %s status to running", task_id)
     else:
-        logger.warning("Worker task %s not found for start update", task_id)
+        logger.info("Worker task %s was not awaiting a start update", task_id)
 
 
 async def _handle_worker_completion(

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -600,8 +600,10 @@ async def handle_generic_webhook(
         "data": body.data,
     }
 
-    # Handle worker completion events - update task status in database
-    if effective_event_type == "worker_completion":
+    # Handle worker lifecycle events - update task status in database
+    if effective_event_type == "worker_started":
+        await _handle_worker_started(db_context, body.data)
+    elif effective_event_type == "worker_completion":
         await _handle_worker_completion(
             db_context,
             body.data,
@@ -620,6 +622,51 @@ async def handle_generic_webhook(
         await webhook_source.emit_event(event_data)
 
     return WebhookEventResponse(status="accepted", event_id=event_id)
+
+
+async def _handle_worker_started(
+    db_context: DatabaseContext,
+    # ast-grep-ignore: no-dict-any - Webhook data is dynamic from external worker
+    data: dict[str, Any] | None,
+) -> None:
+    """Handle worker start webhook by marking the task running."""
+    if not data:
+        logger.warning("Worker started event missing data payload")
+        return
+
+    task_id = data.get("task_id")
+    if not task_id:
+        logger.warning("Worker started event missing task_id")
+        return
+
+    task = await db_context.worker_tasks.get_task(task_id)
+    if not task:
+        logger.warning("Worker task %s not found for start update", task_id)
+        return
+
+    stored_token = task.get("callback_token")
+    provided_token = data.get("callback_token")
+    if stored_token:
+        if not provided_token:
+            logger.warning(
+                "Worker start for task %s missing required callback_token", task_id
+            )
+            return
+        if not hmac.compare_digest(stored_token, provided_token):
+            logger.warning(
+                "Worker start for task %s has invalid callback_token", task_id
+            )
+            return
+
+    updated = await db_context.worker_tasks.update_task_status(
+        task_id=task_id,
+        status="running",
+        started_at=datetime.now(UTC),
+    )
+    if updated:
+        logger.info("Updated worker task %s status to running", task_id)
+    else:
+        logger.warning("Worker task %s not found for start update", task_id)
 
 
 async def _handle_worker_completion(

--- a/src/family_assistant/web/routers/webhooks.py
+++ b/src/family_assistant/web/routers/webhooks.py
@@ -536,6 +536,7 @@ async def handle_generic_webhook(
     Headers (optional):
         - X-Webhook-Signature: HMAC-SHA256 signature for verification
         - X-Webhook-Source: Alternative source identifier (overrides body and query source)
+        - X-Worker-Callback-Token: Per-task proof for worker_started events
 
     Returns:
         JSON response with status and event_id
@@ -588,6 +589,14 @@ async def handle_generic_webhook(
 
     # Build event data for the processor
     # Extra fields first so system-generated values take precedence
+    persisted_data = body.data
+    if effective_event_type == "worker_started" and persisted_data:
+        persisted_data = {
+            key: value
+            for key, value in persisted_data.items()
+            if key != "callback_token"
+        }
+
     # ast-grep-ignore: no-dict-any - Event data intentionally combines webhook payload with generated fields
     event_data: dict[str, Any] = {
         **(body.model_extra or {}),  # Extra fields from payload (lowest priority)
@@ -597,12 +606,16 @@ async def handle_generic_webhook(
         "title": body.title,
         "message": body.message,
         "severity": body.severity,
-        "data": body.data,
+        "data": persisted_data,
     }
 
     # Handle worker lifecycle events - update task status in database
     if effective_event_type == "worker_started":
-        await _handle_worker_started(db_context, body.data)
+        await _handle_worker_started(
+            db_context,
+            body.data,
+            request.headers.get("X-Worker-Callback-Token"),
+        )
     elif effective_event_type == "worker_completion":
         await _handle_worker_completion(
             db_context,
@@ -628,6 +641,7 @@ async def _handle_worker_started(
     db_context: DatabaseContext,
     # ast-grep-ignore: no-dict-any - Webhook data is dynamic from external worker
     data: dict[str, Any] | None,
+    callback_token: str | None,
 ) -> None:
     """Handle worker start webhook by marking the task running."""
     if not data:
@@ -645,14 +659,13 @@ async def _handle_worker_started(
         return
 
     stored_token = task.get("callback_token")
-    provided_token = data.get("callback_token")
     if stored_token:
-        if not provided_token:
+        if not callback_token:
             logger.warning(
                 "Worker start for task %s missing required callback_token", task_id
             )
             return
-        if not hmac.compare_digest(stored_token, provided_token):
+        if not hmac.compare_digest(stored_token, callback_token):
             logger.warning(
                 "Worker start for task %s has invalid callback_token", task_id
             )

--- a/tests/functional/tools/test_worker_task_lifecycle.py
+++ b/tests/functional/tools/test_worker_task_lifecycle.py
@@ -366,6 +366,114 @@ class TestMarkStaleTasks:
         assert "exceeded timeout" in (task.get("error_message") or "")
 
 
+class TestAtomicLifecycleTransitions:
+    """Tests for lifecycle updates that can race backend callbacks."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status", ["running", "success", "failed", "timeout", "cancelled"]
+    )
+    async def test_record_submission_preserves_newer_status(
+        self, db_context: DatabaseContext, status: str
+    ) -> None:
+        task_id = f"submission-{status}"
+        await db_context.worker_tasks.create_task(
+            task_id=task_id,
+            conversation_id="conv-1",
+            interface_type="test",
+            task_description="Fast lifecycle callback",
+        )
+        await db_context.worker_tasks.update_task_status(task_id=task_id, status=status)
+
+        updated = await db_context.worker_tasks.record_task_submission(
+            task_id=task_id, job_name="backend-job"
+        )
+
+        assert updated is True
+        task = await db_context.worker_tasks.get_task(task_id)
+        assert task is not None
+        assert task["status"] == status
+        assert task.get("job_name") == "backend-job"
+
+    @pytest.mark.asyncio
+    async def test_record_submission_transitions_pending_task(
+        self, db_context: DatabaseContext
+    ) -> None:
+        await db_context.worker_tasks.create_task(
+            task_id="submission-pending",
+            conversation_id="conv-1",
+            interface_type="test",
+            task_description="Normal submission",
+        )
+
+        updated = await db_context.worker_tasks.record_task_submission(
+            task_id="submission-pending", job_name="backend-job"
+        )
+
+        assert updated is True
+        task = await db_context.worker_tasks.get_task("submission-pending")
+        assert task is not None
+        assert task["status"] == "submitted"
+        assert task.get("job_name") == "backend-job"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", ["success", "failed", "timeout", "cancelled"])
+    async def test_mark_running_preserves_terminal_status(
+        self, db_context: DatabaseContext, status: str
+    ) -> None:
+        task_id = f"late-start-{status}"
+        await db_context.worker_tasks.create_task(
+            task_id=task_id,
+            conversation_id="conv-1",
+            interface_type="test",
+            task_description="Late start callback",
+        )
+        await db_context.worker_tasks.update_task_status(task_id=task_id, status=status)
+
+        updated = await db_context.worker_tasks.mark_task_running(
+            task_id=task_id, started_at=datetime.now(UTC)
+        )
+
+        assert updated is False
+        task = await db_context.worker_tasks.get_task(task_id)
+        assert task is not None
+        assert task["status"] == status
+        assert task.get("started_at") is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", ["pending", "submitted"])
+    async def test_mark_running_transitions_prestart_status(
+        self, db_context: DatabaseContext, status: str
+    ) -> None:
+        task_id = f"start-{status}"
+        await db_context.worker_tasks.create_task(
+            task_id=task_id,
+            conversation_id="conv-1",
+            interface_type="test",
+            task_description="Start callback",
+        )
+        if status == "submitted":
+            await db_context.worker_tasks.update_task_status(
+                task_id=task_id, status=status
+            )
+        started_at = datetime.now(UTC)
+
+        updated = await db_context.worker_tasks.mark_task_running(
+            task_id=task_id, started_at=started_at
+        )
+
+        assert updated is True
+        task = await db_context.worker_tasks.get_task(task_id)
+        assert task is not None
+        assert task["status"] == "running"
+        stored_started_at = task.get("started_at")
+        assert stored_started_at is not None
+        parsed_started_at = datetime.fromisoformat(stored_started_at)
+        if parsed_started_at.tzinfo is None:
+            parsed_started_at = parsed_started_at.replace(tzinfo=UTC)
+        assert parsed_started_at == started_at
+
+
 class TestCleanupProtectsActive:
     """Tests for cleanup_old_tasks skipping active tasks."""
 

--- a/tests/functional/web/api/test_webhook_events.py
+++ b/tests/functional/web/api/test_webhook_events.py
@@ -10,6 +10,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from family_assistant.events.webhook_source import WebhookEventSource
+from family_assistant.storage.context import DatabaseContext
 from family_assistant.web.app_creator import app as fastapi_app
 
 
@@ -261,6 +262,58 @@ async def test_webhook_event_no_signature_needed_for_unconfigured_source(
             assert response.status_code == 200
             data = response.json()
             assert data["status"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_worker_started_uses_nonpersisted_callback_token_header(
+    db_engine: AsyncEngine,
+) -> None:
+    """Worker start proof bypasses source signing and is excluded from event data."""
+    callback_token = "worker-callback-token"
+    async with DatabaseContext(engine=db_engine) as db_context:
+        await db_context.worker_tasks.create_task(
+            task_id="worker-start-task",
+            conversation_id="conv-1",
+            interface_type="test",
+            task_description="Worker start callback",
+            callback_token=callback_token,
+        )
+
+    mock_config = MagicMock()
+    mock_config.event_system.sources.webhook.secrets = {"worker": "source-secret"}
+    mock_webhook_source = AsyncMock(spec=WebhookEventSource)
+    transport = ASGITransport(app=fastapi_app)
+
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        with (
+            patch.object(fastapi_app.state, "config", mock_config, create=True),
+            patch.object(
+                fastapi_app.state,
+                "webhook_source",
+                mock_webhook_source,
+                create=True,
+            ),
+        ):
+            response = await client.post(
+                "/webhook/event?event_type=worker_started",
+                headers={"X-Worker-Callback-Token": callback_token},
+                json={
+                    "title": "Worker task started",
+                    "data": {
+                        "task_id": "worker-start-task",
+                        "callback_token": callback_token,
+                    },
+                },
+            )
+
+    assert response.status_code == 200
+    emitted_event = mock_webhook_source.emit_event.await_args.args[0]
+    assert emitted_event["source"] is None
+    assert emitted_event["data"] == {"task_id": "worker-start-task"}
+    async with DatabaseContext(engine=db_engine) as db_context:
+        task = await db_context.worker_tasks.get_task("worker-start-task")
+    assert task is not None
+    assert task["status"] == "running"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/llm/test_google_genai_message_conversion.py
+++ b/tests/unit/llm/test_google_genai_message_conversion.py
@@ -19,6 +19,7 @@ from family_assistant.llm import ToolCallFunction, ToolCallItem
 from family_assistant.llm.messages import (
     AssistantMessage,
     LLMMessage,
+    SystemMessage,
     ToolMessage,
     UserMessage,
 )
@@ -38,6 +39,21 @@ class TestThoughtSignatureConversion:
         return GoogleGenAIClient(
             api_key="test_key_for_unit_tests", model="gemini-3.1-pro-preview"
         )
+
+    def test_system_message_with_existing_prefix_is_not_double_prefixed(
+        self, google_client: GoogleGenAIClient
+    ) -> None:
+        """Delegation wake system messages already include their user-facing marker."""
+        messages: list[LLMMessage] = [
+            SystemMessage(content="System: Delegated profile task completed."),
+        ]
+
+        contents = google_client._convert_messages_to_genai_format(messages)
+
+        content = cast("types.Content", contents[0])
+        assert content.parts is not None
+        part = cast("types.Part", content.parts[0])
+        assert part.text == "System: Delegated profile task completed."
 
     def test_thought_signature_attached_to_function_call_part(
         self, google_client: GoogleGenAIClient

--- a/tests/unit/security/test_runtime_taint.py
+++ b/tests/unit/security/test_runtime_taint.py
@@ -843,14 +843,14 @@ async def test_attacker_addressable_egress_is_observed_before_enforcement(
     assert isinstance(result, ToolResult)
     assert result.get_text() == "opened url"
     assert "requested=confirm effective=audit mode=observe" in caplog.text
-    would_enforce_errors = [
+    would_enforce_warnings = [
         record
         for record in caplog.records
-        if record.levelno == logging.ERROR
+        if record.levelno == logging.WARNING
         and "Runtime taint WOULD ENFORCE" in record.getMessage()
     ]
-    assert len(would_enforce_errors) == 1
-    would_enforce_message = would_enforce_errors[0].getMessage()
+    assert len(would_enforce_warnings) == 1
+    would_enforce_message = would_enforce_warnings[0].getMessage()
     assert "would_be=confirm" in would_enforce_message
     assert "max_tier=unknown_external" in would_enforce_message
     assert "do-not-store" not in would_enforce_message
@@ -886,13 +886,13 @@ async def test_allowed_tool_does_not_emit_would_enforce_error(
         result = await provider.execute_tool("home_tool", {}, context, "call_home")
 
     assert isinstance(result, ToolResult)
-    would_enforce_errors = [
+    would_enforce_warnings = [
         record
         for record in caplog.records
-        if record.levelno == logging.ERROR
+        if record.levelno == logging.WARNING
         and "Runtime taint WOULD ENFORCE" in record.getMessage()
     ]
-    assert would_enforce_errors == []
+    assert would_enforce_warnings == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/backends/test_kubernetes_backend.py
+++ b/tests/unit/services/backends/test_kubernetes_backend.py
@@ -233,6 +233,9 @@ class TestKubernetesBackendBuildJobManifest:
 
         compile(python_source, "<worker-start-command>", "exec")
         assert "\nimport json\n" in python_source
+        assert "source=worker" not in python_source
+        assert "X-Worker-Callback-Token" in python_source
+        assert '"callback_token":' not in python_source
 
     def test_build_manifest_gemini_model(self, backend: KubernetesBackend) -> None:
         """Test job manifest for gemini model uses gemini config volume."""

--- a/tests/unit/services/backends/test_kubernetes_backend.py
+++ b/tests/unit/services/backends/test_kubernetes_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -221,6 +222,17 @@ class TestKubernetesBackendBuildJobManifest:
         env_from = container.env_from
         assert len(env_from) == 1
         assert env_from[0].secret_ref.name == "test-api-keys"
+
+    def test_worker_start_command_contains_valid_python_source(
+        self, backend: KubernetesBackend
+    ) -> None:
+        """The shell must pass multiline source to Python rather than escaped text."""
+        command = backend._worker_start_command("https://example.com/webhook")
+
+        python_source = shlex.split(command)[2]
+
+        compile(python_source, "<worker-start-command>", "exec")
+        assert "\nimport json\n" in python_source
 
     def test_build_manifest_gemini_model(self, backend: KubernetesBackend) -> None:
         """Test job manifest for gemini model uses gemini config volume."""

--- a/tests/unit/services/backends/test_kubernetes_backend.py
+++ b/tests/unit/services/backends/test_kubernetes_backend.py
@@ -186,7 +186,10 @@ class TestKubernetesBackendBuildJobManifest:
         assert container.name == "worker"
         assert container.image == "test-image:latest"
         assert container.command is None
-        assert container.args == ["sh", "-c", 'run-task < "$TASK_INPUT"']
+        assert container.args is not None
+        assert container.args[:2] == ["sh", "-c"]
+        assert "event_type=worker_started" in container.args[2]
+        assert 'run-task < "$TASK_INPUT"' in container.args[2]
 
     def test_build_manifest_env_vars(self, backend: KubernetesBackend) -> None:
         """Test job manifest includes correct environment variables."""


### PR DESCRIPTION
### Motivation
- Worker tasks could remain stuck in a `submitted` view when the agent crashed before writing `result.json` because `started_at` was never recorded.  This hides fast lifecycle transitions from the API and UI. 
- Delegated-system messages could be double-prefixed as `System: System: ...` when converting system messages for the Gemini client. 
- Observe-mode taint diagnostics were being logged at `ERROR`, which created noisy error logs for dry-run (observe) policy evaluations.

### Description
- Add a container start wrapper so Kubernetes worker containers POST a `worker_started` webhook before running the task, and update the job manifest to call that wrapper via container args (`_worker_start_command`).
- Add webhook handling for `worker_started` in `webhooks.py` that validates callback tokens and marks the task `running` with `started_at` in the DB.
- Make the spawn path resilient to fast lifecycle callbacks by recording the backend job id without overwriting any status that a fast start/completion callback already set (preserve current status when writing `job_name`).
- Prevent double-`System:` prefixes by normalizing system content in the Gemini conversion path (`_system_prefixed_content`) and using it when building prompts.
- Downgrade `Runtime taint WOULD ENFORCE` diagnostic logs from `ERROR` to `WARNING` to reduce error-log noise while keeping the audit trail.
- Update and add focused unit tests to cover manifest args generation, system-message prefix behavior, and the adjusted taint log expectations.

### Testing
- Ran lint/format/type checks with `uv run ruff check`, `uv run ruff format` and `basedpyright`, and resolved type issues; these checks passed after adjustments. 
- Ran the focused unit test suite with `uv run pytest -n0 tests/unit/services/backends/test_kubernetes_backend.py tests/unit/security/test_runtime_taint.py::test_attacker_addressable_egress_is_observed_before_enforcement tests/unit/security/test_runtime_taint.py::test_allowed_tool_does_not_emit_would_enforce_error tests/unit/llm/test_google_genai_message_conversion.py::TestThoughtSignatureConversion::test_system_message_with_existing_prefix_is_not_double_prefixed` which completed successfully (39 passed, 1 warning).
- Verified repository formatting (`ruff`) and code-conformance checks passed after edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c424fad788330b7f3ec45bd17fc8c)