### PR TITLE
Stop invalidating the prompt cache on every request

### DIFF
--- a/docs/design/prompt-caching.md
+++ b/docs/design/prompt-caching.md
@@ -95,11 +95,11 @@ expose a usage field on those events.
 Note the providers do not agree on what `prompt_tokens` means, so a hit rate computed against it
 directly is wrong for at least one of them:
 
-| Provider  | `prompt_tokens` covers      | Cache buckets                                                                                                   |
-| --------- | --------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Anthropic | the uncached remainder only | `cached_prompt_tokens` and `cache_write_tokens` are **disjoint**; the real prompt total is the sum of all three |
-| OpenAI    | the whole prompt            | `cached_prompt_tokens` is a **subset**; no cache-write concept                                                  |
-| Google    | the whole prompt            | `cached_prompt_tokens` is a **subset**; no cache-write concept                                                  |
+| Provider  | `prompt_tokens` covers      | Cache buckets                                                                                                                                              |
+| --------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Anthropic | the uncached remainder only | `cached_prompt_tokens` and `cache_write_tokens` are **disjoint**; the real prompt total is the sum of all three                                            |
+| OpenAI    | the whole prompt            | `cached_prompt_tokens` is a **subset**, never added on top. The Responses API also reports `cache_write_tokens` (also a subset); Chat Completions does not |
+| Google    | the whole prompt            | `cached_prompt_tokens` is a **subset**; no cache-write count                                                                                               |
 
 Anthropic's `total_tokens` is now computed by adding the cache buckets back, so a cached turn no
 longer reports a prompt many times smaller than the one actually sent.

--- a/docs/design/prompt-caching.md
+++ b/docs/design/prompt-caching.md
@@ -71,6 +71,25 @@ costs nothing extra.
 three providers and surfaced as `gen_ai.usage.cached_input_tokens` /
 `gen_ai.usage.cache_write_input_tokens` span attributes.
 
+Two providers reported nothing at all on the streaming path — which is the path the processing loop
+uses, so the profiles that matter most were unmeasurable:
+
+- **Gemini** extracted usage only for non-streaming calls, on the stale assumption that streaming
+  does not carry it. Streaming chunks are `GenerateContentResponse` objects and do carry
+  `usage_metadata`; the newest one seen is now kept, since not every chunk includes it. Gemini's
+  `thoughts_token_count` also feeds the existing `reasoning_tokens` field.
+- **OpenAI** never asked for streaming usage. Chat Completions omits it unless
+  `stream_options: {"include_usage": true}` is set, so the existing extraction was dead code. Two
+  bugs were stacked here: the usage chunk arrives last with an **empty `choices` list**, so the
+  content guards `continue`d past it and it would have been dropped even once requested.
+
+`stream_options` is sent only to the official API, because an OpenAI-compatible endpoint that
+rejects unknown parameters would fail the request outright. Operators whose endpoint does support it
+can opt in via `model_parameters`, which is merged after the default and wins.
+
+The Deep Research (`interactions`) path is still uninstrumented: the SDK version in use does not
+expose a usage field on those events.
+
 Note the providers do not agree on what `prompt_tokens` means, so a hit rate computed against it
 directly is wrong for at least one of them:
 

--- a/docs/design/prompt-caching.md
+++ b/docs/design/prompt-caching.md
@@ -1,0 +1,106 @@
+# Prompt Caching
+
+## Problem
+
+Every provider we use caches prompts as a **prefix match**: the request is hashed from the start
+(`tools` → `system` → `messages`) and a single differing byte at position N invalidates the cache
+for everything at or after N. Anthropic requires an explicit `cache_control` breakpoint; OpenAI and
+Gemini cache automatically. All three need a byte-stable prefix to hit.
+
+An audit of the request-building path found the prefix changing on essentially every request, so the
+effective hit rate was ~0 across all providers:
+
+1. **The tool loop rewrote the system prompt on every iteration.** `llm_loop.py` appended
+   `[Processing iteration N/M]` to `messages[0]` each time round. Because `system` renders at the
+   front of the prefix, a ten-iteration agentic turn paid ten full-price prefills of the prompt, the
+   tool definitions, and every tool result accumulated so far. This was the single most expensive
+   invalidator, since agentic turns are where the context is largest.
+2. **`current_time` rendered at second resolution inside the system prompt**, so no two turns ever
+   shared a prefix — even back-to-back messages in one conversation.
+3. **Anthropic sent `system` as one monolithic string**, leaving nowhere to place a breakpoint even
+   if the content had been stable.
+4. **No cache accounting.** `cache_read_input_tokens` / `cache_creation_input_tokens` were parsed
+   and discarded, so none of the above was measurable.
+
+## Approach
+
+The guiding constraint is that **the text the model sees must not change**. Everything here is a
+change to prompt *structure* and *request shape*, not content, so there is no behavioral risk to
+re-validate beyond the loop's final-iteration instruction.
+
+### Stable-prefix boundary
+
+`ProcessingService._render_system_prompt` now returns the rendered prompt plus a
+`stable_prefix_len`: the length of the leading run that does not depend on per-turn inputs. It is
+derived by rendering the template a second time with sentinel values for `current_time` and
+`aggregated_other_context` and taking the common prefix — whatever two renderings that differ only
+in those inputs still share is, by construction, independent of them.
+
+Deriving the boundary rather than hardcoding it matters because the template is operator-editable
+per profile: placeholders can appear anywhere, more than once, or not at all. A profile whose
+template omits the volatile placeholders is fully stable and gets a boundary at the end; a profile
+that leads with `{current_time}` gets a boundary right after the (stable) profile preamble.
+
+The boundary rides on `SystemMessage.stable_prefix_len`, which is advisory metadata: providers that
+cannot use it ignore it and send the prompt exactly as before.
+
+### Anthropic breakpoint placement
+
+`AnthropicClient` splits the top-level `system` at that offset into two text blocks and marks only
+the leading one `cache_control: {"type": "ephemeral"}`. Concatenating the blocks reproduces the
+string previously sent. Because a breakpoint on the last system block also covers everything
+rendered before it, this caches the tool definitions along with the static instructions.
+
+When there is no usable boundary the client sends the plain string as before, so requests that
+cannot benefit keep their existing wire format (and existing VCR cassettes keep matching).
+
+### Loop stability
+
+The iteration counter is gone — it was informational and cost a full prefix invalidation per tool
+call. The load-bearing part, the final-iteration "you must answer now" instruction, moved to a
+trailing user message, which appends at the end of the prefix and invalidates nothing. That path
+already existed for conversations carrying Gemini thought signatures; it is now the only path.
+
+On-demand tool activation still rebuilds the system prompt, but only when the addition actually
+changes. Activation also changes the tool list, which invalidates the prefix regardless, so this
+costs nothing extra.
+
+### Measurement
+
+`MessageReasoningInfo` gained `cached_prompt_tokens` and `cache_write_tokens`, populated by all
+three providers and surfaced as `gen_ai.usage.cached_input_tokens` /
+`gen_ai.usage.cache_write_input_tokens` span attributes.
+
+Note the providers do not agree on what `prompt_tokens` means, so a hit rate computed against it
+directly is wrong for at least one of them:
+
+| Provider  | `prompt_tokens` covers      | Cache buckets                                                                                                   |
+| --------- | --------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Anthropic | the uncached remainder only | `cached_prompt_tokens` and `cache_write_tokens` are **disjoint**; the real prompt total is the sum of all three |
+| OpenAI    | the whole prompt            | `cached_prompt_tokens` is a **subset**; no cache-write concept                                                  |
+| Google    | the whole prompt            | `cached_prompt_tokens` is a **subset**; no cache-write concept                                                  |
+
+Anthropic's `total_tokens` is now computed by adding the cache buckets back, so a cached turn no
+longer reports a prompt many times smaller than the one actually sent.
+
+Cache fields are omitted rather than zeroed when a provider does not report them, so "not reported"
+stays distinguishable from a genuine zero-hit turn.
+
+## Deferred
+
+**Move `current_time` and `aggregated_other_context` out of the system prompt entirely**, to the end
+of the message list. The breakpoint split already lets the static instructions cache across turns,
+so this is now an incremental gain: it would additionally let `system_prompt_docs` and the
+delegation catalogue — currently rendered *after* the volatile context, and therefore stranded on
+the uncached side — join the cached prefix. Reordering changes where the model sees this content, so
+unlike everything above it needs validation against the eval suite. Worth doing only if the
+telemetry shows the uncached tail is material.
+
+**Tool-list churn from on-demand activation** is a hard cache reset (tools render at position 0). If
+telemetry shows activation is frequent, Anthropic's `defer_loading` plus tool search would let tool
+schemas be appended rather than swapped, preserving the prefix.
+
+**The 20-block lookback window.** A breakpoint searches back at most 20 content blocks for a prior
+cache entry. A single iteration emitting more than 20 blocks (many parallel tool calls) would
+silently miss. Not currently instrumented; the cache-read telemetry would show it as an unexplained
+miss.

--- a/docs/design/prompt-caching.md
+++ b/docs/design/prompt-caching.md
@@ -51,8 +51,10 @@ the leading one `cache_control: {"type": "ephemeral"}`. Concatenating the blocks
 string previously sent. Because a breakpoint on the last system block also covers everything
 rendered before it, this caches the tool definitions along with the static instructions.
 
-When there is no usable boundary the client sends the plain string as before, so requests that
-cannot benefit keep their existing wire format (and existing VCR cassettes keep matching).
+A prompt that is stable all the way to the end — what a template with no volatile placeholders
+produces — needs no split and is emitted as a single cacheable block. Only when there is no boundary
+at all does the client send the plain string as before, so requests that cannot benefit keep their
+existing wire format (and existing VCR cassettes keep matching).
 
 ### Loop stability
 
@@ -102,8 +104,15 @@ directly is wrong for at least one of them:
 Anthropic's `total_tokens` is now computed by adding the cache buckets back, so a cached turn no
 longer reports a prompt many times smaller than the one actually sent.
 
-Cache fields are omitted rather than zeroed when a provider does not report them, so "not reported"
-stays distinguishable from a genuine zero-hit turn.
+Cache fields are omitted only when a provider does not report them. A **reported zero is recorded as
+zero**, so a known cache miss stays distinguishable from a provider that says nothing about caching
+— otherwise a dashboard that skips unreported values would drop every miss and overstate the hit
+rate.
+
+Streaming usage is exported to the span in `RetryingLLMClient.generate_response_stream` rather than
+per provider, because providers report it in the `done` event's metadata and the OpenAI client has
+no span of its own. Doing it at the retry layer is what makes `gen_ai.usage.*` present for every
+provider instead of only the ones that instrument themselves.
 
 ## Deferred
 
@@ -114,6 +123,19 @@ delegation catalogue — currently rendered *after* the volatile context, and th
 the uncached side — join the cached prefix. Reordering changes where the model sees this content, so
 unlike everything above it needs validation against the eval suite. Worth doing only if the
 telemetry shows the uncached tail is material.
+
+**A breakpoint on the trailing conversation content.** The system-block breakpoint caches `tools` +
+the static system prompt, but nothing in `messages`. During a tool loop the accumulated assistant
+turns and tool results are byte-stable (that is what the loop fix bought) yet still re-read at full
+price on every iteration, because Anthropic caches only up to the last breakpoint. Marking the last
+content block of the most recently appended turn — the documented multi-turn pattern — would let
+iteration N reuse iterations 1..N−1, which on a tool-heavy turn is plausibly a larger saving than
+the system prompt itself.
+
+The reason it is not in the first change: it shifts the cost profile rather than purely removing
+waste. Every request would write an incremental cache entry (1.25× on the delta) to buy 0.1× reads
+on the rest — strongly net-positive when the prefix is re-read each iteration, but it wants the
+telemetry above to confirm rather than assume. It also interacts with the 20-block lookback below.
 
 **Tool-list churn from on-demand activation** is a hard cache reset (tools render at position 0). If
 telemetry shows activation is frequent, Anthropic's `defer_loading` plus tool search would let tool

--- a/src/family_assistant/llm/messages.py
+++ b/src/family_assistant/llm/messages.py
@@ -84,12 +84,28 @@ class MessageReasoningInfo(TypedDict, total=False):
 
     May contain token usage stats from LLM providers, or provenance
     info when a message was sent on behalf of another turn.
+
+    Prompt-cache accounting differs by provider, so ``prompt_tokens`` is not a
+    common denominator for a cache hit rate:
+
+    - Anthropic reports uncached, cache-read, and cache-write tokens as three
+      disjoint buckets. ``prompt_tokens`` holds only the uncached remainder, so
+      the full prompt is
+      ``prompt_tokens + cached_prompt_tokens + cache_write_tokens``.
+    - OpenAI and Google report the full prompt in ``prompt_tokens``, with
+      ``cached_prompt_tokens`` as a subset of it, and expose no cache-write
+      count (``cache_write_tokens`` is absent).
+
+    Compute a hit rate against the reconstructed prompt total rather than
+    against ``prompt_tokens`` directly.
     """
 
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
     reasoning_tokens: int
+    cached_prompt_tokens: int
+    cache_write_tokens: int
     source_turn_id: str | None
     tool_name: str
     thought_summaries: list[dict[str, str | int]]
@@ -248,6 +264,19 @@ class SystemMessage(BaseModel):
 
     role: Literal["system"] = "system"
     content: str
+    stable_prefix_len: int | None = None
+    """Length of the leading run of ``content`` that is stable across requests.
+
+    ``content[:stable_prefix_len]`` is byte-identical on every request in a
+    conversation; the remainder carries per-turn material such as the current
+    time and aggregated context. Providers that support explicit prompt-cache
+    breakpoints split ``content`` here and mark the first part cacheable. The
+    text sent to the model is unchanged either way -- only the block boundary
+    differs.
+
+    ``None`` means the producer did not identify a boundary, in which case
+    ``content`` is sent unsplit and uncached.
+    """
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/family_assistant/llm/messages.py
+++ b/src/family_assistant/llm/messages.py
@@ -93,8 +93,9 @@ class MessageReasoningInfo(TypedDict, total=False):
       the full prompt is
       ``prompt_tokens + cached_prompt_tokens + cache_write_tokens``.
     - OpenAI and Google report the full prompt in ``prompt_tokens``, with
-      ``cached_prompt_tokens`` as a subset of it, and expose no cache-write
-      count (``cache_write_tokens`` is absent).
+      ``cached_prompt_tokens`` as a subset of it rather than an extra bucket.
+      OpenAI's Responses API also reports ``cache_write_tokens``, likewise a
+      subset; Chat Completions and Google do not report one at all.
 
     Compute a hit rate against the reconstructed prompt total rather than
     against ``prompt_tokens`` directly.

--- a/src/family_assistant/llm/providers/anthropic_client.py
+++ b/src/family_assistant/llm/providers/anthropic_client.py
@@ -557,19 +557,26 @@ class AnthropicClient(BaseLLMClient):
         reported separately. `total_tokens` therefore has to add all three back
         together, or cached turns will under-report the prompt.
         """
-        cache_read = getattr(usage, "cache_read_input_tokens", None) or 0
-        cache_write = getattr(usage, "cache_creation_input_tokens", None) or 0
+        cache_read = getattr(usage, "cache_read_input_tokens", None)
+        cache_write = getattr(usage, "cache_creation_input_tokens", None)
 
         reasoning_info = MessageReasoningInfo(
             prompt_tokens=usage.input_tokens,
             completion_tokens=usage.output_tokens,
             total_tokens=(
-                usage.input_tokens + cache_read + cache_write + usage.output_tokens
+                usage.input_tokens
+                + (cache_read or 0)
+                + (cache_write or 0)
+                + usage.output_tokens
             ),
         )
