### PR TITLE
Report the configured timezone in the browser

### DIFF
--- a/src/family_assistant/tools/browser_backend.py
+++ b/src/family_assistant/tools/browser_backend.py
@@ -489,6 +489,7 @@ class RemoteBrowserBackend:
         config: BrowserHandoffConfig,
         conversation_id: str,
         client: httpx.AsyncClient | None = None,
+        timezone_id: str | None = None,
     ) -> None:
         if not config.service_url:
             raise BrowserBackendError(
@@ -497,6 +498,9 @@ class RemoteBrowserBackend:
         self._config = config
         self._conversation_id = conversation_id
         self._base_url = config.service_url.rstrip("/")
+        # IANA timezone (e.g. "Australia/Sydney") forwarded to browser-server so the
+        # remote browser context reports the user's local time to in-page JS.
+        self._timezone_id = timezone_id
         self._session_id: str | None = None
         # ``client`` is an injection seam for tests (e.g. httpx.MockTransport).
         self._client = client or httpx.AsyncClient(timeout=config.timeout_seconds)
@@ -526,14 +530,17 @@ class RemoteBrowserBackend:
     async def _ensure_session(self) -> str:
         if self._session_id is not None:
             return self._session_id
+        payload: JsonDict = {
+            "conversation_id": self._conversation_id,
+            "interface_type": "research",
+            "initial_owner": "agent",
+        }
+        if self._timezone_id:
+            payload["timezone_id"] = self._timezone_id
         resp = await self._client.post(
             f"{self._base_url}/v1/sessions",
             headers=self._headers(),
-            json={
-                "conversation_id": self._conversation_id,
-                "interface_type": "research",
-                "initial_owner": "agent",
-            },
+            json=payload,
         )
         self._raise_for_status(resp, "create session")
         self._session_id = str(resp.json()["session_id"])
@@ -838,7 +845,9 @@ async def get_browser_backend(exec_context: ToolExecutionContext) -> BrowserBack
         session_key = exec_context.conversation_id or "default"
         backend = _remote_backends.get(session_key)
         if backend is None:
-            backend = RemoteBrowserBackend(config, session_key)
+            tz = getattr(exec_context, "timezone", None)
+            timezone_id = str(tz) if tz else None
+            backend = RemoteBrowserBackend(config, session_key, timezone_id=timezone_id)
             _remote_backends[session_key] = backend
         return backend
     session: BrowserSession = await get_browser_session(exec_context)

--- a/src/family_assistant/tools/browser_session.py
+++ b/src/family_assistant/tools/browser_session.py
@@ -57,6 +57,10 @@ class BrowserSession:
     page: Page | None = field(default=None, repr=False)
     screen_width: int = SCREEN_WIDTH
     screen_height: int = SCREEN_HEIGHT
+    # IANA timezone (e.g. ``"Australia/Sydney"``) applied to the browser context so
+    # in-page JS (``new Date()``, ``Intl``) reports the user's local time. ``None``
+    # leaves the host default in place. Mirrors the remote browser-server backend.
+    timezone_id: str | None = None
     # Maps short refs (e.g. ``"e12"``) to CSS selectors that the
     # semantic DOM tools can hand back to Playwright. Populated by
     # browser_dom snapshots; cleared on navigation.
@@ -87,6 +91,7 @@ class BrowserSession:
             context = await create_stealth_context(
                 self.browser,
                 viewport={"width": self.screen_width, "height": self.screen_height},
+                timezone_id=self.timezone_id,
             )
             self.context = context
 
@@ -124,7 +129,8 @@ async def get_browser_session(exec_context: ToolExecutionContext) -> BrowserSess
     """Get or create a browser session for the given execution context."""
     session_key = exec_context.conversation_id or "default"
     if session_key not in _sessions:
-        _sessions[session_key] = BrowserSession()
+        tz = getattr(exec_context, "timezone", None)
+        _sessions[session_key] = BrowserSession(timezone_id=str(tz) if tz else None)
     return _sessions[session_key]
 
 

--- a/tests/unit/tools/test_browser_backend.py
+++ b/tests/unit/tools/test_browser_backend.py
@@ -328,6 +328,11 @@ async def test_get_browser_backend_forwards_context_timezone() -> None:
     )
     backend = await get_browser_backend(ctx)
     assert isinstance(backend, RemoteBrowserBackend)
