### PR TITLE
Normalize OpenAI Responses tool arguments

### DIFF
--- a/src/family_assistant/llm/providers/openai_client.py
+++ b/src/family_assistant/llm/providers/openai_client.py
@@ -290,11 +290,14 @@ class OpenAIClient(BaseLLMClient):
                             ],
                         })
                     for tool_call in message.tool_calls or []:
+                        arguments = tool_call.function.arguments
+                        if isinstance(arguments, dict):
+                            arguments = json.dumps(arguments)
                         input_items.append({
                             "type": "function_call",
                             "call_id": tool_call.id,
                             "name": tool_call.function.name,
-                            "arguments": tool_call.function.arguments,
+                            "arguments": arguments,
                         })
             elif message.role == "tool":
                 input_items.append({

--- a/tests/unit/llm/providers/test_openai_responses_input.py
+++ b/tests/unit/llm/providers/test_openai_responses_input.py
@@ -1,5 +1,8 @@
 """Regression tests for OpenAI Responses API input conversion."""
 
+import json
+
+from family_assistant.llm import ToolCallFunction, ToolCallItem
 from family_assistant.llm.messages import AssistantMessage, LLMMessage
 from family_assistant.llm.providers.openai_client import OpenAIClient
 
@@ -48,3 +51,58 @@ def test_synthesized_responses_assistant_message_omits_status() -> None:
     ])
 
     assert "status" not in input_items[0]
+
+
+def test_responses_serializes_structured_tool_call_arguments() -> None:
+    """Tool calls from providers such as Gemini must be replayed as JSON strings."""
+    client = OpenAIClient(api_key="test-key", model="gpt-5.6-sol")
+    arguments: dict[str, object] = {
+        "location": "Melbourne",
+        "units": "metric",
+    }
+    messages: list[LLMMessage] = [
+        AssistantMessage(
+            content="",
+            tool_calls=[
+                ToolCallItem(
+                    id="call_123",
+                    type="function",
+                    function=ToolCallFunction(
+                        name="get_weather",
+                        arguments=arguments,
+                    ),
+                )
+            ],
+        )
+    ]
+
+    input_items = client._messages_to_responses_input(messages)
+
+    serialized_arguments = input_items[0]["arguments"]
+    assert isinstance(serialized_arguments, str)
+    assert json.loads(serialized_arguments) == arguments
+
+
+def test_responses_preserves_string_tool_call_arguments() -> None:
+    """Tool calls already encoded for OpenAI must not be double-serialized."""
+    client = OpenAIClient(api_key="test-key", model="gpt-5.6-sol")
+    arguments = '{"location":"Melbourne","units":"metric"}'
+    messages: list[LLMMessage] = [
+        AssistantMessage(
+            content="",
+            tool_calls=[
+                ToolCallItem(
+                    id="call_123",
+                    type="function",
+                    function=ToolCallFunction(
+                        name="get_weather",
+                        arguments=arguments,
+                    ),
+                )
+            ],
+        )
+    ]
+
+    input_items = client._messages_to_responses_input(messages)
+
+    assert input_items[0]["arguments"] == arguments


### PR DESCRIPTION
## Summary

- serialize structured tool-call arguments before replaying them through the OpenAI Responses API
- preserve arguments that are already JSON strings
- add regression coverage for Gemini-originated dict arguments and OpenAI-originated string arguments

## Root cause

`ToolCallFunction.arguments` intentionally supports both JSON strings and structured dictionaries because Gemini returns function-call arguments as dictionaries. The OpenAI Responses API requires the `arguments` field on a `function_call` input item to be a JSON string. The Responses-specific message converter forwarded the shared value unchanged, so replaying a Gemini-generated tool call through OpenAI produced a 400 response (`expected a string, but got an object instead`).

The existing Chat Completions serialization path already normalizes structured arguments with `json.dumps`; this change applies the same provider-boundary normalization to the Responses path.

## Impact

Conversations can switch from Gemini-backed profiles to GPT-5.6-sol without failing when prior assistant messages contain structured tool-call arguments.

## Validation

- `.venv/bin/pytest tests/unit/llm/providers/test_openai_responses_input.py tests/unit/llm/test_google_genai_message_conversion.py -xq` (`9 passed, 1 skipped`)
- `scripts/format-and-lint.sh src/family_assistant/llm/providers/openai_client.py tests/unit/llm/providers/test_openai_responses_input.py`
- commit-time pre-commit checks