-        if cache_read:
+        # A reported zero is a known cache miss and is recorded as such. Only an
+        # absent field is left out, so a miss cannot be mistaken for a provider
+        # that reports nothing -- otherwise a dashboard that skips unreported
+        # values would drop every miss and overstate the hit rate.
+        if cache_read is not None:
             reasoning_info["cached_prompt_tokens"] = cache_read
-        if cache_write:
+        if cache_write is not None:
             reasoning_info["cache_write_tokens"] = cache_write
         return reasoning_info
 
@@ -587,16 +594,26 @@ class AnthropicClient(BaseLLMClient):
         cacheable. Concatenating the returned blocks reproduces the single string
         this used to send, so the model sees identical text either way.
 
-        Without a usable boundary there is nothing worth caching -- a breakpoint
-        over volatile text buys cache writes and no reads -- so the plain string
-        form is returned instead.
+        A prompt that is stable all the way to the end needs no split -- it is
+        emitted as one cacheable block. Only when there is no boundary at all is
+        the plain string returned, since a breakpoint over volatile text buys
+        cache writes and no reads.
         """
         if not system_parts:
             return None
 
         system_prompt = "\n\n".join(system_parts)
-        if stable_prefix_len is None or not 0 < stable_prefix_len < len(system_prompt):
+        if stable_prefix_len is None or stable_prefix_len <= 0:
             return system_prompt
+
+        if stable_prefix_len >= len(system_prompt):
+            return [
+                TextBlockParam(
+                    type="text",
+                    text=system_prompt,
+                    cache_control={"type": "ephemeral"},
+                )
+            ]
 
         return [
             TextBlockParam(

--- a/src/family_assistant/llm/providers/anthropic_client.py
+++ b/src/family_assistant/llm/providers/anthropic_client.py
@@ -66,6 +66,7 @@ from family_assistant.llm.messages import (
     message_to_json_dict,
 )
 from family_assistant.llm.request_buffer import LLMRequestRecord, get_request_buffer
+from family_assistant.llm.utils.usage_telemetry import set_usage_span_attributes
 from family_assistant.tools.types import ToolDefinition
 
 from ..base import (
@@ -331,7 +332,7 @@ class AnthropicClient(BaseLLMClient):
         for attempt in range(max_retries + 1):
             try:
                 processed_messages = self._process_tool_messages(attempt_messages)
-                system_prompt, api_messages = (
+                system_blocks, api_messages = (
                     self._convert_messages_to_anthropic_format(processed_messages)
                 )
                 # ast-grep-ignore: no-dict-any - kwargs dict for client.messages.create(**params) requires heterogeneous values
@@ -350,8 +351,8 @@ class AnthropicClient(BaseLLMClient):
                     **self.default_kwargs,
                     **self._get_model_specific_params(self.model),
                 }
-                if system_prompt:
-                    params["system"] = system_prompt
+                if system_blocks:
+                    params["system"] = system_blocks
 
                 response = await self.client.messages.create(**params)
                 tool_input = self._extract_forced_tool_input(response, tool_name)
@@ -467,10 +468,10 @@ class AnthropicClient(BaseLLMClient):
         self,
         messages: Sequence[LLMMessage],
         # ast-grep-ignore: no-dict-any - MessageParam TypedDict incompatible with dynamic content merging in _merge_consecutive_roles
-    ) -> tuple[str | None, list[dict[str, Any]]]:
+    ) -> tuple[str | list[TextBlockParam] | None, list[dict[str, Any]]]:
         """Convert typed messages to Anthropic API format.
 
-        Returns (system_prompt, api_messages).
+        Returns (system_blocks, api_messages).
 
         Key differences from OpenAI:
         - System messages are extracted to the top-level `system` parameter
@@ -480,11 +481,18 @@ class AnthropicClient(BaseLLMClient):
         - Images use source.type: "base64" format
         """
         system_parts: list[str] = []
+        # Stable-prefix length of the first system message, used to place the
+        # prompt-cache breakpoint. Only the first is considered: it is the
+        # profile's system prompt, and anything hoisted after it (mid-conversation
+        # system triggers) is per-turn material that belongs past the breakpoint.
+        stable_prefix_len: int | None = None
         # ast-grep-ignore: no-dict-any - MessageParam TypedDict incompatible with dynamic content merging in _merge_consecutive_roles
         api_messages: list[dict[str, Any]] = []
 
         for msg in messages:
             if isinstance(msg, SystemMessage):
+                if not system_parts:
+                    stable_prefix_len = msg.stable_prefix_len
                 system_parts.append(msg.content)
 
             elif isinstance(msg, UserMessage):
@@ -535,8 +543,69 @@ class AnthropicClient(BaseLLMClient):
         # Merge consecutive same-role messages (Anthropic requires alternating roles)
         api_messages = self._merge_consecutive_roles(api_messages)
 
-        system_prompt = "\n\n".join(system_parts) if system_parts else None
-        return system_prompt, api_messages
+        system_blocks = self._build_system_blocks(system_parts, stable_prefix_len)
+        return system_blocks, api_messages
+
+    @staticmethod
+    def _reasoning_info_from_usage(
+        usage: Any,  # noqa: ANN401 - anthropic.types.Usage, shape varies by SDK version
+    ) -> MessageReasoningInfo:
+        """Build reasoning info from an Anthropic usage object.
+
+        Anthropic splits prompt tokens into three disjoint buckets: `input_tokens`
+        counts only the uncached remainder, with cache reads and cache writes
+        reported separately. `total_tokens` therefore has to add all three back
+        together, or cached turns will under-report the prompt.
+        """
+        cache_read = getattr(usage, "cache_read_input_tokens", None) or 0
+        cache_write = getattr(usage, "cache_creation_input_tokens", None) or 0
+
+        reasoning_info = MessageReasoningInfo(
+            prompt_tokens=usage.input_tokens,
+            completion_tokens=usage.output_tokens,
+            total_tokens=(
+                usage.input_tokens + cache_read + cache_write + usage.output_tokens
+            ),
+        )
+        if cache_read:
+            reasoning_info["cached_prompt_tokens"] = cache_read
+        if cache_write:
+            reasoning_info["cache_write_tokens"] = cache_write
+        return reasoning_info
+
+    @staticmethod
+    def _build_system_blocks(
+        system_parts: list[str],
+        stable_prefix_len: int | None,
+    ) -> str | list[TextBlockParam] | None:
+        """Build the top-level `system` value, with a prompt-cache breakpoint.
+
+        Prompt caching is a prefix match, so a breakpoint only pays off when the
+        text ahead of it is byte-identical between requests. The profile's system
+        prompt ends with per-turn material (current time, aggregated context), so
+        we split it at `stable_prefix_len` and mark only the leading block
+        cacheable. Concatenating the returned blocks reproduces the single string
+        this used to send, so the model sees identical text either way.
+
+        Without a usable boundary there is nothing worth caching -- a breakpoint
+        over volatile text buys cache writes and no reads -- so the plain string
+        form is returned instead.
+        """
+        if not system_parts:
+            return None
+
+        system_prompt = "\n\n".join(system_parts)
+        if stable_prefix_len is None or not 0 < stable_prefix_len < len(system_prompt):
+            return system_prompt
+
+        return [
+            TextBlockParam(
+                type="text",
+                text=system_prompt[:stable_prefix_len],
+                cache_control={"type": "ephemeral"},
+            ),
+            TextBlockParam(type="text", text=system_prompt[stable_prefix_len:]),
+        ]
 
     @staticmethod
     def _convert_user_content(
@@ -649,7 +718,7 @@ class AnthropicClient(BaseLLMClient):
             try:
                 processed_messages = self._process_tool_messages(list(messages))
 
-                system_prompt, api_messages = (
+                system_blocks, api_messages = (
                     self._convert_messages_to_anthropic_format(processed_messages)
                 )
 
@@ -662,8 +731,8 @@ class AnthropicClient(BaseLLMClient):
                     **self._get_model_specific_params(self.model),
                 }
 
-                if system_prompt:
-                    params["system"] = system_prompt
+                if system_blocks:
+                    params["system"] = system_blocks
 
                 if tools:
                     params["tools"] = self._convert_tools_to_anthropic_format(tools)
@@ -697,18 +766,8 @@ class AnthropicClient(BaseLLMClient):
                 # Extract usage information
                 reasoning_info: MessageReasoningInfo | None = None
                 if response.usage:
-                    reasoning_info = MessageReasoningInfo(
-                        prompt_tokens=response.usage.input_tokens,
-                        completion_tokens=response.usage.output_tokens,
-                        total_tokens=response.usage.input_tokens
-                        + response.usage.output_tokens,
-                    )
-                    span.set_attribute(
-                        "gen_ai.usage.input_tokens", response.usage.input_tokens
-                    )
-                    span.set_attribute(
-                        "gen_ai.usage.output_tokens", response.usage.output_tokens
-                    )
+                    reasoning_info = self._reasoning_info_from_usage(response.usage)
+                    set_usage_span_attributes(span, reasoning_info)
 
                 span.set_attribute("gen_ai.response.model", self.model)
 
@@ -925,7 +984,7 @@ class AnthropicClient(BaseLLMClient):
             try:
                 processed_messages = self._process_tool_messages(list(messages))
 
-                system_prompt, api_messages = (
+                system_blocks, api_messages = (
                     self._convert_messages_to_anthropic_format(processed_messages)
                 )
 
@@ -938,8 +997,8 @@ class AnthropicClient(BaseLLMClient):
                     **self._get_model_specific_params(self.model),
                 }
 
-                if system_prompt:
-                    params["system"] = system_prompt
+                if system_blocks:
+                    params["system"] = system_blocks
 
                 if tools:
                     params["tools"] = self._convert_tools_to_anthropic_format(tools)
@@ -1005,19 +1064,11 @@ class AnthropicClient(BaseLLMClient):
 
                 metadata: StreamEventMetadata = {}
                 if final_message and final_message.usage:
-                    metadata["reasoning_info"] = MessageReasoningInfo(
-                        prompt_tokens=final_message.usage.input_tokens,
-                        completion_tokens=final_message.usage.output_tokens,
-                        total_tokens=final_message.usage.input_tokens
-                        + final_message.usage.output_tokens,
+                    stream_reasoning_info = self._reasoning_info_from_usage(
+                        final_message.usage
                     )
-                    span.set_attribute(
-                        "gen_ai.usage.input_tokens", final_message.usage.input_tokens
-                    )
-                    span.set_attribute(
-                        "gen_ai.usage.output_tokens",
-                        final_message.usage.output_tokens,
-                    )
+                    metadata["reasoning_info"] = stream_reasoning_info
+                    set_usage_span_attributes(span, stream_reasoning_info)
 
                 span.set_attribute("gen_ai.response.model", self.model)
 
@@ -1147,11 +1198,7 @@ class AnthropicClient(BaseLLMClient):
 
         metadata: StreamEventMetadata = {}
         if response.usage:
-            metadata["reasoning_info"] = MessageReasoningInfo(
-                prompt_tokens=response.usage.input_tokens,
-                completion_tokens=response.usage.output_tokens,
-                total_tokens=response.usage.input_tokens + response.usage.output_tokens,
-            )
+            metadata["reasoning_info"] = self._reasoning_info_from_usage(response.usage)
 
         events.append(LLMStreamEvent(type="done", metadata=metadata))
         return events

--- a/src/family_assistant/llm/providers/google_genai_client.py
+++ b/src/family_assistant/llm/providers/google_genai_client.py
@@ -1248,6 +1248,13 @@ class GoogleGenAIClient(BaseLLMClient):
                         completion_tokens=getattr(usage, "candidates_token_count", 0),
                         total_tokens=getattr(usage, "total_token_count", 0),
                     )
+                    # Gemini caches implicitly and reports hits as a subset of
+                    # prompt_token_count, so this is not added to the total.
+                    cached_tokens = (
+                        getattr(usage, "cached_content_token_count", None) or 0
+                    )
+                    if cached_tokens:
+                        reasoning_info["cached_prompt_tokens"] = cached_tokens
 
                 # Add thought summaries to reasoning_info for debugging/introspection
                 if thought_summaries:

--- a/src/family_assistant/llm/providers/google_genai_client.py
+++ b/src/family_assistant/llm/providers/google_genai_client.py
@@ -55,6 +55,7 @@ from family_assistant.llm.messages import (
     message_to_json_dict,
 )
 from family_assistant.llm.request_buffer import LLMRequestRecord, get_request_buffer
+from family_assistant.llm.utils.usage_telemetry import set_usage_span_attributes
 from family_assistant.processing.protocol import (
     DelegationPermanentError,
     DelegationTaskNotFoundError,
@@ -1243,18 +1244,7 @@ class GoogleGenAIClient(BaseLLMClient):
                 reasoning_info: MessageReasoningInfo | None = None
                 if hasattr(response, "usage_metadata") and response.usage_metadata:
                     usage = response.usage_metadata
-                    reasoning_info = MessageReasoningInfo(
-                        prompt_tokens=getattr(usage, "prompt_token_count", 0),
-                        completion_tokens=getattr(usage, "candidates_token_count", 0),
-                        total_tokens=getattr(usage, "total_token_count", 0),
-                    )
-                    # Gemini caches implicitly and reports hits as a subset of
-                    # prompt_token_count, so this is not added to the total.
-                    cached_tokens = (
-                        getattr(usage, "cached_content_token_count", None) or 0
-                    )
-                    if cached_tokens:
-                        reasoning_info["cached_prompt_tokens"] = cached_tokens
+                    reasoning_info = self._reasoning_info_from_usage_metadata(usage)
 
                 # Add thought summaries to reasoning_info for debugging/introspection
                 if thought_summaries:
@@ -1288,17 +1278,7 @@ class GoogleGenAIClient(BaseLLMClient):
                 except Exception as record_err:
                     logger.debug(f"Failed to record LLM request: {record_err}")
 
-                if llm_output.reasoning_info:
-                    if "prompt_tokens" in llm_output.reasoning_info:
-                        span.set_attribute(
-                            "gen_ai.usage.input_tokens",
-                            llm_output.reasoning_info["prompt_tokens"],
-                        )
-                    if "completion_tokens" in llm_output.reasoning_info:
-                        span.set_attribute(
-                            "gen_ai.usage.output_tokens",
-                            llm_output.reasoning_info["completion_tokens"],
-                        )
+                set_usage_span_attributes(span, llm_output.reasoning_info)
 
                 return llm_output
 
@@ -1367,6 +1347,29 @@ class GoogleGenAIClient(BaseLLMClient):
             return LLMProviderError(
                 error_message, provider="google", model=self.model_name
             )
+
+    @staticmethod
+    def _reasoning_info_from_usage_metadata(
+        usage: Any,  # noqa: ANN401 - types.GenerateContentResponseUsageMetadata
+    ) -> MessageReasoningInfo:
+        """Build reasoning info from Gemini's `usage_metadata`.
+
+        Gemini caches implicitly and reports hits in `cached_content_token_count`
+        as a *subset* of `prompt_token_count`, so cached tokens are not added to
+        the total the way Anthropic's separate buckets are.
+        """
+        reasoning_info = MessageReasoningInfo(
+            prompt_tokens=getattr(usage, "prompt_token_count", 0) or 0,
+            completion_tokens=getattr(usage, "candidates_token_count", 0) or 0,
+            total_tokens=getattr(usage, "total_token_count", 0) or 0,
+        )
+        cached_tokens = getattr(usage, "cached_content_token_count", None) or 0
+        if cached_tokens:
+            reasoning_info["cached_prompt_tokens"] = cached_tokens
+        thoughts_tokens = getattr(usage, "thoughts_token_count", None) or 0
+        if thoughts_tokens:
+            reasoning_info["reasoning_tokens"] = thoughts_tokens
+        return reasoning_info
 
     @staticmethod
     def _parse_retry_after(error_message: str) -> float | None:
@@ -1960,10 +1963,17 @@ class GoogleGenAIClient(BaseLLMClient):
             accumulated_tool_calls = []
             thought_summaries: list[dict[str, str | int]] = []
             part_index = 0
+            # Gemini reports usage on streaming chunks, with the last one
+            # carrying the final cumulative counts. Keep the newest seen rather
+            # than reading a single chunk, since not every chunk includes it.
+            latest_usage_metadata: Any | None = None
 
             # Process stream chunks
             with trace.use_span(span, end_on_exit=False):
                 async for chunk in stream_response:  # type: ignore[misc]
+                    if getattr(chunk, "usage_metadata", None):
+                        latest_usage_metadata = chunk.usage_metadata
+
                     # Extract text content from chunk
                     if hasattr(chunk, "text") and chunk.text:
                         yield LLMStreamEvent(  # noqa: ASYNC119
@@ -2077,14 +2087,23 @@ class GoogleGenAIClient(BaseLLMClient):
                 )
 
             # Signal completion
-            # Note: Usage metadata might not be available in streaming mode
             done_metadata: StreamEventMetadata = {}
+
+            stream_reasoning_info: MessageReasoningInfo | None = None
+            if latest_usage_metadata is not None:
+                stream_reasoning_info = self._reasoning_info_from_usage_metadata(
+                    latest_usage_metadata
+                )
+                set_usage_span_attributes(span, stream_reasoning_info)
 
             # Add thought summaries to reasoning_info for debugging/introspection
             if thought_summaries:
-                done_metadata["reasoning_info"] = MessageReasoningInfo(
-                    thought_summaries=thought_summaries
-                )
+                if stream_reasoning_info is None:
+                    stream_reasoning_info = MessageReasoningInfo()
+                stream_reasoning_info["thought_summaries"] = thought_summaries
+
+            if stream_reasoning_info is not None:
+                done_metadata["reasoning_info"] = stream_reasoning_info
 
             # Record successful streaming request to diagnostics buffer
             duration_ms = (time.monotonic() - start_time) * 1000

--- a/src/family_assistant/llm/providers/google_genai_client.py
+++ b/src/family_assistant/llm/providers/google_genai_client.py
@@ -1363,11 +1363,13 @@ class GoogleGenAIClient(BaseLLMClient):
             completion_tokens=getattr(usage, "candidates_token_count", 0) or 0,
             total_tokens=getattr(usage, "total_token_count", 0) or 0,
         )
-        cached_tokens = getattr(usage, "cached_content_token_count", None) or 0
-        if cached_tokens:
+        # A reported zero is a known cache miss; only an absent field is left
+        # out, so a miss stays distinguishable from "provider reported nothing".
+        cached_tokens = getattr(usage, "cached_content_token_count", None)
+        if cached_tokens is not None:
             reasoning_info["cached_prompt_tokens"] = cached_tokens
-        thoughts_tokens = getattr(usage, "thoughts_token_count", None) or 0
-        if thoughts_tokens:
+        thoughts_tokens = getattr(usage, "thoughts_token_count", None)
+        if thoughts_tokens is not None:
             reasoning_info["reasoning_tokens"] = thoughts_tokens
         return reasoning_info
 

--- a/src/family_assistant/llm/providers/openai_client.py
+++ b/src/family_assistant/llm/providers/openai_client.py
@@ -310,7 +310,7 @@ class OpenAIClient(BaseLLMClient):
     @staticmethod
     def _cached_prompt_tokens(
         usage: Any,  # noqa: ANN401 - usage arrives as an SDK object or a raw dict
-    ) -> int:
+    ) -> int | None:
         """Extract cache-hit prompt tokens from an OpenAI usage payload.
 
         Caching is automatic on OpenAI, and the hit count lives under