+    # Private read (SLF001): this asserts the one thing this test exists to check
+    # -- that get_browser_backend wired exec_context.timezone into the backend at
+    # construction. There is no public accessor for it, and observing it via the
+    # create-session body (covered by the tests above) would require driving a
+    # live session with network I/O, which this selection test deliberately avoids.
     assert backend._timezone_id == "Australia/Sydney"  # noqa: SLF001
     await backend.close()
 

--- a/tests/unit/tools/test_browser_backend.py
+++ b/tests/unit/tools/test_browser_backend.py
@@ -11,6 +11,7 @@ import base64
 import json
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
+from zoneinfo import ZoneInfo
 
 import httpx
 import pytest
@@ -101,6 +102,9 @@ def _make_mock_browser_server() -> tuple[httpx.AsyncClient, list[httpx.Request]]
     return client, seen
 
 
+_DEFAULT_TZ = ZoneInfo("Australia/Sydney")
+
+
 def _config(enabled: bool = True) -> BrowserHandoffConfig:
     return BrowserHandoffConfig(
         enabled=enabled,
@@ -131,6 +135,30 @@ async def test_remote_backend_screenshot_decodes_png() -> None:
     backend = RemoteBrowserBackend(_config(), "conv_shot", client=client)
     png = await backend.screenshot_png()
     assert png[:8] == b"\x89PNG\r\n\x1a\n"
+    await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_backend_sends_timezone_in_create_session() -> None:
+    """The create-session request carries the configured IANA timezone so the
+    remote browser context reports the user's local time to in-page JS."""
+    client, seen = _make_mock_browser_server()
+    backend = RemoteBrowserBackend(
+        _config(), "conv_tz", client=client, timezone_id="Australia/Sydney"
+    )
+    await backend.goto("https://example.test/page")
+    create = next(r for r in seen if r.url.path == "/v1/sessions")
+    assert json.loads(create.content)["timezone_id"] == "Australia/Sydney"
+    await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_backend_omits_timezone_when_unset() -> None:
+    client, seen = _make_mock_browser_server()
+    backend = RemoteBrowserBackend(_config(), "conv_no_tz", client=client)
+    await backend.goto("https://example.test/page")
+    create = next(r for r in seen if r.url.path == "/v1/sessions")
+    assert "timezone_id" not in json.loads(create.content)
     await backend.close()
 
 
@@ -264,13 +292,20 @@ async def test_remote_backend_request_handoff_returns_url() -> None:
     await backend.close()
 
 
-def _exec_context(*, enabled: bool, profile_id: str | None) -> ToolExecutionContext:
+def _exec_context(
+    *,
+    enabled: bool,
+    profile_id: str | None,
+    timezone: ZoneInfo | None = _DEFAULT_TZ,
+    conversation_id: str = "conv_select",
+) -> ToolExecutionContext:
     app_config = SimpleNamespace(browser_handoff_config=_config(enabled=enabled))
     service = SimpleNamespace(app_config=app_config)
     ctx = SimpleNamespace(
         processing_service=service,
         processing_profile_id=profile_id,
-        conversation_id="conv_select",
+        conversation_id=conversation_id,
+        timezone=timezone,
     )
     return cast("ToolExecutionContext", cast("object", ctx))
 
@@ -280,6 +315,20 @@ async def test_get_browser_backend_uses_remote_for_handoff_profile() -> None:
     ctx = _exec_context(enabled=True, profile_id="browser_profile")
     backend = await get_browser_backend(ctx)
     assert isinstance(backend, RemoteBrowserBackend)
+    await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_get_browser_backend_forwards_context_timezone() -> None:
+    ctx = _exec_context(
+        enabled=True,
+        profile_id="browser_profile",
+        timezone=ZoneInfo("Australia/Sydney"),
+        conversation_id="conv_tz_select",
+    )
+    backend = await get_browser_backend(ctx)
+    assert isinstance(backend, RemoteBrowserBackend)
+    assert backend._timezone_id == "Australia/Sydney"  # noqa: SLF001
     await backend.close()
 
 

--- a/tests/unit/tools/test_browser_session.py
+++ b/tests/unit/tools/test_browser_session.py
@@ -1,0 +1,48 @@
+"""Unit tests for the local BrowserSession timezone plumbing.
+
+The remote browser-server backend forwards the profile's configured timezone so
+in-page ``new Date()`` reports local time; these tests cover the parity behaviour
+for the local Playwright session (``get_browser_session`` -> ``BrowserSession``).
+The real browser launch is exercised by ``tests/functional/tools/test_browser_dom.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from family_assistant.tools.browser_session import (
+    close_browser_session,
+    get_browser_session,
+)
+
+if TYPE_CHECKING:
+    from family_assistant.tools.types import ToolExecutionContext
+
+
+def _ctx(conversation_id: str, timezone: ZoneInfo | None) -> ToolExecutionContext:
+    ctx = SimpleNamespace(conversation_id=conversation_id, timezone=timezone)
+    return cast("ToolExecutionContext", cast("object", ctx))
+
+
+@pytest.mark.asyncio
+async def test_get_browser_session_sets_timezone_from_context() -> None:
+    ctx = _ctx("conv_local_tz", ZoneInfo("Australia/Sydney"))
+    session = await get_browser_session(ctx)
+    try:
+        assert session.timezone_id == "Australia/Sydney"
+    finally:
+        await close_browser_session(ctx)
+
+
+@pytest.mark.asyncio
+async def test_get_browser_session_timezone_none_when_absent() -> None:
+    ctx = _ctx("conv_local_no_tz", None)
+    session = await get_browser_session(ctx)
+    try:
+        assert session.timezone_id is None
+    finally:
+        await close_browser_session(ctx)


### PR DESCRIPTION
## Summary

Makes in-page JavaScript (`new Date()`, `Intl.DateTimeFormat`) report the user's configured timezone (e.g. `Australia/Sydney`) when the assistant browses, instead of the browser host's timezone. The timezone already existed as `ProcessingConfig.timezone` (surfaced on every tool's `exec_context.timezone`); it just wasn't reaching the browser.

## Changes

- **Remote browser-server backend** (`RemoteBrowserBackend`): sends the profile's IANA timezone as `timezone_id` in the `POST /v1/sessions` body (omitted when unavailable). `get_browser_backend` threads `exec_context.timezone` into the backend at construction.
- **Local Playwright backend** (`BrowserSession`): parity fix — `get_browser_session` threads `exec_context.timezone` into the session, which passes `timezone_id` to `create_stealth_context` (the param already existed but was never populated).

## Cross-repo

The server side is `werdnum/browser-server#28`, which adds the `timezone_id` field to `POST /v1/sessions` and applies it to the Playwright context. `werdnum/kube-config` sets a `BROWSER_TIMEZONE` default on the browser-server deployment as a fallback.

## Tests

- `tests/unit/tools/test_browser_backend.py`: create-session body carries `timezone_id`; omitted when unset; `get_browser_backend` forwards the context timezone.
- `tests/unit/tools/test_browser_session.py`: local session picks up the context timezone.

All pass; ruff / ruff format / basedpyright / pylint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1Z91EfdKdQt7z99gZ4m4Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1Z91EfdKdQt7z99gZ4m4Z)_