### PR TITLE
Fix crash on list-valued JSON Schema type in Gemini tool conversion

### DIFF
--- a/src/family_assistant/llm/providers/google_genai_client.py
+++ b/src/family_assistant/llm/providers/google_genai_client.py
@@ -55,7 +55,7 @@ from family_assistant.llm.messages import (
 )
 from family_assistant.llm.request_buffer import LLMRequestRecord, get_request_buffer
 from family_assistant.tools.computer_use_names import COMPUTER_USE_FUNCTION_NAMES
-from family_assistant.tools.types import ToolDefinition
+from family_assistant.tools.types import ToolDefinition, normalize_json_schema_type
 
 from ..base import (
     AuthenticationError,
@@ -135,30 +135,6 @@ def _normalize_thought_signature(raw_value: bytes | None) -> bytes | None:
     return raw_value
 
 
-def _normalize_json_schema_type(
-    type_value: object, default: str = "string"
-) -> tuple[str, bool]:
-    """Normalize a JSON Schema ``type`` value to a single type name plus nullability.
-
-    JSON Schema permits ``type`` to be either a string or a list of strings such as
-    ``["string", "null"]`` to express a nullable field. Gemini's schema expects a
-    single scalar type together with a separate ``nullable`` flag, so collapse the
-    list form here and report whether ``"null"`` was present.
-    """
-    if isinstance(type_value, list):
-        non_null = [t for t in type_value if t != "null"]
-        nullable = len(non_null) != len(type_value)
-        resolved: object = non_null[0] if non_null else default
-    else:
-        resolved = type_value
-        nullable = False
-
-    if not isinstance(resolved, str):
-        resolved = default
-
-    return resolved, nullable
-
-
 def convert_tools_to_genai_format(tools: list[ToolDefinition]) -> list[Any]:
     """Convert OpenAI-style tools to Gemini format."""
 
@@ -177,14 +153,14 @@ def convert_tools_to_genai_format(tools: list[ToolDefinition]) -> list[Any]:
         # Convert properties to Google format
         google_properties = {}
         for prop_name, prop_def in properties.items():
-            prop_type, prop_nullable = _normalize_json_schema_type(
+            prop_type, prop_nullable = normalize_json_schema_type(
                 prop_def.get("type", "string")
             )
 
             if prop_type == "array":
                 # Handle array types - need to specify items
                 items_def = prop_def.get("items", {})
-                items_type_name, _ = _normalize_json_schema_type(
+                items_type_name, _ = normalize_json_schema_type(
                     items_def.get("type", "string")
                 )
                 items_type = types.Type(items_type_name.upper())

--- a/src/family_assistant/llm/providers/google_genai_client.py
+++ b/src/family_assistant/llm/providers/google_genai_client.py
@@ -135,6 +135,30 @@ def _normalize_thought_signature(raw_value: bytes | None) -> bytes | None:
     return raw_value
 
 
+def _normalize_json_schema_type(
+    type_value: object, default: str = "string"
+) -> tuple[str, bool]:
+    """Normalize a JSON Schema ``type`` value to a single type name plus nullability.
+
+    JSON Schema permits ``type`` to be either a string or a list of strings such as
+    ``["string", "null"]`` to express a nullable field. Gemini's schema expects a
+    single scalar type together with a separate ``nullable`` flag, so collapse the
+    list form here and report whether ``"null"`` was present.
+    """
+    if isinstance(type_value, list):
+        non_null = [t for t in type_value if t != "null"]
+        nullable = len(non_null) != len(type_value)
+        resolved: object = non_null[0] if non_null else default
+    else:
+        resolved = type_value
+        nullable = False
+
+    if not isinstance(resolved, str):
+        resolved = default
+
+    return resolved, nullable
+
+
 def convert_tools_to_genai_format(tools: list[ToolDefinition]) -> list[Any]:
     """Convert OpenAI-style tools to Gemini format."""
 
@@ -153,16 +177,22 @@ def convert_tools_to_genai_format(tools: list[ToolDefinition]) -> list[Any]:
         # Convert properties to Google format
         google_properties = {}
         for prop_name, prop_def in properties.items():
-            prop_type = prop_def.get("type", "string")
+            prop_type, prop_nullable = _normalize_json_schema_type(
+                prop_def.get("type", "string")
+            )
 
             if prop_type == "array":
                 # Handle array types - need to specify items
                 items_def = prop_def.get("items", {})
-                items_type = types.Type(items_def.get("type", "string").upper())
+                items_type_name, _ = _normalize_json_schema_type(
+                    items_def.get("type", "string")
+                )
+                items_type = types.Type(items_type_name.upper())
 
                 google_properties[prop_name] = types.Schema(
                     type=types.Type.ARRAY,
                     description=prop_def.get("description", ""),
+                    nullable=prop_nullable,
                     items=types.Schema(
                         type=items_type,
                         description=items_def.get("description", ""),
@@ -174,6 +204,7 @@ def convert_tools_to_genai_format(tools: list[ToolDefinition]) -> list[Any]:
                 google_properties[prop_name] = types.Schema(
                     type=schema_type,
                     description=prop_def.get("description", ""),
+                    nullable=prop_nullable,
                 )
 
         # Create function declaration

--- a/src/family_assistant/llm/providers/google_genai_client.py
+++ b/src/family_assistant/llm/providers/google_genai_client.py
@@ -160,7 +160,7 @@ def convert_tools_to_genai_format(tools: list[ToolDefinition]) -> list[Any]:
             if prop_type == "array":
                 # Handle array types - need to specify items
                 items_def = prop_def.get("items", {})
-                items_type_name, _ = normalize_json_schema_type(
+                items_type_name, items_nullable = normalize_json_schema_type(
                     items_def.get("type", "string")
                 )
                 items_type = types.Type(items_type_name.upper())
@@ -172,6 +172,7 @@ def convert_tools_to_genai_format(tools: list[ToolDefinition]) -> list[Any]:
                     items=types.Schema(
                         type=items_type,
                         description=items_def.get("description", ""),
+                        nullable=items_nullable,
                     ),
                 )
             else:

--- a/src/family_assistant/llm/providers/google_genai_client.py
+++ b/src/family_assistant/llm/providers/google_genai_client.py
@@ -168,11 +168,11 @@ def convert_tools_to_genai_format(tools: list[ToolDefinition]) -> list[Any]:
                 google_properties[prop_name] = types.Schema(
                     type=types.Type.ARRAY,
                     description=prop_def.get("description", ""),
-                    nullable=prop_nullable,
+                    nullable=prop_nullable or None,
                     items=types.Schema(
                         type=items_type,
                         description=items_def.get("description", ""),
-                        nullable=items_nullable,
+                        nullable=items_nullable or None,
                     ),
                 )
             else:
@@ -181,7 +181,7 @@ def convert_tools_to_genai_format(tools: list[ToolDefinition]) -> list[Any]:
                 google_properties[prop_name] = types.Schema(
                     type=schema_type,
                     description=prop_def.get("description", ""),
-                    nullable=prop_nullable,
+                    nullable=prop_nullable or None,
                 )
 
         # Create function declaration

--- a/src/family_assistant/tools/types.py
+++ b/src/family_assistant/tools/types.py
@@ -115,7 +115,10 @@ class ToolPropertyItems(TypedDict, total=False):
     For complex nested objects, additional fields may be present.
     """
 
-    type: str
+    # JSON Schema permits ``type`` to be a list such as ``["string", "null"]`` to
+    # express a nullable field, so it is not always a bare string. Use
+    # ``normalize_json_schema_type`` before treating it as a single scalar type.
+    type: str | list[str]
     description: str
     # ast-grep-ignore: no-dict-any - JSON Schema nested properties can be arbitrarily deep
     properties: dict[str, Any]  # Nested object properties
@@ -133,7 +136,9 @@ class ToolPropertySchema(TypedDict, total=False):
     Follows JSON Schema format as used by OpenAI function calling.
     """
 
-    type: str
+    # See ``ToolPropertyItems.type``: JSON Schema allows the list form (e.g.
+    # ``["string", "null"]``) for nullable fields.
+    type: str | list[str]
     description: str
     format: str
     default: Any
@@ -153,7 +158,9 @@ class ToolParametersSchema(TypedDict, total=False):
     Follows JSON Schema 'object' type format.
     """
 
-    type: str
+    # See ``ToolPropertyItems.type``: JSON Schema allows the list form here too,
+    # although the parameters object is conventionally a bare ``"object"``.
+    type: str | list[str]
     properties: dict[str, ToolPropertySchema]
     required: list[str]
     additionalProperties: bool
@@ -178,6 +185,33 @@ class ToolDefinition(TypedDict):
 
     type: str
     function: ToolFunctionSchema
+
+
+def normalize_json_schema_type(
+    type_value: object, default: str = "string"
+) -> tuple[str, bool]:
+    """Normalize a JSON Schema ``type`` value to a single type name plus nullability.
+
+    JSON Schema permits ``type`` to be either a string or a list of strings such as
+    ``["string", "null"]`` to express a nullable field. Consumers that need a single
+    scalar type (e.g. the Gemini schema converters) should route the raw ``type``
+    through here to collapse the list form and learn whether ``"null"`` was present.
+
+    Returns a ``(type_name, nullable)`` tuple. ``type_name`` falls back to ``default``
+    when the value is missing, all-null, or not a string.
+    """
+    if isinstance(type_value, list):
+        non_null = [t for t in type_value if t != "null"]
+        nullable = len(non_null) != len(type_value)
+        resolved: object = non_null[0] if non_null else default
+    else:
+        resolved = type_value
+        nullable = False
+
+    if not isinstance(resolved, str):
+        resolved = default
+
+    return resolved, nullable
 
 
 if TYPE_CHECKING:

--- a/src/family_assistant/web/routers/gemini_live_api.py
+++ b/src/family_assistant/web/routers/gemini_live_api.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 
 from family_assistant.processing import ProcessingService
 from family_assistant.tools import get_tool_definitions_for_advertisement
+from family_assistant.tools.types import normalize_json_schema_type
 from family_assistant.web.auth import get_user_from_request
 from family_assistant.web.dependencies import get_processing_service
 from family_assistant.web.models import GeminiLiveConfig
@@ -59,8 +60,15 @@ class EphemeralTokenRequest(BaseModel):
     profile_id: str | None = None
 
 
-def _convert_json_schema_type_to_gemini(schema_type: str) -> str:
-    """Convert JSON Schema type to Gemini API type."""
+def _convert_json_schema_type_to_gemini(
+    schema_type: str | list[str],
+) -> tuple[str, bool]:
+    """Convert a JSON Schema type to a Gemini API type plus a nullability flag.
+
+    JSON Schema ``type`` may be a list such as ``["string", "null"]`` to express a
+    nullable field, so collapse it to a single Gemini type and report whether the
+    field is nullable.
+    """
     type_map = {
         "object": "OBJECT",
         "string": "STRING",
@@ -69,18 +77,20 @@ def _convert_json_schema_type_to_gemini(schema_type: str) -> str:
         "boolean": "BOOLEAN",
         "array": "ARRAY",
     }
-    return type_map.get(schema_type.lower(), schema_type.upper())
+    resolved, nullable = normalize_json_schema_type(schema_type, default="string")
+    return type_map.get(resolved.lower(), resolved.upper()), nullable
 
 
 def _convert_properties_to_gemini(properties: PropertySchema) -> PropertySchema:
     """Recursively convert JSON Schema properties to Gemini format."""
     result: PropertySchema = {}
     for name, prop_schema in properties.items():
-        converted: PropertySchema = {
-            "type": _convert_json_schema_type_to_gemini(
-                prop_schema.get("type", "string")
-            )
-        }
+        gemini_type, nullable = _convert_json_schema_type_to_gemini(
+            prop_schema.get("type", "string")
+        )
+        converted: PropertySchema = {"type": gemini_type}
+        if nullable:
+            converted["nullable"] = True
         if "description" in prop_schema:
             converted["description"] = prop_schema["description"]
         if "properties" in prop_schema:
@@ -89,9 +99,13 @@ def _convert_properties_to_gemini(properties: PropertySchema) -> PropertySchema:
             )
         if "items" in prop_schema:
             items = prop_schema["items"]
-            converted["items"] = {
-                "type": _convert_json_schema_type_to_gemini(items.get("type", "string"))
-            }
+            item_type, item_nullable = _convert_json_schema_type_to_gemini(
+                items.get("type", "string")
+            )
+            item_converted: PropertySchema = {"type": item_type}
+            if item_nullable:
+                item_converted["nullable"] = True
+            converted["items"] = item_converted
         if "enum" in prop_schema:
             converted["enum"] = prop_schema["enum"]
         result[name] = converted
@@ -108,8 +122,11 @@ def _convert_tool_to_gemini_format(tool: ToolSchema) -> GeminiToolDeclaration:
 
     if "parameters" in func:
         params = func["parameters"]
+        params_type, _ = _convert_json_schema_type_to_gemini(
+            params.get("type", "object")
+        )
         gemini_params: PropertySchema = {
-            "type": _convert_json_schema_type_to_gemini(params.get("type", "object")),
+            "type": params_type,
         }
         if "properties" in params:
             gemini_params["properties"] = _convert_properties_to_gemini(

--- a/tests/unit/llm/providers/test_google_genai_tool_conversion.py
+++ b/tests/unit/llm/providers/test_google_genai_tool_conversion.py
@@ -9,10 +9,9 @@ from typing import Any, cast
 from google.genai import types
 
 from family_assistant.llm.providers.google_genai_client import (
-    _normalize_json_schema_type,  # noqa: PLC2701 - unit tests need direct access to internal helper
     convert_tools_to_genai_format,
 )
-from family_assistant.tools.types import ToolDefinition
+from family_assistant.tools.types import ToolDefinition, normalize_json_schema_type
 
 
 def _tool_with_properties(
@@ -59,22 +58,22 @@ class TestNormalizeJsonSchemaType:
     """Tests for the JSON Schema ``type`` normalization helper."""
 
     def test_scalar_string_type(self) -> None:
-        assert _normalize_json_schema_type("string") == ("string", False)
+        assert normalize_json_schema_type("string") == ("string", False)
 
     def test_nullable_list_type_collapses_to_non_null(self) -> None:
-        assert _normalize_json_schema_type(["string", "null"]) == ("string", True)
+        assert normalize_json_schema_type(["string", "null"]) == ("string", True)
 
     def test_null_first_ordering(self) -> None:
-        assert _normalize_json_schema_type(["null", "integer"]) == ("integer", True)
+        assert normalize_json_schema_type(["null", "integer"]) == ("integer", True)
 
     def test_list_without_null_is_not_nullable(self) -> None:
-        assert _normalize_json_schema_type(["string", "number"]) == ("string", False)
+        assert normalize_json_schema_type(["string", "number"]) == ("string", False)
 
     def test_all_null_falls_back_to_default(self) -> None:
-        assert _normalize_json_schema_type(["null"]) == ("string", True)
+        assert normalize_json_schema_type(["null"]) == ("string", True)
 
     def test_non_string_value_falls_back_to_default(self) -> None:
-        assert _normalize_json_schema_type(None) == ("string", False)
+        assert normalize_json_schema_type(None) == ("string", False)
 
 
 class TestConvertToolsToGenaiFormat:

--- a/tests/unit/llm/providers/test_google_genai_tool_conversion.py
+++ b/tests/unit/llm/providers/test_google_genai_tool_conversion.py
@@ -126,3 +126,4 @@ class TestConvertToolsToGenaiFormat:
         assert tags.type == types.Type.ARRAY
         assert tags.items is not None
         assert tags.items.type == types.Type.STRING
+        assert tags.items.nullable is True

--- a/tests/unit/llm/providers/test_google_genai_tool_conversion.py
+++ b/tests/unit/llm/providers/test_google_genai_tool_conversion.py
@@ -1,0 +1,129 @@
+"""Unit tests for converting OpenAI-style tools to Gemini schema format.
+
+Focuses on JSON Schema ``type`` handling, including the list form
+(e.g. ``["string", "null"]``) used to express nullable/optional fields.
+"""
+
+from typing import Any, cast
+
+from google.genai import types
+
+from family_assistant.llm.providers.google_genai_client import (
+    _normalize_json_schema_type,  # noqa: PLC2701 - unit tests need direct access to internal helper
+    convert_tools_to_genai_format,
+)
+from family_assistant.tools.types import ToolDefinition
+
+
+def _tool_with_properties(
+    # ast-grep-ignore: no-dict-any - test constructs raw JSON Schema property payloads
+    properties: dict[str, Any],
+    required: list[str],
+) -> ToolDefinition:
+    """Build a single-function tool definition around the given properties.
+
+    ``ToolPropertySchema.type`` is declared as ``str``, but real JSON Schema
+    payloads may carry a list ``type`` (e.g. ``["string", "null"]``). The cast
+    lets tests exercise that runtime shape.
+    """
+    return cast(
+        "ToolDefinition",
+        {
+            "type": "function",
+            "function": {
+                "name": "sample_tool",
+                "description": "Sample tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                },
+            },
+        },
+    )
+
+
+def _properties_of(tools: list[ToolDefinition]) -> dict[str, types.Schema]:
+    converted = convert_tools_to_genai_format(tools)
+    assert len(converted) == 1
+    declarations = converted[0].function_declarations
+    assert declarations is not None
+    assert len(declarations) == 1
+    parameters = declarations[0].parameters
+    assert parameters is not None
+    assert parameters.properties is not None
+    return parameters.properties
+
+
+class TestNormalizeJsonSchemaType:
+    """Tests for the JSON Schema ``type`` normalization helper."""
+
+    def test_scalar_string_type(self) -> None:
+        assert _normalize_json_schema_type("string") == ("string", False)
+
+    def test_nullable_list_type_collapses_to_non_null(self) -> None:
+        assert _normalize_json_schema_type(["string", "null"]) == ("string", True)
+
+    def test_null_first_ordering(self) -> None:
+        assert _normalize_json_schema_type(["null", "integer"]) == ("integer", True)
+
+    def test_list_without_null_is_not_nullable(self) -> None:
+        assert _normalize_json_schema_type(["string", "number"]) == ("string", False)
+
+    def test_all_null_falls_back_to_default(self) -> None:
+        assert _normalize_json_schema_type(["null"]) == ("string", True)
+
+    def test_non_string_value_falls_back_to_default(self) -> None:
+        assert _normalize_json_schema_type(None) == ("string", False)
+
+
+class TestConvertToolsToGenaiFormat:
+    """Tests for converting tool definitions into Gemini schema objects."""
+
+    def test_nullable_scalar_property_sets_nullable_flag(self) -> None:
+        tools = [
+            _tool_with_properties(
+                {
+                    "note": {
+                        "type": ["string", "null"],
+                        "description": "Optional note",
+                    }
+                },
+                required=[],
+            )
+        ]
+
+        note = _properties_of(tools)["note"]
+        assert note.type == types.Type.STRING
+        assert note.nullable is True
+
+    def test_non_nullable_scalar_property(self) -> None:
+        tools = [
+            _tool_with_properties(
+                {"query": {"type": "string", "description": "Query"}},
+                required=["query"],
+            )
+        ]
+
+        query = _properties_of(tools)["query"]
+        assert query.type == types.Type.STRING
+        assert not query.nullable
+
+    def test_nullable_array_items_type(self) -> None:
+        tools = [
+            _tool_with_properties(
+                {
+                    "tags": {
+                        "type": "array",
+                        "description": "Tags",
+                        "items": {"type": ["string", "null"]},
+                    }
+                },
+                required=["tags"],
+            )
+        ]
+
+        tags = _properties_of(tools)["tags"]
+        assert tags.type == types.Type.ARRAY
+        assert tags.items is not None
+        assert tags.items.type == types.Type.STRING

--- a/tests/unit/web/test_gemini_live_api.py
+++ b/tests/unit/web/test_gemini_live_api.py
@@ -14,7 +14,11 @@ from family_assistant.config_models import AppConfig, ToolsConfig
 from family_assistant.delegation_security import DelegationSecurityLevel
 from family_assistant.llm import LLMOutput
 from family_assistant.processing import ProcessingService, ProcessingServiceConfig
-from family_assistant.web.routers.gemini_live_api import gemini_live_router
+from family_assistant.web.routers.gemini_live_api import (
+    _convert_json_schema_type_to_gemini,  # noqa: PLC2701 - unit tests need direct access to internal helper
+    _convert_properties_to_gemini,  # noqa: PLC2701 - unit tests need direct access to internal helper
+    gemini_live_router,
+)
 from tests.mocks.mock_llm import RuleBasedMockLLMClient
 
 if TYPE_CHECKING:
@@ -23,6 +27,41 @@ if TYPE_CHECKING:
         ToolExecutionContext,
         ToolResult,
     )
+
+
+def test_convert_scalar_type_to_gemini() -> None:
+    assert _convert_json_schema_type_to_gemini("string") == ("STRING", False)
+
+
+def test_convert_nullable_list_type_to_gemini() -> None:
+    assert _convert_json_schema_type_to_gemini(["string", "null"]) == ("STRING", True)
+
+
+def test_convert_properties_marks_nullable_field() -> None:
+    properties = {"note": {"type": ["string", "null"], "description": "Optional"}}
+
+    converted = _convert_properties_to_gemini(properties)
+
+    assert converted["note"]["type"] == "STRING"
+    assert converted["note"]["nullable"] is True
+
+
+def test_convert_properties_nullable_array_items() -> None:
+    properties = {"tags": {"type": "array", "items": {"type": ["string", "null"]}}}
+
+    converted = _convert_properties_to_gemini(properties)
+
+    assert converted["tags"]["type"] == "ARRAY"
+    assert converted["tags"]["items"]["type"] == "STRING"
+    assert converted["tags"]["items"]["nullable"] is True
+
+
+def test_convert_properties_non_nullable_field_omits_flag() -> None:
+    properties = {"query": {"type": "string"}}
+
+    converted = _convert_properties_to_gemini(properties)
+
+    assert "nullable" not in converted["query"]
 
 
 class VoiceModeStubToolsProvider:


### PR DESCRIPTION
## Summary

`convert_tools_to_genai_format` assumed a JSON Schema `"type"` field is always a string and called `.upper()` on it directly. JSON Schema also permits the **list form** — e.g. `["string", "null"]` to express a nullable/optional field. When any advertised tool had such a property, `.upper()` was invoked on a `list` and raised `AttributeError` **before any LLM token was generated**, failing the entire turn (and every retry, since each hit the same code path). This broke the artist profile completely (10+ crashes in one evening).

Per review feedback, this is fundamentally *"the job for a type checker"* — so the fix does two things: patch the crash, and make the type honest so the checker prevents the whole class of bug going forward.

## Changes

**Make the schema type honest**
- Widen `type` on `ToolPropertyItems` / `ToolPropertySchema` / `ToolParametersSchema` from `str` to `str | list[str]`, matching what JSON Schema actually allows. Any future code that calls a string method on a schema `type` without normalizing now fails `basedpyright`. (`scripting/validator.py` already handled the list form — the two Gemini converters were the ones that didn't.)

**One shared normalizer**
- Add `normalize_json_schema_type` in `tools/types.py`: collapses the list form to a single type name plus a `nullable` flag, falling back to a default for missing/all-null/non-string values.
- `convert_tools_to_genai_format` (`google_genai_client.py`) now uses the shared helper and propagates `nullable` into the emitted Gemini schema.
- `_convert_json_schema_type_to_gemini` (`gemini_live_api.py`, the voice-mode ephemeral-token endpoint) had the **identical latent crash** on list-typed properties. It now normalizes too and propagates `nullable` into the emitted schema.

## Tests

- `tests/unit/llm/providers/test_google_genai_tool_conversion.py` — direct tests of the shared helper (null-first ordering, all-null fallback, non-string input) and end-to-end conversion of nullable scalar/array properties.
- `tests/unit/web/test_gemini_live_api.py` — added converter tests covering nullable scalar and array-item types for the voice-mode path.

## Verification

- `scripts/format-and-lint.sh` passes clean across the whole repo (ruff, basedpyright, pylint, conformance) — confirming the type widening breaks no other consumer.
- 512 tests across `tests/unit/llm/`, the gemini-live suite, and `tests/functional/scripting` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1oDQhk3qaD2eRFsERbb34

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1oDQhk3qaD2eRFsERbb34)_