@@ -318,6 +318,10 @@ class OpenAIClient(BaseLLMClient):
         (Responses). Unlike Anthropic, these are a *subset* of the reported
         prompt total, not a separate bucket to add on top. There is no
         cache-write counterpart.
+
+        Returns `None` only when the payload carries no cache field at all. A
+        reported zero comes back as `0`, so a known cache miss stays
+        distinguishable from a payload that says nothing about caching.
         """
         for field in ("prompt_tokens_details", "input_tokens_details"):
             details = (
@@ -332,9 +336,9 @@ class OpenAIClient(BaseLLMClient):
                 if isinstance(details, dict)
                 else getattr(details, "cached_tokens", None)
             )
-            if cached:
+            if cached is not None:
                 return int(cached)
-        return 0
+        return None
 
     @staticmethod
     def _responses_reasoning_info(response: Response) -> MessageReasoningInfo | None:
@@ -351,7 +355,7 @@ class OpenAIClient(BaseLLMClient):
         if details and getattr(details, "reasoning_tokens", None) is not None:
             reasoning_info["reasoning_tokens"] = details.reasoning_tokens
         cached = OpenAIClient._cached_prompt_tokens(usage)
-        if cached:
+        if cached is not None:
             reasoning_info["cached_prompt_tokens"] = cached
         return reasoning_info
 
@@ -517,7 +521,7 @@ class OpenAIClient(BaseLLMClient):
                         reasoning_info["reasoning_tokens"] = details.reasoning_tokens
 
                 cached = self._cached_prompt_tokens(response.usage)
-                if cached:
+                if cached is not None:
                     reasoning_info["cached_prompt_tokens"] = cached
 
             llm_output = LLMOutput(
@@ -950,7 +954,7 @@ class OpenAIClient(BaseLLMClient):
                     total_tokens=stream_usage.total_tokens,
                 )
                 cached = self._cached_prompt_tokens(stream_usage)
-                if cached:
+                if cached is not None:
                     stream_reasoning_info["cached_prompt_tokens"] = cached
                 metadata["reasoning_info"] = stream_reasoning_info
 
@@ -1145,7 +1149,7 @@ class OpenAIClient(BaseLLMClient):
                             total_tokens=int(usage.get("total_tokens", 0)),
                         )
                         cached = self._cached_prompt_tokens(usage)
-                        if cached:
+                        if cached is not None:
                             responses_reasoning_info["cached_prompt_tokens"] = cached
                         metadata["reasoning_info"] = responses_reasoning_info
                     output = response.get("output")
@@ -1318,7 +1322,7 @@ class OpenAIClient(BaseLLMClient):
                 total_tokens=usage.get("total_tokens", 0),
             )
             cached = self._cached_prompt_tokens(usage)
-            if cached:
+            if cached is not None:
                 replay_reasoning_info["cached_prompt_tokens"] = cached
             metadata["reasoning_info"] = replay_reasoning_info
 

--- a/src/family_assistant/llm/providers/openai_client.py
+++ b/src/family_assistant/llm/providers/openai_client.py
@@ -308,6 +308,35 @@ class OpenAIClient(BaseLLMClient):
         return input_items
 
     @staticmethod
+    def _cached_prompt_tokens(
+        usage: Any,  # noqa: ANN401 - usage arrives as an SDK object or a raw dict
+    ) -> int:
+        """Extract cache-hit prompt tokens from an OpenAI usage payload.
+
+        Caching is automatic on OpenAI, and the hit count lives under
+        `prompt_tokens_details` (Chat Completions) or `input_tokens_details`
+        (Responses). Unlike Anthropic, these are a *subset* of the reported
+        prompt total, not a separate bucket to add on top. There is no
+        cache-write counterpart.
+        """
+        for field in ("prompt_tokens_details", "input_tokens_details"):
+            details = (
+                usage.get(field)
+                if isinstance(usage, dict)
+                else getattr(usage, field, None)
+            )
+            if details is None:
+                continue
+            cached = (
+                details.get("cached_tokens")
+                if isinstance(details, dict)
+                else getattr(details, "cached_tokens", None)
+            )
+            if cached:
+                return int(cached)
+        return 0
+
+    @staticmethod
     def _responses_reasoning_info(response: Response) -> MessageReasoningInfo | None:
         """Extract usage information from a Responses API response."""
         usage = getattr(response, "usage", None)
@@ -321,6 +350,9 @@ class OpenAIClient(BaseLLMClient):
         details = getattr(usage, "output_tokens_details", None)
         if details and getattr(details, "reasoning_tokens", None) is not None:
             reasoning_info["reasoning_tokens"] = details.reasoning_tokens
+        cached = OpenAIClient._cached_prompt_tokens(usage)
+        if cached:
+            reasoning_info["cached_prompt_tokens"] = cached
         return reasoning_info
 
     @staticmethod
@@ -483,6 +515,10 @@ class OpenAIClient(BaseLLMClient):
                     details = response.usage.completion_tokens_details
                     if details and hasattr(details, "reasoning_tokens"):
                         reasoning_info["reasoning_tokens"] = details.reasoning_tokens
+
+                cached = self._cached_prompt_tokens(response.usage)
+                if cached:
+                    reasoning_info["cached_prompt_tokens"] = cached
 
             llm_output = LLMOutput(
                 content=content,
@@ -892,11 +928,16 @@ class OpenAIClient(BaseLLMClient):
                 and hasattr(last_chunk_with_usage, "usage")
                 and last_chunk_with_usage.usage
             ):
-                metadata["reasoning_info"] = MessageReasoningInfo(
-                    prompt_tokens=last_chunk_with_usage.usage.prompt_tokens,
-                    completion_tokens=last_chunk_with_usage.usage.completion_tokens,
-                    total_tokens=last_chunk_with_usage.usage.total_tokens,
+                stream_usage = last_chunk_with_usage.usage
+                stream_reasoning_info = MessageReasoningInfo(
+                    prompt_tokens=stream_usage.prompt_tokens,
+                    completion_tokens=stream_usage.completion_tokens,
+                    total_tokens=stream_usage.total_tokens,
                 )
+                cached = self._cached_prompt_tokens(stream_usage)
+                if cached:
+                    stream_reasoning_info["cached_prompt_tokens"] = cached
+                metadata["reasoning_info"] = stream_reasoning_info
 
             # Record successful streaming request to diagnostics buffer
             duration_ms = (time.monotonic() - start_time) * 1000
@@ -1083,11 +1124,15 @@ class OpenAIClient(BaseLLMClient):
                 if isinstance(response, dict):
                     usage = response.get("usage")
                     if isinstance(usage, dict):
-                        metadata["reasoning_info"] = MessageReasoningInfo(
+                        responses_reasoning_info = MessageReasoningInfo(
                             prompt_tokens=int(usage.get("input_tokens", 0)),
                             completion_tokens=int(usage.get("output_tokens", 0)),
                             total_tokens=int(usage.get("total_tokens", 0)),
                         )
+                        cached = self._cached_prompt_tokens(usage)
+                        if cached:
+                            responses_reasoning_info["cached_prompt_tokens"] = cached
+                        metadata["reasoning_info"] = responses_reasoning_info
                     output = response.get("output")
                     if isinstance(output, list):
                         metadata["provider_metadata"] = {
@@ -1252,10 +1297,14 @@ class OpenAIClient(BaseLLMClient):
         metadata: StreamEventMetadata = {}
         if last_chunk_with_usage:
             usage = last_chunk_with_usage.get("usage") or {}
-            metadata["reasoning_info"] = MessageReasoningInfo(
+            replay_reasoning_info = MessageReasoningInfo(
                 prompt_tokens=usage.get("prompt_tokens", 0),
                 completion_tokens=usage.get("completion_tokens", 0),
                 total_tokens=usage.get("total_tokens", 0),
             )
+            cached = self._cached_prompt_tokens(usage)
+            if cached:
+                replay_reasoning_info["cached_prompt_tokens"] = cached
+            metadata["reasoning_info"] = replay_reasoning_info
 
         yield LLMStreamEvent(type="done", metadata=metadata)

--- a/src/family_assistant/llm/providers/openai_client.py
+++ b/src/family_assistant/llm/providers/openai_client.py
@@ -832,6 +832,18 @@ class OpenAIClient(BaseLLMClient):
                 "model": self.model,
                 "messages": api_message_dicts,
                 "stream": True,  # Enable streaming
+                # Streaming responses carry no usage unless it is requested, so
+                # without this the whole turn reports no tokens at all -- prompt
+                # cache hits included. Only sent to the official API: an
+                # OpenAI-compatible endpoint that rejects unknown parameters
+                # would fail the request outright. Operators whose endpoint does
+                # support it can opt in through model_parameters, since those
+                # are merged below and win over this default.
+                **(
+                    {"stream_options": {"include_usage": True}}
+                    if self._is_direct_openai
+                    else {}
+                ),
                 **self.default_kwargs,
                 **self._get_model_specific_params(self.model),
             }
@@ -859,14 +871,17 @@ class OpenAIClient(BaseLLMClient):
             last_chunk_with_usage: Any | None = None
 
             async for chunk in stream:
+                # The usage chunk arrives last and carries an empty `choices`
+                # list, so it has to be captured before the guards below skip it.
+                if chunk is not None and getattr(chunk, "usage", None):
+                    last_chunk_with_usage = chunk
+
                 if not chunk or not hasattr(chunk, "choices") or not chunk.choices:
                     continue
 
                 delta = chunk.choices[0].delta
                 if not delta:
                     continue
-
-                last_chunk_with_usage = chunk
 
                 # Handle content
                 if delta.content:

--- a/src/family_assistant/llm/providers/openai_client.py
+++ b/src/family_assistant/llm/providers/openai_client.py
@@ -308,37 +308,61 @@ class OpenAIClient(BaseLLMClient):
         return input_items
 
     @staticmethod
-    def _cached_prompt_tokens(
+    def _usage_detail_tokens(
         usage: Any,  # noqa: ANN401 - usage arrives as an SDK object or a raw dict
+        field: str,
     ) -> int | None:
-        """Extract cache-hit prompt tokens from an OpenAI usage payload.
+        """Read a token count out of an OpenAI usage payload's details block.
 
-        Caching is automatic on OpenAI, and the hit count lives under
-        `prompt_tokens_details` (Chat Completions) or `input_tokens_details`
-        (Responses). Unlike Anthropic, these are a *subset* of the reported
-        prompt total, not a separate bucket to add on top. There is no
-        cache-write counterpart.
+        The block is `prompt_tokens_details` on Chat Completions and
+        `input_tokens_details` on Responses. Both SDK objects and raw dicts turn
+        up here: the Responses streaming path and VCR replay hand back parsed
+        JSON rather than typed models, and some fields (`cache_write_tokens`) are
+        present in API responses but not modelled by the pinned SDK, so they are
+        only reachable by name.
 
-        Returns `None` only when the payload carries no cache field at all. A
-        reported zero comes back as `0`, so a known cache miss stays
-        distinguishable from a payload that says nothing about caching.
+        Returns `None` only when the field is absent everywhere. A reported zero
+        comes back as `0`, so a known miss stays distinguishable from a payload
+        that says nothing.
         """
-        for field in ("prompt_tokens_details", "input_tokens_details"):
+        for block in ("prompt_tokens_details", "input_tokens_details"):
             details = (
-                usage.get(field)
+                usage.get(block)
                 if isinstance(usage, dict)
-                else getattr(usage, field, None)
+                else getattr(usage, block, None)
             )
             if details is None:
                 continue
-            cached = (
-                details.get("cached_tokens")
+            value = (
+                details.get(field)
                 if isinstance(details, dict)
-                else getattr(details, "cached_tokens", None)
+                else getattr(details, field, None)
             )
-            if cached is not None:
-                return int(cached)
+            if value is not None:
+                return int(value)
         return None
+
+    @classmethod
+    def _cached_prompt_tokens(
+        cls,
+        usage: Any,  # noqa: ANN401 - usage arrives as an SDK object or a raw dict
+    ) -> int | None:
+        """Cache-hit prompt tokens. A *subset* of the reported prompt total,
+        unlike Anthropic's separate bucket, so it is never added to the total."""
+        return cls._usage_detail_tokens(usage, "cached_tokens")
+
+    @classmethod
+    def _cache_write_tokens(
+        cls,
+        usage: Any,  # noqa: ANN401 - usage arrives as an SDK object or a raw dict
+    ) -> int | None:
+        """Cache-write tokens, reported by the Responses API.
+
+        Chat Completions does not report this; Responses does, even though the
+        pinned SDK does not type it. Also a subset of the prompt total rather
+        than an extra bucket.
+        """
+        return cls._usage_detail_tokens(usage, "cache_write_tokens")
 
     @staticmethod
     def _responses_reasoning_info(response: Response) -> MessageReasoningInfo | None:
@@ -357,6 +381,9 @@ class OpenAIClient(BaseLLMClient):
         cached = OpenAIClient._cached_prompt_tokens(usage)
         if cached is not None:
             reasoning_info["cached_prompt_tokens"] = cached
+        cache_write = OpenAIClient._cache_write_tokens(usage)
+        if cache_write is not None:
+            reasoning_info["cache_write_tokens"] = cache_write
         return reasoning_info
 
     @staticmethod
@@ -523,6 +550,9 @@ class OpenAIClient(BaseLLMClient):
                 cached = self._cached_prompt_tokens(response.usage)
                 if cached is not None:
                     reasoning_info["cached_prompt_tokens"] = cached
+                cache_write = self._cache_write_tokens(response.usage)
+                if cache_write is not None:
+                    reasoning_info["cache_write_tokens"] = cache_write
 
             llm_output = LLMOutput(
                 content=content,
@@ -956,6 +986,18 @@ class OpenAIClient(BaseLLMClient):
                 cached = self._cached_prompt_tokens(stream_usage)
                 if cached is not None:
                     stream_reasoning_info["cached_prompt_tokens"] = cached
+                cache_write = self._cache_write_tokens(stream_usage)
+                if cache_write is not None:
+                    stream_reasoning_info["cache_write_tokens"] = cache_write
+                # Mirror the non-streaming path: reasoning models report this
+                # under completion_tokens_details, and enabling include_usage is
+                # what makes it reachable on a streamed turn at all.
+                completion_details = getattr(
+                    stream_usage, "completion_tokens_details", None
+                )
+                reasoning_tokens = getattr(completion_details, "reasoning_tokens", None)
+                if reasoning_tokens is not None:
+                    stream_reasoning_info["reasoning_tokens"] = reasoning_tokens
                 metadata["reasoning_info"] = stream_reasoning_info
 
             # Record successful streaming request to diagnostics buffer
@@ -1151,6 +1193,9 @@ class OpenAIClient(BaseLLMClient):
                         cached = self._cached_prompt_tokens(usage)
                         if cached is not None:
                             responses_reasoning_info["cached_prompt_tokens"] = cached
+                        cache_write = self._cache_write_tokens(usage)
+                        if cache_write is not None:
+                            responses_reasoning_info["cache_write_tokens"] = cache_write
                         metadata["reasoning_info"] = responses_reasoning_info
                     output = response.get("output")
                     if isinstance(output, list):
@@ -1253,6 +1298,12 @@ class OpenAIClient(BaseLLMClient):
         last_chunk_with_usage: dict[str, Any] | None = None
 
         for chunk in chunk_dicts:
+            # The terminal usage chunk carries an empty `choices` list, so it has
+            # to be captured before the guard below skips it -- same shape as the
+            # live-stream path.
+            if chunk.get("usage"):
+                last_chunk_with_usage = chunk
+
             choices = chunk.get("choices") or []
             if not choices or not isinstance(choices, list):
                 continue
@@ -1293,9 +1344,6 @@ class OpenAIClient(BaseLLMClient):
                 if func_args:
                     tc_data["function"]["arguments"] += func_args
 
-            if chunk.get("usage"):
-                last_chunk_with_usage = chunk
-
         for tc_data in current_tool_calls.values():
             tc_id = tc_data["id"]
             if tc_data["function"]["name"] and tc_id:
@@ -1324,6 +1372,9 @@ class OpenAIClient(BaseLLMClient):
             cached = self._cached_prompt_tokens(usage)
             if cached is not None:
                 replay_reasoning_info["cached_prompt_tokens"] = cached
+            cache_write = self._cache_write_tokens(usage)
+            if cache_write is not None:
+                replay_reasoning_info["cache_write_tokens"] = cache_write
             metadata["reasoning_info"] = replay_reasoning_info
 
         yield LLMStreamEvent(type="done", metadata=metadata)

--- a/src/family_assistant/llm/retrying_client.py
+++ b/src/family_assistant/llm/retrying_client.py
@@ -38,6 +38,20 @@ from .base import (
 from .messages import UserMessage
 from .utils.usage_telemetry import set_usage_span_attributes
 
+
+def _record_stream_usage(span: trace.Span, event: LLMStreamEvent) -> None:
+    """Export usage from a stream's terminal event onto the retry span.
+
+    Providers report streaming usage in the `done` event's metadata rather than
+    on a span of their own -- the OpenAI client has no span at all -- so doing it
+    here is what makes `gen_ai.usage.*` present for every provider instead of
+    only the ones that happen to instrument themselves.
+    """
+    if event.type != "done" or not event.metadata:
+        return
+    set_usage_span_attributes(span, event.metadata.get("reasoning_info"))
+
+
 T = TypeVar("T", bound=BaseModel)
 R = TypeVar("R")
 
@@ -279,6 +293,7 @@ class RetryingLLMClient:
                         tool_choice=tool_choice,
                     ):
                         with trace.use_span(span, end_on_exit=False):
+                            _record_stream_usage(span, event)
                             yield event  # noqa: ASYNC119
                         events_yielded = True
                 except Exception as e:
@@ -317,6 +332,7 @@ class RetryingLLMClient:
                                 ):
                                     events_yielded = True
                                     with trace.use_span(span, end_on_exit=False):
+                                        _record_stream_usage(span, event)
                                         yield event  # noqa: ASYNC119
                                 return
                             except Exception as retry_err:
@@ -366,6 +382,7 @@ class RetryingLLMClient:
                                     tool_choice=tool_choice,
                                 ):
                                     with trace.use_span(span, end_on_exit=False):
+                                        _record_stream_usage(span, event)
                                         yield event  # noqa: ASYNC119
                             except Exception as fallback_error:
                                 logger.error(

--- a/src/family_assistant/llm/retrying_client.py
+++ b/src/family_assistant/llm/retrying_client.py
@@ -36,6 +36,7 @@ from .base import (
     ServiceUnavailableError,
 )
 from .messages import UserMessage
+from .utils.usage_telemetry import set_usage_span_attributes
 
 T = TypeVar("T", bound=BaseModel)
 R = TypeVar("R")
@@ -120,17 +121,7 @@ class RetryingLLMClient:
                     tool_choice=tool_choice,
                 )
                 span.set_attribute("gen_ai.response.model", self.primary_model)
-                if result.reasoning_info:
-                    if "prompt_tokens" in result.reasoning_info:
-                        span.set_attribute(
-                            "gen_ai.usage.input_tokens",
-                            result.reasoning_info["prompt_tokens"],
-                        )
-                    if "completion_tokens" in result.reasoning_info:
-                        span.set_attribute(
-                            "gen_ai.usage.output_tokens",
-                            result.reasoning_info["completion_tokens"],
-                        )
+                set_usage_span_attributes(span, result.reasoning_info)
                 return result
             except retriable_errors as e:
                 logger.warning(
@@ -171,17 +162,7 @@ class RetryingLLMClient:
                         tool_choice=tool_choice,
                     )
                     span.set_attribute("gen_ai.response.model", self.primary_model)
-                    if result.reasoning_info:
-                        if "prompt_tokens" in result.reasoning_info:
-                            span.set_attribute(
-                                "gen_ai.usage.input_tokens",
-                                result.reasoning_info["prompt_tokens"],
-                            )
-                        if "completion_tokens" in result.reasoning_info:
-                            span.set_attribute(
-                                "gen_ai.usage.output_tokens",
-                                result.reasoning_info["completion_tokens"],
-                            )
+                    set_usage_span_attributes(span, result.reasoning_info)
                     return result
                 except retriable_errors as e:
                     logger.warning(
@@ -237,17 +218,7 @@ class RetryingLLMClient:
                     span.set_attribute(
                         "gen_ai.response.model", self.fallback_model or ""
                     )
-                    if result.reasoning_info:
-                        if "prompt_tokens" in result.reasoning_info:
-                            span.set_attribute(
-                                "gen_ai.usage.input_tokens",
-                                result.reasoning_info["prompt_tokens"],
-                            )
-                        if "completion_tokens" in result.reasoning_info:
-                            span.set_attribute(
-                                "gen_ai.usage.output_tokens",
-                                result.reasoning_info["completion_tokens"],
-                            )
+                    set_usage_span_attributes(span, result.reasoning_info)
                     return result
                 except Exception as e:
                     logger.error(

--- a/src/family_assistant/llm/utils/usage_telemetry.py
+++ b/src/family_assistant/llm/utils/usage_telemetry.py
@@ -1,0 +1,38 @@
+"""Span attributes for LLM token usage, including prompt-cache accounting."""
+
+from opentelemetry.trace import Span
+
+from family_assistant.llm.messages import MessageReasoningInfo
+
+__all__ = ["set_usage_span_attributes"]
+
+
+def set_usage_span_attributes(
+    span: Span,
+    reasoning_info: MessageReasoningInfo | None,
+) -> None:
+    """Record token usage from *reasoning_info* onto *span*.
+
+    Cache attributes are only set when the provider reported them, so their
+    absence on a span means "not reported" rather than "zero" -- a distinction
+    that matters when the provider or model silently does not cache.
+    """
+    if not reasoning_info:
+        return
+
+    if "prompt_tokens" in reasoning_info:
+        span.set_attribute("gen_ai.usage.input_tokens", reasoning_info["prompt_tokens"])
+    if "completion_tokens" in reasoning_info:
+        span.set_attribute(
+            "gen_ai.usage.output_tokens", reasoning_info["completion_tokens"]
+        )
+    if "cached_prompt_tokens" in reasoning_info:
+        span.set_attribute(
+            "gen_ai.usage.cached_input_tokens",
+            reasoning_info["cached_prompt_tokens"],
+        )
+    if "cache_write_tokens" in reasoning_info:
+        span.set_attribute(
+            "gen_ai.usage.cache_write_input_tokens",
+            reasoning_info["cache_write_tokens"],
+        )

--- a/src/family_assistant/processing/deep_research_service.py
+++ b/src/family_assistant/processing/deep_research_service.py
@@ -94,13 +94,17 @@ class DeepResearchProcessingService(ProcessingService):
         in the background.
         """
         _ = initial_taint_sources
-        system_prompt = self._render_system_prompt(
+        system_prompt, stable_prefix_len = self._render_system_prompt(
             user_name=user_name, aggregated_other_context_str=""
         )
         user_text = self._extract_user_content_for_history(content_parts)
         messages: list[LLMMessage] = []
         if system_prompt:
-            messages.append(SystemMessage(content=system_prompt))
+            messages.append(
+                SystemMessage(
+                    content=system_prompt, stable_prefix_len=stable_prefix_len
+                )
+            )
         messages.append(UserMessage(content=user_text))
 
         previous_interaction_id: str | None = None

--- a/src/family_assistant/processing/llm_loop.py
+++ b/src/family_assistant/processing/llm_loop.py
@@ -267,7 +267,11 @@ class LLMStreamingLoop:
         pending_attachment_ids: list[
             str
         ] = []  # Track attachment IDs from attach_to_response calls
-        original_system_content: str | None = None  # Store original system prompt
+        # The system prompt as it arrived, before any on-demand tool additions.
+        original_system_message: SystemMessage | None = None
+        # The addition currently baked into messages[0], so the system prompt is
+        # rebuilt only when it actually changes rather than on every iteration.
+        applied_system_prompt_addition: str | None = None
 
         can_confirm = request_confirmation_callback is not None
 
@@ -353,40 +357,49 @@ class LLMStreamingLoop:
             # If so, we cannot modify the system prompt as it would invalidate signatures.
             has_thought_signatures = messages_have_thought_signatures(messages)
 
-            # Add iteration context to system prompt ONLY if no thought signatures present
-            # Thought signatures are cryptographically tied to the exact conversation context
-            if messages and messages[0].role == "system" and not has_thought_signatures:
-                # Store original system content on first iteration
-                if original_system_content is None:
-                    original_system_content = str(messages[0].content)
+            # Fold on-demand tool additions into the system prompt, but only when
+            # they have actually changed. The system prompt renders at the front of
+            # the prompt prefix, so rewriting it per iteration -- as this loop used
+            # to do to append an iteration counter -- invalidated the provider
+            # prompt cache on every tool call, re-reading the whole prompt and every
+            # accumulated tool result at full price. On-demand activation already
+            # changes the tool list (which invalidates the prefix regardless), so
+            # rebuilding here costs nothing extra.
+            #
+            # Thought signatures are cryptographically tied to the exact conversation
+            # context, so the system prompt is left completely alone when present.
+            if (
+                messages
+                and isinstance(messages[0], SystemMessage)
+                and not has_thought_signatures
+                and applied_system_prompt_addition != system_prompt_addition
+            ):
+                if original_system_message is None:
+                    original_system_message = messages[0]
 
-                # Add iteration status to system prompt
-                iteration_suffix = (
-                    f"\n\n[Processing iteration {current_iteration}/{max_iterations}]"
-                )
-                if is_final_iteration:
-                    iteration_suffix += "\nIMPORTANT: This is the final iteration. You MUST provide your final response now without requesting additional tools."
-
-                # Build system prompt: original + provider additions + iteration suffix
-                system_content = original_system_content
+                system_content = original_system_message.content
                 if system_prompt_addition:
                     system_content += "\n\n" + system_prompt_addition
-                system_content += iteration_suffix
 
-                # Create new message with modified content (Pydantic models are immutable)
-                messages[0] = SystemMessage(content=system_content)
-            elif is_final_iteration and has_thought_signatures:
-                # Add final iteration instruction as a user message rather than modifying
-                # the system prompt. This approach works reliably regardless of whether
-                # thought signatures are present.
-                final_iteration_instruction = UserMessage(
-                    content=(
-                        "[SYSTEM: This is the final processing iteration. Tools are no longer available. "
-                        "You MUST now provide your final response summarizing your findings and conclusions. "
-                        "Do NOT output raw JSON or tool call arguments - provide a natural language response to the user.]"
+                # model_copy preserves stable_prefix_len, which points into the
+                # original content and stays valid when text is appended after it.
+                messages[0] = original_system_message.model_copy(
+                    update={"content": system_content}
+                )
+                applied_system_prompt_addition = system_prompt_addition
+
+            if is_final_iteration:
+                # Delivered as a trailing user message rather than a system-prompt
+                # edit so the cached prefix survives the final iteration too.
+                messages.append(
+                    UserMessage(
+                        content=(
+                            "[SYSTEM: This is the final processing iteration. Tools are no longer available. "
+                            "You MUST now provide your final response summarizing your findings and conclusions. "
+                            "Do NOT output raw JSON or tool call arguments - provide a natural language response to the user.]"
+                        )
                     )
                 )
-                messages.append(final_iteration_instruction)
                 logger.info("Added final iteration instruction as user message")
 
             # On final iteration, don't offer any tools to ensure we get a response

--- a/src/family_assistant/processing/llm_loop.py
+++ b/src/family_assistant/processing/llm_loop.py
@@ -489,10 +489,21 @@ class LLMStreamingLoop:
                     logger.warning(
                         f"Context length exceeded, pruning messages and retrying: {e}"
                     )
+                    # Prune without the synthetic final-iteration instruction.
+                    # The turn splitter starts a new turn at every UserMessage, so
+                    # leaving it in costs a real turn out of min_turns -- and at
+                    # min_turns=1 it is the *only* turn kept, discarding the
+                    # user's request and every accumulated tool result.
                     messages = prune_messages_for_context(
-                        messages,
+                        [
+                            msg
+                            for msg in messages
+                            if msg is not final_iteration_instruction
+                        ],
                         min_turns=self.config.context_pruning_min_turns,
                     )
+                    if final_iteration_instruction is not None:
+                        messages.append(final_iteration_instruction)
                     context_retry_attempted = True
                     continue
 

--- a/src/family_assistant/processing/llm_loop.py
+++ b/src/family_assistant/processing/llm_loop.py
@@ -272,6 +272,8 @@ class LLMStreamingLoop:
         # The addition currently baked into messages[0], so the system prompt is
         # rebuilt only when it actually changes rather than on every iteration.
         applied_system_prompt_addition: str | None = None
+        # The synthetic final-iteration instruction, once appended.
+        final_iteration_instruction: UserMessage | None = None
 
         can_confirm = request_confirmation_callback is not None
 
@@ -391,15 +393,16 @@ class LLMStreamingLoop:
             if is_final_iteration:
                 # Delivered as a trailing user message rather than a system-prompt
                 # edit so the cached prefix survives the final iteration too.
-                messages.append(
-                    UserMessage(
-                        content=(
-                            "[SYSTEM: This is the final processing iteration. Tools are no longer available. "
-                            "You MUST now provide your final response summarizing your findings and conclusions. "
-                            "Do NOT output raw JSON or tool call arguments - provide a natural language response to the user.]"
-                        )
+                # Kept on hand so downstream scans for the user's actual request
+                # can skip it -- it is scaffolding, not something the user said.
+                final_iteration_instruction = UserMessage(
+                    content=(
+                        "[SYSTEM: This is the final processing iteration. Tools are no longer available. "
+                        "You MUST now provide your final response summarizing your findings and conclusions. "
+                        "Do NOT output raw JSON or tool call arguments - provide a natural language response to the user.]"
                     )
                 )
+                messages.append(final_iteration_instruction)
                 logger.info("Added final iteration instruction as user message")
 
             # On final iteration, don't offer any tools to ensure we get a response
@@ -554,6 +557,12 @@ class LLMStreamingLoop:
                 # Extract original user query from messages (most recent first)
                 original_query = ""
                 for msg in reversed(messages):
+                    # Skip our own final-iteration scaffolding: it is the newest
+                    # user message on the last iteration, and selecting
+                    # attachments against it would match the boilerplate rather
+                    # than what the user actually asked for.
+                    if msg is final_iteration_instruction:
+                        continue
                     if isinstance(msg, UserMessage):
                         if isinstance(msg.content, str):
                             original_query = msg.content

--- a/src/family_assistant/processing/service.py
+++ b/src/family_assistant/processing/service.py
@@ -69,6 +69,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
+# Sentinel substituted for per-turn system prompt inputs when locating the
+# prompt's stable prefix. Chosen so it cannot share a leading character with a
+# real timestamp or context block, which would hide the boundary.
+_VOLATILE_PROBE = "\x00\x00per-turn-probe\x00\x00"
+
+
+def _common_prefix_len(left: str, right: str) -> int | None:
+    """Length of the longest common prefix of two strings, or None if empty."""
+    limit = min(len(left), len(right))
+    index = 0
+    while index < limit and left[index] == right[index]:
+        index += 1
+    return index or None
+
 
 def _taint_metadata_from_sources(
     sources: Sequence[TaintSource] | None,
@@ -393,19 +407,54 @@ class ProcessingService:
 
     def _render_system_prompt(
         self, user_name: str, aggregated_other_context_str: str
-    ) -> str:
-        """Render a system prompt with strict placeholder validation."""
-        system_prompt_template = self.service_config.prompts.get(
-            "system_prompt",
-            "You are a helpful assistant. Current time is {current_time}.",
+    ) -> tuple[str, int | None]:
+        """Render a system prompt and locate its request-stable prefix.
+
+        Returns the rendered prompt plus the length of the leading run that does
+        not depend on per-turn inputs (see ``SystemMessage.stable_prefix_len``),
+        or ``None`` if no such boundary exists.
+
+        The boundary is found by rendering a second time with sentinel values for
+        the per-turn inputs and taking the common prefix: whatever two renderings
+        that differ only in those inputs still share is, by construction,
+        independent of them. Deriving it this way keeps it correct for
+        operator-edited templates, which may place the placeholders anywhere or
+        omit them entirely.
+        """
+        rendered = self._format_system_prompt(
+            user_name=user_name,
+            current_time_str=self._current_time_str(),
+            aggregated_other_context_str=aggregated_other_context_str,
         )
-        system_prompt_docs = self.service_config.prompts.get("system_prompt_docs", "")
-        current_time_str = (
+        probe = self._format_system_prompt(
+            user_name=user_name,
+            current_time_str=_VOLATILE_PROBE,
+            aggregated_other_context_str=_VOLATILE_PROBE,
+        )
+        stable_prefix_len = _common_prefix_len(rendered, probe)
+        return rendered, stable_prefix_len
+
+    def _current_time_str(self) -> str:
+        return (
             self.clock
             .now()
             .astimezone(self.service_config.timezone)
             .strftime("%Y-%m-%d %H:%M:%S %Z")
         )
+
+    def _format_system_prompt(
+        self,
+        *,
+        user_name: str,
+        current_time_str: str,
+        aggregated_other_context_str: str,
+    ) -> str:
+        """Render the system prompt template with strict placeholder validation."""
+        system_prompt_template = self.service_config.prompts.get(
+            "system_prompt",
+            "You are a helpful assistant. Current time is {current_time}.",
+        )
+        system_prompt_docs = self.service_config.prompts.get("system_prompt_docs", "")
         format_args = {
             "user_name": user_name,
             "current_time": current_time_str,
@@ -732,17 +781,30 @@ class ProcessingService:
             else:
                 aggregated_other_context_str = thread_attachments_context
 
-        final_system_prompt = self._render_system_prompt(
+        final_system_prompt, stable_prefix_len = self._render_system_prompt(
             user_name=user_name,
             aggregated_other_context_str=aggregated_other_context_str,
         )
         delegation_addition = await self.delegation_catalog_addition()
         if delegation_addition:
-            final_system_prompt = (
-                f"{final_system_prompt}\n\n{delegation_addition}".strip()
-            )
+            # Appended after the per-turn context, so it lands past the stable
+            # prefix. Guard the offset anyway: a misplaced breakpoint would put
+            # per-turn text inside the cached block, which fails silently as a
+            # cache that only ever writes and never reads.
+            combined = f"{final_system_prompt}\n\n{delegation_addition}".strip()
+            if stable_prefix_len is not None and not combined.startswith(
+                final_system_prompt[:stable_prefix_len]
+            ):
+                stable_prefix_len = None
+            final_system_prompt = combined
         if final_system_prompt:
-            messages_for_llm.insert(0, SystemMessage(content=final_system_prompt))
+            messages_for_llm.insert(
+                0,
+                SystemMessage(
+                    content=final_system_prompt,
+                    stable_prefix_len=stable_prefix_len,
+                ),
+            )
 
         attachment_injection_messages = (
             await self.attachment_processor.process_content_parts(

--- a/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_multiturn_conversation_non_streaming_preserves_thought_signatures[postgres]/mldev.json
+++ b/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_multiturn_conversation_non_streaming_preserves_thought_signatures[postgres]/mldev.json
@@ -17,7 +17,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -265,7 +265,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -530,7 +530,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"

--- a/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_multiturn_conversation_non_streaming_preserves_thought_signatures[sqlite]/mldev.json
+++ b/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_multiturn_conversation_non_streaming_preserves_thought_signatures[sqlite]/mldev.json
@@ -17,7 +17,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -265,7 +265,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -602,7 +602,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"

--- a/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_multiturn_conversation_with_tool_calls_preserves_thought_signatures[postgres]/mldev.json
+++ b/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_multiturn_conversation_with_tool_calls_preserves_thought_signatures[postgres]/mldev.json
@@ -17,7 +17,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -265,7 +265,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -530,7 +530,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -778,7 +778,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"

--- a/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_multiturn_conversation_with_tool_calls_preserves_thought_signatures[sqlite]/mldev.json
+++ b/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_multiturn_conversation_with_tool_calls_preserves_thought_signatures[sqlite]/mldev.json
@@ -17,7 +17,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -265,7 +265,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -602,7 +602,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -850,7 +850,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"

--- a/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_streaming_multiturn_with_tool_calls_reproduces_bug[postgres]/mldev.json
+++ b/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_streaming_multiturn_with_tool_calls_reproduces_bug[postgres]/mldev.json
@@ -17,7 +17,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -265,7 +265,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"

--- a/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_streaming_multiturn_with_tool_calls_reproduces_bug[sqlite]/mldev.json
+++ b/tests/cassettes/gemini/functional.web.api.test_thought_signature_persistence/test_streaming_multiturn_with_tool_calls_reproduces_bug[sqlite]/mldev.json
@@ -17,7 +17,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"
@@ -265,7 +265,7 @@
               {
                 "parts": [
                   {
-                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant.\n\n[Processing iteration 1/5]"
+                    "text": "System: [Active Processing Profile: test]\nThe user has explicitly selected the \"test\" processing profile.\nYour available tools and capabilities are specific to this profile. Do not attempt actions outside your profile's scope.\n\nYou are a helpful assistant."
                   }
                 ],
                 "role": "user"

--- a/tests/functional/home_assistant/test_camera_tool.py
+++ b/tests/functional/home_assistant/test_camera_tool.py
@@ -285,9 +285,15 @@ async def test_get_camera_snapshot_list_cameras(
 
     # --- LLM Rules ---
     def list_cameras_matcher(kwargs: MatcherArgs) -> bool:
-        last_text = get_last_message_text(kwargs.get("messages", [])).lower()
+        messages = kwargs.get("messages", [])
+        last_text = get_last_message_text(messages).lower()
+        # Gate on the user turn: the tool result also says "Available cameras",
+        # so without this the initial call matches again on the next iteration
+        # and the loop spins until it runs out of iterations.
         return (
-            "cameras" in last_text
+            bool(messages)
+            and messages[-1].role == "user"
+            and "cameras" in last_text
             and "available" in last_text
             and kwargs.get("tools") is not None
         )

--- a/tests/functional/home_assistant/test_list_entities_tool.py
+++ b/tests/functional/home_assistant/test_list_entities_tool.py
@@ -255,8 +255,17 @@ async def test_list_home_assistant_entities_with_area_filter(
 
     # --- LLM Rules ---
     def area_filter_matcher(kwargs: MatcherArgs) -> bool:
-        last_text = get_last_message_text(kwargs.get("messages", [])).lower()
-        return "pool" in last_text and kwargs.get("tools") is not None
+        messages = kwargs.get("messages", [])
+        last_text = get_last_message_text(messages).lower()
+        # Gate on the user turn: the tool result mentions the pool area too, so
+        # without this the initial call matches again on the next iteration and
+        # the loop spins until it runs out of iterations.
+        return (
+            bool(messages)
+            and messages[-1].role == "user"
+            and "pool" in last_text
+            and kwargs.get("tools") is not None
+        )
 
     area_filter_response = MockLLMOutput(
         content="I'll find devices in the pool area.",

--- a/tests/unit/llm/providers/test_anthropic_client.py
+++ b/tests/unit/llm/providers/test_anthropic_client.py
@@ -198,16 +198,40 @@ class TestAnthropicPromptCacheBreakpoint:
 
         assert system_value == "You are a helpful assistant."
 
-    @pytest.mark.parametrize("offset", [0, 28, 99])
-    def test_out_of_range_offsets_do_not_split(self, offset: int) -> None:
-        """A degenerate offset must not produce an empty or truncated block."""
+    def test_zero_offset_does_not_split(self) -> None:
+        """Nothing stable to cache, so keep the pre-existing shape."""
         content = "You are a helpful assistant."
+        system_value = self._convert([
+            SystemMessage(content=content, stable_prefix_len=0),
+            UserMessage(content="hi"),
+        ])
+
+        assert system_value == content
+
+    @pytest.mark.parametrize("offset", [28, 99])
+    def test_fully_stable_prompt_is_cached_as_one_block(self, offset: int) -> None:
+        """A prompt stable to the end is the ideal case and must still cache.
+
+        `offset == len(content)` is what a template with no volatile
+        placeholders produces; a larger offset can only mean the content was
+        trimmed after the boundary was computed. Neither is a reason to skip
+        caching the whole thing.
+        """
+        content = "You are a helpful assistant."
+        assert offset >= len(content)
+
         system_value = self._convert([
             SystemMessage(content=content, stable_prefix_len=offset),
             UserMessage(content="hi"),
         ])
 
-        assert system_value == content
+        assert system_value == [
+            {
+                "type": "text",
+                "text": content,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
 
     def test_hoisted_mid_conversation_system_message_lands_past_the_breakpoint(
         self,
@@ -274,4 +298,19 @@ class TestAnthropicCacheUsageReporting:
 
         assert "cached_prompt_tokens" not in info
         assert "cache_write_tokens" not in info
+        assert info.get("total_tokens") == 120
+
+    def test_reported_zero_cache_tokens_are_preserved(self) -> None:
+        """Anthropic always reports these fields, so 0 is a known miss."""
+        info = AnthropicClient._reasoning_info_from_usage(
+            self._usage(
+                input_tokens=100,
+                output_tokens=20,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+            )
+        )
+
+        assert info.get("cached_prompt_tokens") == 0
+        assert info.get("cache_write_tokens") == 0
         assert info.get("total_tokens") == 120

--- a/tests/unit/llm/providers/test_anthropic_client.py
+++ b/tests/unit/llm/providers/test_anthropic_client.py
@@ -3,9 +3,12 @@
 import base64
 import os
 import tempfile
+from types import SimpleNamespace
 
 import pytest
+from anthropic.types import TextBlockParam
 
+from family_assistant.llm.messages import LLMMessage, SystemMessage, UserMessage
 from family_assistant.llm.providers.anthropic_client import AnthropicClient
 
 
@@ -144,3 +147,131 @@ class TestAnthropicFormatUserMessageWithFile:
             assert len(content_str) == 100
         finally:
             os.unlink(tmp_path)
+
+
+@pytest.mark.no_db
+class TestAnthropicPromptCacheBreakpoint:
+    """Placement of the prompt-cache breakpoint in the top-level system value."""
+
+    @staticmethod
+    def _convert(
+        messages: list[LLMMessage],
+    ) -> str | list[TextBlockParam] | None:
+        client = AnthropicClient(api_key="test", model="claude-sonnet-4-6")
+        system_value, _ = client._convert_messages_to_anthropic_format(messages)
+        return system_value
+
+    def test_splits_at_stable_prefix_and_marks_only_the_prefix_cacheable(self) -> None:
+        stable = "You are a helpful assistant."
+        volatile = "\n\nCurrent time: 2026-07-25 10:00:00 UTC"
+        system_value = self._convert([
+            SystemMessage(content=stable + volatile, stable_prefix_len=len(stable)),
+            UserMessage(content="hi"),
+        ])
+
+        assert system_value == [
+            {
+                "type": "text",
+                "text": stable,
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"type": "text", "text": volatile},
+        ]
+
+    def test_split_preserves_the_exact_prompt_text(self) -> None:
+        """The model must see identical bytes whether or not we split."""
+        content = "stable part\n\nCurrent time: 2026-07-25"
+        system_value = self._convert([
+            SystemMessage(content=content, stable_prefix_len=len("stable part")),
+            UserMessage(content="hi"),
+        ])
+
+        assert isinstance(system_value, list)
+        assert "".join(block["text"] for block in system_value) == content
+
+    def test_falls_back_to_plain_string_without_a_boundary(self) -> None:
+        """No boundary means nothing cacheable, so keep the pre-existing shape."""
+        system_value = self._convert([
+            SystemMessage(content="You are a helpful assistant."),
+            UserMessage(content="hi"),
+        ])
+
+        assert system_value == "You are a helpful assistant."
+
+    @pytest.mark.parametrize("offset", [0, 28, 99])
+    def test_out_of_range_offsets_do_not_split(self, offset: int) -> None:
+        """A degenerate offset must not produce an empty or truncated block."""
+        content = "You are a helpful assistant."
+        system_value = self._convert([
+            SystemMessage(content=content, stable_prefix_len=offset),
+            UserMessage(content="hi"),
+        ])
+
+        assert system_value == content
+
+    def test_hoisted_mid_conversation_system_message_lands_past_the_breakpoint(
+        self,
+    ) -> None:
+        """Per-turn system triggers must not end up inside the cached block."""
+        stable = "You are a helpful assistant."
+        system_value = self._convert([
+            SystemMessage(content=stable, stable_prefix_len=len(stable)),
+            UserMessage(content="hi"),
+            SystemMessage(content="System: Reminder triggered at 10:00:00"),
+        ])
+
+        assert isinstance(system_value, list)
+        assert system_value[0]["text"] == stable
+        assert system_value[0].get("cache_control") == {"type": "ephemeral"}
+        assert "Reminder triggered" in system_value[1]["text"]
+        assert "cache_control" not in system_value[1]
+
+    def test_no_system_messages_yields_none(self) -> None:
+        assert self._convert([UserMessage(content="hi")]) is None
+
+
+@pytest.mark.no_db
+class TestAnthropicCacheUsageReporting:
+    """Anthropic reports cache tokens as buckets disjoint from input_tokens."""
+
+    @staticmethod
+    def _usage(**kwargs: int | None) -> SimpleNamespace:
+        return SimpleNamespace(
+            input_tokens=kwargs.get("input_tokens", 0),
+            output_tokens=kwargs.get("output_tokens", 0),
+            cache_read_input_tokens=kwargs.get("cache_read_input_tokens"),
+            cache_creation_input_tokens=kwargs.get("cache_creation_input_tokens"),
+        )
+
+    def test_cache_read_is_reported_and_added_to_the_total(self) -> None:
+        info = AnthropicClient._reasoning_info_from_usage(
+            self._usage(
+                input_tokens=100, output_tokens=20, cache_read_input_tokens=4000
+            )
+        )
+
+        assert info.get("cached_prompt_tokens") == 4000
+        assert info.get("prompt_tokens") == 100
+        # Without adding the cache bucket back, a cached turn would report a
+        # prompt ~40x smaller than the one actually sent.
+        assert info.get("total_tokens") == 4120
+
+    def test_cache_write_is_reported_and_added_to_the_total(self) -> None:
+        info = AnthropicClient._reasoning_info_from_usage(
+            self._usage(
+                input_tokens=100, output_tokens=20, cache_creation_input_tokens=4000
+            )
+        )
+
+        assert info.get("cache_write_tokens") == 4000
+        assert info.get("total_tokens") == 4120
+
+    def test_absent_cache_fields_are_omitted_not_zeroed(self) -> None:
+        """Absent must stay distinguishable from a genuine zero-hit turn."""
+        info = AnthropicClient._reasoning_info_from_usage(
+            self._usage(input_tokens=100, output_tokens=20)
+        )
+
+        assert "cached_prompt_tokens" not in info
+        assert "cache_write_tokens" not in info
+        assert info.get("total_tokens") == 120

--- a/tests/unit/llm/providers/test_provider_usage_instrumentation.py
+++ b/tests/unit/llm/providers/test_provider_usage_instrumentation.py
@@ -58,6 +58,14 @@ class TestGeminiUsageMetadata:
         assert "cached_prompt_tokens" not in info
         assert "reasoning_tokens" not in info
 
+    def test_reported_zero_cache_hit_is_preserved(self) -> None:
+        """A reported miss must stay distinguishable from nothing reported."""
+        info = GoogleGenAIClient._reasoning_info_from_usage_metadata(
+            self._usage(prompt_token_count=10, cached_content_token_count=0)
+        )
+
+        assert info.get("cached_prompt_tokens") == 0
+
     def test_none_counts_do_not_crash(self) -> None:
         """The SDK leaves counts unset rather than zero on some responses."""
         info = GoogleGenAIClient._reasoning_info_from_usage_metadata(
@@ -95,9 +103,16 @@ class TestOpenAICachedPromptTokens:
             == 256
         )
 
-    def test_missing_details_reports_zero(self) -> None:
-        assert OpenAIClient._cached_prompt_tokens(SimpleNamespace()) == 0
-        assert OpenAIClient._cached_prompt_tokens({}) == 0
+    def test_absent_cache_field_is_none_not_zero(self) -> None:
+        """None means "nothing reported"; 0 means a known miss."""
+        assert OpenAIClient._cached_prompt_tokens(SimpleNamespace()) is None
+        assert OpenAIClient._cached_prompt_tokens({}) is None
+
+    def test_reported_zero_is_preserved(self) -> None:
+        """A reported miss must not be dropped, or hit rates read too high."""
+        usage = SimpleNamespace(prompt_tokens_details=SimpleNamespace(cached_tokens=0))
+
+        assert OpenAIClient._cached_prompt_tokens(usage) == 0
 
 
 class _UsageChunk:

--- a/tests/unit/llm/providers/test_provider_usage_instrumentation.py
+++ b/tests/unit/llm/providers/test_provider_usage_instrumentation.py
@@ -114,6 +114,21 @@ class TestOpenAICachedPromptTokens:
 
         assert OpenAIClient._cached_prompt_tokens(usage) == 0
 
+    def test_responses_cache_write_tokens_are_read(self) -> None:
+        """The Responses API reports cache writes even though the pinned SDK
+        does not type the field, so it is only reachable by name."""
+        usage = {
+            "input_tokens_details": {"cache_write_tokens": 128, "cached_tokens": 0}
+        }
+
+        assert OpenAIClient._cache_write_tokens(usage) == 128
+        assert OpenAIClient._cached_prompt_tokens(usage) == 0
+
+    def test_chat_completions_reports_no_cache_write(self) -> None:
+        usage = SimpleNamespace(prompt_tokens_details=SimpleNamespace(cached_tokens=64))
+
+        assert OpenAIClient._cache_write_tokens(usage) is None
+
 
 class _UsageChunk:
     """A final streaming chunk carrying usage and no choices, as OpenAI sends."""
@@ -193,6 +208,20 @@ class TestOpenAIStreamUsage:
 
         assert params["stream_options"] == {"include_usage": False}
 
+    async def test_streaming_preserves_reasoning_tokens(self) -> None:
+        """include_usage makes this reachable on a streamed turn for the first
+        time; the non-streaming path already reported it."""
+        client = OpenAIClient(api_key="test", model="gpt-5.5")
+        chunk = _UsageChunk(cached_tokens=0)
+        chunk.usage.completion_tokens_details = SimpleNamespace(reasoning_tokens=777)
+
+        _, events = await self._captured_params(client, [chunk])
+
+        done = [event for event in events if event.type == "done"]
+        reasoning_info = (done[-1].metadata or {}).get("reasoning_info")
+        assert reasoning_info is not None
+        assert reasoning_info.get("reasoning_tokens") == 777
+
     async def test_usage_only_final_chunk_is_not_skipped(self) -> None:
         """The usage chunk has empty choices, so the content guards skip it."""
         client = OpenAIClient(api_key="test", model="gpt-5.5")
@@ -207,3 +236,45 @@ class TestOpenAIStreamUsage:
         assert reasoning_info is not None
         assert reasoning_info.get("cached_prompt_tokens") == 4000
         assert reasoning_info.get("prompt_tokens") == 5000
+
+
+@pytest.mark.no_db
+class TestOpenAIReplayStreamUsage:
+    """VCR replay hands back parsed dicts, and had the same empty-choices bug."""
+
+    async def _replay_events(
+        self,
+        # ast-grep-ignore: no-dict-any - replay chunks are parsed JSON
+        chunk_dicts: list[dict[str, Any]],
+    ) -> list[LLMStreamEvent]:
+        client = OpenAIClient(api_key="test", model="gpt-5.5")
+        return [
+            event async for event in client._emit_events_from_chunk_dicts(chunk_dicts)
+        ]
+
+    async def test_usage_only_chunk_is_captured(self) -> None:
+        events = await self._replay_events([
+            {
+                "choices": [
+                    {"delta": {"content": "hi"}, "index": 0, "finish_reason": None}
+                ]
+            },
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 500,
+                    "completion_tokens": 10,
+                    "total_tokens": 510,
+                    "prompt_tokens_details": {"cached_tokens": 384},
+                },
+            },
+        ])
+
+        done = [event for event in events if event.type == "done"]
+        assert done
+        reasoning_info = (done[-1].metadata or {}).get("reasoning_info")
+        assert reasoning_info is not None, (
+            "replayed stream emitted a done event with no usage at all"
+        )
+        assert reasoning_info.get("cached_prompt_tokens") == 384
+        assert reasoning_info.get("prompt_tokens") == 500

--- a/tests/unit/llm/providers/test_provider_usage_instrumentation.py
+++ b/tests/unit/llm/providers/test_provider_usage_instrumentation.py
@@ -1,0 +1,194 @@
+"""Token-usage instrumentation for the Google and OpenAI providers.
+
+Streaming is the path the processing loop actually uses, so usage that is only
+reported for non-streaming calls leaves the default profiles unmeasurable.
+"""
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any, ClassVar, cast
+
+import pytest
+
+from family_assistant.llm import LLMStreamEvent
+from family_assistant.llm.messages import UserMessage
+from family_assistant.llm.providers.google_genai_client import GoogleGenAIClient
+from family_assistant.llm.providers.openai_client import OpenAIClient
+
+
+@pytest.mark.no_db
+class TestGeminiUsageMetadata:
+    @staticmethod
+    def _usage(**kwargs: int | None) -> SimpleNamespace:
+        return SimpleNamespace(
+            prompt_token_count=kwargs.get("prompt_token_count", 0),
+            candidates_token_count=kwargs.get("candidates_token_count", 0),
+            total_token_count=kwargs.get("total_token_count", 0),
+            cached_content_token_count=kwargs.get("cached_content_token_count"),
+            thoughts_token_count=kwargs.get("thoughts_token_count"),
+        )
+
+    def test_cache_hits_are_reported_without_inflating_the_total(self) -> None:
+        """Gemini's cached count is a subset of the prompt, unlike Anthropic's."""
+        info = GoogleGenAIClient._reasoning_info_from_usage_metadata(
+            self._usage(
+                prompt_token_count=5000,
+                candidates_token_count=100,
+                total_token_count=5100,
+                cached_content_token_count=4000,
+            )
+        )
+
+        assert info.get("cached_prompt_tokens") == 4000
+        assert info.get("prompt_tokens") == 5000
+        assert info.get("total_tokens") == 5100
+
+    def test_thinking_tokens_are_reported(self) -> None:
+        info = GoogleGenAIClient._reasoning_info_from_usage_metadata(
+            self._usage(prompt_token_count=10, thoughts_token_count=250)
+        )
+
+        assert info.get("reasoning_tokens") == 250
+
+    def test_absent_optional_counts_are_omitted(self) -> None:
+        info = GoogleGenAIClient._reasoning_info_from_usage_metadata(
+            self._usage(prompt_token_count=10, candidates_token_count=2)
+        )
+
+        assert "cached_prompt_tokens" not in info
+        assert "reasoning_tokens" not in info
+
+    def test_none_counts_do_not_crash(self) -> None:
+        """The SDK leaves counts unset rather than zero on some responses."""
+        info = GoogleGenAIClient._reasoning_info_from_usage_metadata(
+            SimpleNamespace(
+                prompt_token_count=None,
+                candidates_token_count=None,
+                total_token_count=None,
+            )
+        )
+
+        assert info.get("prompt_tokens") == 0
+        assert info.get("total_tokens") == 0
+
+
+@pytest.mark.no_db
+class TestOpenAICachedPromptTokens:
+    def test_reads_chat_completions_shape(self) -> None:
+        usage = SimpleNamespace(
+            prompt_tokens_details=SimpleNamespace(cached_tokens=1024)
+        )
+
+        assert OpenAIClient._cached_prompt_tokens(usage) == 1024
+
+    def test_reads_responses_shape(self) -> None:
+        usage = SimpleNamespace(input_tokens_details=SimpleNamespace(cached_tokens=512))
+
+        assert OpenAIClient._cached_prompt_tokens(usage) == 512
+
+    def test_reads_raw_dict_payloads(self) -> None:
+        """Streaming replay and the Responses stream hand back plain dicts."""
+        assert (
+            OpenAIClient._cached_prompt_tokens({
+                "prompt_tokens_details": {"cached_tokens": 256}
+            })
+            == 256
+        )
+
+    def test_missing_details_reports_zero(self) -> None:
+        assert OpenAIClient._cached_prompt_tokens(SimpleNamespace()) == 0
+        assert OpenAIClient._cached_prompt_tokens({}) == 0
+
+
+class _UsageChunk:
+    """A final streaming chunk carrying usage and no choices, as OpenAI sends."""
+
+    choices: ClassVar[list[object]] = []
+
+    def __init__(self, cached_tokens: int) -> None:
+        self.usage = SimpleNamespace(
+            prompt_tokens=5000,
+            completion_tokens=100,
+            total_tokens=5100,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
+        )
+
+
+@pytest.mark.no_db
+class TestOpenAIStreamUsage:
+    @staticmethod
+    async def _captured_params(
+        client: OpenAIClient,
+        chunks: list[object],
+        # ast-grep-ignore: no-dict-any - captures arbitrary SDK request kwargs
+    ) -> tuple[dict[str, Any], list[LLMStreamEvent]]:
+        # ast-grep-ignore: no-dict-any - captures arbitrary SDK request kwargs
+        captured: dict[str, Any] = {}
+
+        async def _fake_create(**kwargs: Any) -> AsyncIterator[object]:  # noqa: ANN401
+            captured.update(kwargs)
+
+            async def _iter() -> AsyncIterator[object]:
+                for chunk in chunks:
+                    yield chunk
+
+            return _iter()
+
+        client.client = cast(
+            "Any",
+            SimpleNamespace(
+                chat=SimpleNamespace(completions=SimpleNamespace(create=_fake_create))
+            ),
+        )
+        events = [
+            event
+            async for event in client.generate_response_stream(
+                messages=[UserMessage(content="hi")]
+            )
+        ]
+        return captured, events
+
+    async def test_direct_openai_requests_usage_on_the_stream(self) -> None:
+        """Without stream_options the API sends no usage for a streamed turn."""
+        client = OpenAIClient(api_key="test", model="gpt-5.5")
+
+        params, _ = await self._captured_params(client, [])
+
+        assert params["stream_options"] == {"include_usage": True}
+
+    async def test_compatible_endpoint_is_not_sent_stream_options(self) -> None:
+        """An endpoint that rejects unknown parameters must not be sent them."""
+        client = OpenAIClient(
+            api_key="test", model="gpt-5.5", base_url="https://openrouter.ai/api/v1"
+        )
+
+        params, _ = await self._captured_params(client, [])
+
+        assert "stream_options" not in params
+
+    async def test_model_parameters_can_override_the_default(self) -> None:
+        """Operators on a compatible endpoint need a way to opt in."""
+        client = OpenAIClient(
+            api_key="test",
+            model="gpt-5.5",
+            model_parameters={"gpt-5.5": {"stream_options": {"include_usage": False}}},
+        )
+
+        params, _ = await self._captured_params(client, [])
+
+        assert params["stream_options"] == {"include_usage": False}
+
+    async def test_usage_only_final_chunk_is_not_skipped(self) -> None:
+        """The usage chunk has empty choices, so the content guards skip it."""
+        client = OpenAIClient(api_key="test", model="gpt-5.5")
+
+        _, events = await self._captured_params(
+            client, [_UsageChunk(cached_tokens=4000)]
+        )
+
+        done = [event for event in events if event.type == "done"]
+        assert done
+        reasoning_info = (done[-1].metadata or {}).get("reasoning_info")
+        assert reasoning_info is not None
+        assert reasoning_info.get("cached_prompt_tokens") == 4000
+        assert reasoning_info.get("prompt_tokens") == 5000

--- a/tests/unit/processing/test_llm_loop_system_prompt_stability.py
+++ b/tests/unit/processing/test_llm_loop_system_prompt_stability.py
@@ -21,6 +21,7 @@ from family_assistant.llm.messages import SystemMessage, UserMessage
 from family_assistant.llm.tool_call import ToolCallFunction, ToolCallItem
 from family_assistant.processing import ProcessingService, ProcessingServiceConfig
 from family_assistant.storage.context import get_db_context
+from family_assistant.tools.types import ToolAttachment, ToolResult
 from tests.mocks.mock_llm import (  # pylint: disable=no-name-in-module
     RuleBasedMockLLMClient,
 )
@@ -29,11 +30,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
 
     from family_assistant.llm.messages import LLMMessage
-    from family_assistant.tools.types import (
-        ToolDefinition,
-        ToolExecutionContext,
-        ToolResult,
-    )
+    from family_assistant.tools.types import ToolDefinition, ToolExecutionContext
 
 
 class _EchoToolsProvider:
@@ -241,3 +238,71 @@ async def test_system_prompt_keeps_its_cache_breakpoint_through_the_loop(
     for system_message in captured:
         assert system_message.stable_prefix_len is not None
         assert 0 < system_message.stable_prefix_len <= len(system_message.content)
+
+
+class _AttachingToolsProvider(_EchoToolsProvider):
+    """Returns a tool result carrying more attachments than the selection threshold."""
+
+    async def execute_tool(
+        self,
+        name: str,
+        # ast-grep-ignore: no-dict-any - tool args are dynamic
+        arguments: dict[str, Any],
+        context: ToolExecutionContext,
+        call_id: str | None = None,
+    ) -> str | ToolResult:
+        return ToolResult(
+            text="attached",
+            attachments=[
+                ToolAttachment(
+                    mime_type="text/plain",
+                    description=f"file {index}",
+                    attachment_id=f"att{index}",
+                )
+                for index in range(4)
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_attachment_selection_uses_the_users_request_not_the_scaffolding(
+    db_engine: AsyncEngine,
+) -> None:
+    """The synthetic final-iteration instruction is the newest user message on the
+    last iteration. Selecting attachments against it would match boilerplate
+    instead of what the user actually asked for."""
+    llm_client = _SnapshottingMockLLMClient(tool_call_rounds=1)
+    service = _make_service(llm_client, max_iterations=2)
+    service.tool_executor.tools_provider = _AttachingToolsProvider()
+    service.llm_loop.tool_executor.tools_provider = _AttachingToolsProvider()
+    service.app_config.attachment_selection_threshold = 1
+
+    queries: list[str] = []
+
+    async def _capture_query(
+        pending_attachment_ids: list[str],
+        original_query: str,
+        *,
+        acting_user_id: str | None,
+    ) -> list[str]:
+        queries.append(original_query)
+        return pending_attachment_ids
+
+    service.llm_loop.attachment_processor.select_for_response = _capture_query  # type: ignore[method-assign]
+
+    async with get_db_context(db_engine) as db_context:
+        await service.handle_chat_interaction(
+            db_context=db_context,
+            interface_type="web",
+            conversation_id="cache-attachment-query",
+            trigger_content_parts=[
+                {"type": "text", "text": "Show me the pictures of the cat"}
+            ],
+            trigger_interface_message_id=None,
+            user_name="Test User",
+        )
+
+    assert queries, "attachment selection never ran"
+    for query in queries:
+        assert "final processing iteration" not in query.lower()
+    assert queries[0] == "Show me the pictures of the cat"

--- a/tests/unit/processing/test_llm_loop_system_prompt_stability.py
+++ b/tests/unit/processing/test_llm_loop_system_prompt_stability.py
@@ -17,6 +17,7 @@ import pytest
 from family_assistant.config_models import AppConfig, ToolsConfig
 from family_assistant.delegation_security import DelegationSecurityLevel
 from family_assistant.llm import LLMOutput
+from family_assistant.llm.base import ContextLengthError
 from family_assistant.llm.messages import SystemMessage, UserMessage
 from family_assistant.llm.tool_call import ToolCallFunction, ToolCallItem
 from family_assistant.processing import ProcessingService, ProcessingServiceConfig
@@ -79,6 +80,7 @@ class _SnapshottingMockLLMClient(RuleBasedMockLLMClient):
         self._round = 0
         self.system_prompts: list[str] = []
         self.trailing_messages: list[LLMMessage] = []
+        self.retry_messages: list[LLMMessage] = []
 
     async def generate_response(
         self,
@@ -91,6 +93,7 @@ class _SnapshottingMockLLMClient(RuleBasedMockLLMClient):
             first.content if isinstance(first, SystemMessage) else ""
         )
         self.trailing_messages.append(messages[-1])
+        self.retry_messages = list(messages)
 
         self._round += 1
         if self._round <= self._tool_call_rounds:
@@ -306,3 +309,54 @@ async def test_attachment_selection_uses_the_users_request_not_the_scaffolding(
     for query in queries:
         assert "final processing iteration" not in query.lower()
     assert queries[0] == "Show me the pictures of the cat"
+
+
+class _ContextLimitOnceMockLLMClient(_SnapshottingMockLLMClient):
+    """Raises ContextLengthError once, then succeeds, to drive the pruning retry."""
+
+    def __init__(self) -> None:
+        super().__init__(tool_call_rounds=0)
+        self._raised = False
+
+    async def generate_response(
+        self,
+        messages: list[LLMMessage],
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: str | None = "auto",
+    ) -> LLMOutput:
+        if not self._raised:
+            self._raised = True
+            raise ContextLengthError(
+                "context length exceeded", provider="mock", model="mock"
+            )
+        return await super().generate_response(messages, tools, tool_choice)
+
+
+@pytest.mark.asyncio
+async def test_context_pruning_keeps_the_user_turn_not_the_scaffolding(
+    db_engine: AsyncEngine,
+) -> None:
+    """The turn splitter starts a turn at every UserMessage, so the synthetic
+    final-iteration instruction must be excluded from pruning. At min_turns=1 it
+    would otherwise be the only turn kept, dropping the user's actual request."""
+    llm_client = _ContextLimitOnceMockLLMClient()
+    service = _make_service(llm_client, max_iterations=1)
+    service.llm_loop.config.context_pruning_min_turns = 1
+
+    async with get_db_context(db_engine) as db_context:
+        await service.handle_chat_interaction(
+            db_context=db_context,
+            interface_type="web",
+            conversation_id="cache-pruning",
+            trigger_content_parts=[{"type": "text", "text": "Remember the milk"}],
+            trigger_interface_message_id=None,
+            user_name="Test User",
+        )
+
+    # The retry is the only recorded call: the first attempt raised.
+    assert llm_client.retry_messages, "pruning retry never happened"
+    texts = [str(msg.content) for msg in llm_client.retry_messages]
+    assert any("Remember the milk" in text for text in texts), (
+        f"user request was pruned away, leaving only: {texts}"
+    )
+    assert "final processing iteration" in texts[-1].lower()

--- a/tests/unit/processing/test_llm_loop_system_prompt_stability.py
+++ b/tests/unit/processing/test_llm_loop_system_prompt_stability.py
@@ -1,0 +1,243 @@
+"""The tool-call loop must not rewrite the system prompt between iterations.
+
+The system prompt renders at the front of the provider prompt prefix, so any
+per-iteration edit invalidates the prompt cache for the whole turn -- prompt,
+tools, and every accumulated tool result get re-read at full price on each tool
+call. These tests pin the prompt as byte-stable across iterations.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, cast
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from family_assistant.config_models import AppConfig, ToolsConfig
+from family_assistant.delegation_security import DelegationSecurityLevel
+from family_assistant.llm import LLMOutput
+from family_assistant.llm.messages import SystemMessage, UserMessage
+from family_assistant.llm.tool_call import ToolCallFunction, ToolCallItem
+from family_assistant.processing import ProcessingService, ProcessingServiceConfig
+from family_assistant.storage.context import get_db_context
+from tests.mocks.mock_llm import (  # pylint: disable=no-name-in-module
+    RuleBasedMockLLMClient,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+    from family_assistant.llm.messages import LLMMessage
+    from family_assistant.tools.types import (
+        ToolDefinition,
+        ToolExecutionContext,
+        ToolResult,
+    )
+
+
+class _EchoToolsProvider:
+    async def get_tool_definitions(
+        self, *, can_confirm: bool = True
+    ) -> list[ToolDefinition]:
+        return [
+            cast(
+                "ToolDefinition",
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "echo_tool",
+                        "description": "Echoes back.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+            )
+        ]
+
+    async def execute_tool(
+        self,
+        name: str,
+        # ast-grep-ignore: no-dict-any - tool args are dynamic
+        arguments: dict[str, Any],
+        context: ToolExecutionContext,
+        call_id: str | None = None,
+    ) -> str | ToolResult:
+        return "echoed"
+
+    async def close(self) -> None:
+        pass
+
+
+class _SnapshottingMockLLMClient(RuleBasedMockLLMClient):
+    """Records the exact prompt seen on each call.
+
+    The loop mutates its message list in place, so the shared recorder in
+    RuleBasedMockLLMClient would hand every call the same final list. These
+    snapshots are taken per call instead.
+    """
+
+    def __init__(self, tool_call_rounds: int) -> None:
+        super().__init__(rules=[], default_response=LLMOutput(content="done"))
+        self._tool_call_rounds = tool_call_rounds
+        self._round = 0
+        self.system_prompts: list[str] = []
+        self.trailing_messages: list[LLMMessage] = []
+
+    async def generate_response(
+        self,
+        messages: list[LLMMessage],
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: str | None = "auto",
+    ) -> LLMOutput:
+        first = messages[0]
+        self.system_prompts.append(
+            first.content if isinstance(first, SystemMessage) else ""
+        )
+        self.trailing_messages.append(messages[-1])
+
+        self._round += 1
+        if self._round <= self._tool_call_rounds:
+            return LLMOutput(
+                content=None,
+                tool_calls=[
+                    ToolCallItem(
+                        id=f"call_{self._round}",
+                        type="function",
+                        function=ToolCallFunction(
+                            name="echo_tool", arguments=json.dumps({})
+                        ),
+                    )
+                ],
+            )
+        return LLMOutput(content="done")
+
+
+def _make_service(
+    llm_client: RuleBasedMockLLMClient,
+    max_iterations: int,
+) -> ProcessingService:
+    return ProcessingService(
+        llm_client=llm_client,
+        tools_provider=_EchoToolsProvider(),
+        service_config=ProcessingServiceConfig(
+            prompts={"system_prompt": "You are a test assistant. {current_time}"},
+            timezone=ZoneInfo("UTC"),
+            max_history_messages=5,
+            history_max_age_hours=1,
+            tools_config=ToolsConfig(),
+            delegation_security_level=DelegationSecurityLevel.CONFIRM,
+            id="llm-loop-cache",
+            max_iterations=max_iterations,
+        ),
+        context_providers=[],
+        server_url="http://testserver",
+        app_config=AppConfig(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_is_byte_stable_across_tool_iterations(
+    db_engine: AsyncEngine,
+) -> None:
+    llm_client = _SnapshottingMockLLMClient(tool_call_rounds=2)
+    service = _make_service(llm_client, max_iterations=5)
+
+    async with get_db_context(db_engine) as db_context:
+        result = await service.handle_chat_interaction(
+            db_context=db_context,
+            interface_type="web",
+            conversation_id="cache-stability",
+            trigger_content_parts=[{"type": "text", "text": "Hello"}],
+            trigger_interface_message_id=None,
+            user_name="Test User",
+        )
+
+    assert result.status.value == "success"
+    assert len(llm_client.system_prompts) == 3
+    assert len(set(llm_client.system_prompts)) == 1
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_carries_no_iteration_counter(
+    db_engine: AsyncEngine,
+) -> None:
+    llm_client = _SnapshottingMockLLMClient(tool_call_rounds=1)
+    service = _make_service(llm_client, max_iterations=5)
+
+    async with get_db_context(db_engine) as db_context:
+        await service.handle_chat_interaction(
+            db_context=db_context,
+            interface_type="web",
+            conversation_id="cache-no-counter",
+            trigger_content_parts=[{"type": "text", "text": "Hello"}],
+            trigger_interface_message_id=None,
+            user_name="Test User",
+        )
+
+    assert llm_client.system_prompts
+    for prompt in llm_client.system_prompts:
+        assert "Processing iteration" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_final_iteration_instruction_is_appended_not_prepended(
+    db_engine: AsyncEngine,
+) -> None:
+    """Delivering it as a trailing user message keeps the cached prefix intact."""
+    llm_client = _SnapshottingMockLLMClient(tool_call_rounds=0)
+    service = _make_service(llm_client, max_iterations=1)
+
+    async with get_db_context(db_engine) as db_context:
+        await service.handle_chat_interaction(
+            db_context=db_context,
+            interface_type="web",
+            conversation_id="cache-final-iteration",
+            trigger_content_parts=[{"type": "text", "text": "Hello"}],
+            trigger_interface_message_id=None,
+            user_name="Test User",
+        )
+
+    assert llm_client.system_prompts
+    assert "final processing iteration" not in llm_client.system_prompts[0].lower()
+
+    trailing = llm_client.trailing_messages[0]
+    assert isinstance(trailing, UserMessage)
+    assert "final processing iteration" in str(trailing.content).lower()
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_keeps_its_cache_breakpoint_through_the_loop(
+    db_engine: AsyncEngine,
+) -> None:
+    """A rebuilt system message must not silently drop the breakpoint offset."""
+    llm_client = _SnapshottingMockLLMClient(tool_call_rounds=1)
+    service = _make_service(llm_client, max_iterations=5)
+
+    captured: list[SystemMessage] = []
+    original = llm_client.generate_response
+
+    async def _capture(
+        messages: list[LLMMessage],
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: str | None = "auto",
+    ) -> LLMOutput:
+        if isinstance(messages[0], SystemMessage):
+            captured.append(messages[0])
+        return await original(messages, tools, tool_choice)
+
+    llm_client.generate_response = _capture  # type: ignore[method-assign]
+
+    async with get_db_context(db_engine) as db_context:
+        await service.handle_chat_interaction(
+            db_context=db_context,
+            interface_type="web",
+            conversation_id="cache-breakpoint-survives",
+            trigger_content_parts=[{"type": "text", "text": "Hello"}],
+            trigger_interface_message_id=None,
+            user_name="Test User",
+        )
+
+    assert captured
+    for system_message in captured:
+        assert system_message.stable_prefix_len is not None
+        assert 0 < system_message.stable_prefix_len <= len(system_message.content)

--- a/tests/unit/processing/test_processing_fail_fast.py
+++ b/tests/unit/processing/test_processing_fail_fast.py
@@ -173,7 +173,7 @@ async def test_prepare_turn_messages_uses_isolated_writes() -> None:
         return_value=([], "")
     )
     service.context_preparer.aggregate_context = AsyncMock(return_value="")
-    service._render_system_prompt = MagicMock(return_value="")  # type: ignore[method-assign]
+    service._render_system_prompt = MagicMock(return_value=("", None))  # type: ignore[method-assign]
     service.attachment_processor.process_content_parts = AsyncMock(return_value=[])
     service.attachment_processor.convert_message_urls = AsyncMock(
         side_effect=lambda db_context, messages, acting_user_id=None: messages
@@ -520,7 +520,7 @@ def test_render_system_prompt_allows_escaped_literal_braces() -> None:
         "Link: {server_url}/automations/{{automation_id}}"
     )
 
-    rendered_prompt = service._render_system_prompt("tester", "")
+    rendered_prompt, _ = service._render_system_prompt("tester", "")
 
     assert "http://testserver/automations/{automation_id}" in rendered_prompt
 
@@ -530,7 +530,7 @@ def test_render_system_prompt_supports_placeholder_adjacent_to_escaped_braces() 
     service = _make_service()
     service.service_config.prompts["system_prompt"] = "Wrapped: {{{server_url}}}"
 
-    rendered_prompt = service._render_system_prompt("tester", "")
+    rendered_prompt, _ = service._render_system_prompt("tester", "")
 
     assert "{http://testserver}" in rendered_prompt
 
@@ -555,7 +555,7 @@ def test_all_processing_profile_system_prompts_can_be_rendered() -> None:
         service.service_config.id = profile_id
         service.service_config.prompts = processing_config.prompts
 
-        rendered_prompt = service._render_system_prompt(
+        rendered_prompt, _ = service._render_system_prompt(
             "tester", "Context with literal braces: {name}"
         )
 

--- a/tests/unit/processing/test_system_prompt_cache_prefix.py
+++ b/tests/unit/processing/test_system_prompt_cache_prefix.py
@@ -1,0 +1,148 @@
+"""Tests for the request-stable prefix of the rendered system prompt.
+
+The prefix drives where providers place a prompt-cache breakpoint. If it ever
+covers per-turn material the cache silently stops hitting, so these tests pin
+the property that actually matters: the prefix does not move or change when the
+per-turn inputs do.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from family_assistant.config_models import AppConfig, ToolsConfig
+from family_assistant.delegation_security import DelegationSecurityLevel
+from family_assistant.llm import LLMOutput
+from family_assistant.processing import ProcessingService, ProcessingServiceConfig
+from family_assistant.utils.clock import MockClock
+from tests.mocks.mock_llm import (  # pylint: disable=no-name-in-module
+    RuleBasedMockLLMClient,
+)
+
+if TYPE_CHECKING:
+    from family_assistant.tools import ToolExecutionContext
+    from family_assistant.tools.types import ToolDefinition, ToolResult
+
+
+class SimpleToolsProvider:
+    async def get_tool_definitions(self) -> list[ToolDefinition]:
+        return []
+
+    async def execute_tool(
+        self,
+        name: str,
+        # ast-grep-ignore: no-dict-any - tool args are dynamic
+        arguments: dict[str, Any],
+        context: ToolExecutionContext,
+        call_id: str | None = None,
+    ) -> str | ToolResult:
+        return ""
+
+    async def close(self) -> None:
+        pass
+
+
+DEFAULT_TEMPLATE = (
+    "You are a helper with a long stable preamble.\n\n"
+    "# Context\nCurrent time: {current_time}\n\n{aggregated_other_context}\n"
+)
+
+
+def _make_service(
+    template: str = DEFAULT_TEMPLATE,
+    clock: MockClock | None = None,
+) -> ProcessingService:
+    config = ProcessingServiceConfig(
+        prompts={"system_prompt": template},
+        timezone=ZoneInfo("UTC"),
+        max_history_messages=10,
+        history_max_age_hours=24,
+        tools_config=ToolsConfig(),
+        delegation_security_level=DelegationSecurityLevel.CONFIRM,
+        id="cache_prefix_test",
+        max_iterations=5,
+    )
+    return ProcessingService(
+        llm_client=RuleBasedMockLLMClient(
+            rules=[], default_response=LLMOutput(content="ok")
+        ),
+        tools_provider=SimpleToolsProvider(),
+        service_config=config,
+        context_providers=[],
+        server_url="http://testserver",
+        app_config=AppConfig(),
+        clock=clock or MockClock(datetime(2026, 7, 25, 10, 0, 0, tzinfo=UTC)),
+    )
+
+
+@pytest.mark.no_db
+class TestStableSystemPromptPrefix:
+    def test_prefix_excludes_the_timestamp(self) -> None:
+        service = _make_service()
+
+        rendered, prefix_len = service._render_system_prompt("tester", "")
+
+        assert prefix_len is not None
+        assert "2026-07-25 10:00:00" in rendered
+        assert "2026-07-25 10:00:00" not in rendered[:prefix_len]
+
+    def test_prefix_is_identical_across_different_clock_times(self) -> None:
+        """The whole point: the cached block must survive the clock advancing."""
+        early = _make_service(
+            clock=MockClock(datetime(2026, 7, 25, 10, 0, 0, tzinfo=UTC))
+        )
+        later = _make_service(
+            clock=MockClock(datetime(2026, 7, 25, 23, 59, 59, tzinfo=UTC))
+        )
+
+        early_rendered, early_len = early._render_system_prompt("tester", "")
+        later_rendered, later_len = later._render_system_prompt("tester", "")
+
+        assert early_len == later_len
+        assert early_rendered[:early_len] == later_rendered[:later_len]
+        assert early_rendered != later_rendered
+
+    def test_prefix_is_identical_across_different_aggregated_context(self) -> None:
+        service = _make_service()
+
+        empty_rendered, empty_len = service._render_system_prompt("tester", "")
+        full_rendered, full_len = service._render_system_prompt(
+            "tester", "Calendar:\n- 09:00 standup"
+        )
+
+        assert empty_len == full_len
+        assert empty_rendered[:empty_len] == full_rendered[:full_len]
+
+    def test_prefix_covers_the_bulk_of_a_realistic_prompt(self) -> None:
+        """A breakpoint that lands early enough to be worthless is a silent bug."""
+        service = _make_service()
+
+        rendered, prefix_len = service._render_system_prompt(
+            "tester", "Calendar:\n- 09:00 standup"
+        )
+
+        assert prefix_len is not None
+        assert prefix_len > len(rendered) * 0.5
+
+    def test_template_without_volatile_placeholders_is_fully_stable(self) -> None:
+        service = _make_service(template="You are a helper. Nothing varies here.")
+
+        rendered, prefix_len = service._render_system_prompt("tester", "")
+
+        assert prefix_len == len(rendered)
+
+    def test_boundary_stops_at_the_first_volatile_byte(self) -> None:
+        """With the timestamp first in the template, only the profile preamble
+        (which the service prepends ahead of it) is stable, and the boundary
+        must land there rather than swallowing the timestamp."""
+        service = _make_service(template="{current_time} then the rest of the prompt.")
+
+        rendered, prefix_len = service._render_system_prompt("tester", "")
+
+        assert prefix_len is not None
+        assert "2026-07-25 10:00:00" not in rendered[:prefix_len]
+        assert rendered[prefix_len:].startswith("2026-07-25 10:00:00")


### PR DESCRIPTION
Prompt caching is a prefix match — the request is hashed from the start (`tools` → `system` → `messages`) and one differing byte at position N invalidates everything from there on. The request-building path was changing the prefix on essentially every call, so the effective hit rate was ~0 across all three providers. Anthropic additionally had no `cache_control` breakpoint anywhere in the codebase, so its caching was never enabled at all.

This is steps 0–2 of the plan in `docs/design/prompt-caching.md`; step 3 is deliberately deferred there.

## The three fixes

All structural — **the text the model sees is unchanged**, so there's nothing to re-validate behaviourally except the loop's final-iteration instruction.

**1. The tool loop rewrote the system prompt on every iteration.** `llm_loop.py` appended `[Processing iteration N/M]` to `messages[0]` each time round. Since `system` renders at the front of the prefix, a ten-iteration agentic turn paid ten full-price prefills of the prompt, the tool definitions, and every tool result accumulated so far — the most expensive invalidator, because agentic turns are where the context is largest.

The counter is gone. The load-bearing part — the final-iteration "you must answer now" instruction — moved to a trailing user message, which appends at the end of the prefix and invalidates nothing. That path already existed for conversations carrying Gemini thought signatures; it's now the only path. On-demand tool additions still rebuild the prompt, but only when they actually change (activation also changes the tool list, which invalidates the prefix regardless, so it costs nothing extra).

**2. `_render_system_prompt` now returns the prompt's request-stable prefix length.** Derived by rendering a second time with sentinel values for `current_time` / `aggregated_other_context` and taking the common prefix: whatever two renderings that differ only in those inputs still share is, by construction, independent of them. Deriving it rather than hardcoding an offset keeps it correct for operator-edited templates, which may place the placeholders anywhere, more than once, or not at all.

**3. `AnthropicClient` splits the top-level `system` at that offset** into two text blocks and marks only the leading one `cache_control: {"type": "ephemeral"}`. Concatenating them reproduces the string previously sent. Because a breakpoint on the last system block also covers everything rendered before it, this brings the tool definitions under the breakpoint too. With no usable boundary it sends the plain string exactly as before — which is why the existing 24 Anthropic cassettes still match without re-recording.

## Measurement

Cache tokens were previously parsed and discarded, leaving none of the above observable. `MessageReasoningInfo` gained `cached_prompt_tokens` / `cache_write_tokens`, populated by all three providers and surfaced as `gen_ai.usage.cached_input_tokens` / `gen_ai.usage.cache_write_input_tokens` via a shared helper (which also de-duplicated three copies of the usage-telemetry block in `retrying_client.py`).

Two providers reported nothing at all on the **streaming** path — the path the processing loop actually uses, so the Gemini-default profiles were entirely unmeasurable:

- **Gemini** extracted usage only for non-streaming calls, on the stale assumption recorded in the comment there. Streaming chunks are `GenerateContentResponse` objects and do carry `usage_metadata`; the newest one seen is now kept, since not every chunk includes it. `thoughts_token_count` also feeds the existing `reasoning_tokens` field.
- **OpenAI Chat Completions** had two stacked bugs: streaming usage is omitted unless `stream_options.include_usage` is set, so the existing extraction was dead code; and the usage chunk arrives last carrying an **empty `choices` list**, so the content guards skipped it and it would have been dropped even once requested.

### Things worth a reviewer's attention

- **`total_tokens` semantics changed for Anthropic.** Its cache buckets are disjoint from `input_tokens`, so the old `input + output` badly under-reported cached turns (a 4k-token cached prompt would report ~100). It now sums all three. The providers disagree here — Anthropic's cached count is a separate bucket, OpenAI's and Gemini's are a *subset* of the prompt total — so a hit rate computed naively against `prompt_tokens` is wrong for at least one of them. Documented on `MessageReasoningInfo` and in the design doc.
- **`stream_options` goes only to the official OpenAI API**, since a compatible endpoint that rejects unknown parameters would fail the request outright. Given `defaults.yaml` references OpenRouter, that means OpenRouter turns still report no usage by default; operators can opt in via `model_parameters`, which is merged after this default and wins (covered by a test).
- **Deep Research (`interactions`) is left uninstrumented** — the installed SDK exposes no usage field on those events, so anything there would be guesswork.

## Testing

- `tests/unit` + `tests/integration`: 2067 passed
- `tests/functional`: 1603 passed
- All 107 LLM cassettes replay green (`LLM_RECORD_MODE=replay`), including all 24 Anthropic ones
- `scripts/format-and-lint.sh` clean

New coverage, with each guard checked to actually fail against the pre-change code:

- The four `test_llm_loop_system_prompt_stability.py` tests all fail on `origin/main` (verified by swapping the file back).
- `test_usage_only_final_chunk_is_not_skipped` fails when only the OpenAI chunk-loop guard is reverted.
- `test_system_prompt_cache_prefix.py` pins the property that matters: the prefix is byte-identical across different clock times and different aggregated context, and never contains the timestamp.

**Two Home Assistant tests were passing by accident and this change exposed it.** An over-broad first matcher also matched the tool result, spinning the loop to `max_iterations`; the second matcher then only fired because nothing followed the tool message, which my trailing instruction displaces. Both matchers now gate on the user turn and exercise the intended two-iteration flow. I confirmed they pass against unmodified source too, so it's a genuine test fix rather than compensation for a regression.

Three `test_google_computer_use_integration` browser tests fail in my sandbox, identically on `origin/main` — pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwXG2mbdnRpDcCVxwoBqsL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwXG2mbdnRpDcCVxwoBqsL)_