### PR TITLE
Reap attachments that no message or note references

### DIFF
--- a/docs/design/attachment-orphan-reaper.md
+++ b/docs/design/attachment-orphan-reaper.md
@@ -1,0 +1,66 @@
+# Reaping unreferenced attachments
+
+## Problem
+
+The web client uploads an attachment first (`POST /api/attachments/upload`) and only afterwards
+sends the message that references it. The upload commits an `attachment_metadata` row and writes the
+file immediately, so every send that never produces a persisted message leaves both behind: the user
+closes the tab after attaching, the kickoff fails, the network drops, or the conversation already
+has a running turn and the send is refused with 409.
+
+Nothing collected those rows. `AttachmentRegistry.cleanup_orphaned_attachments` builds its
+"referenced" set from *every* row in `attachment_metadata`, so it can only delete files that have no
+row at all — an abandoned upload has a row, and keeps it forever. It also had no caller.
+
+## Approach
+
+A reaper that works on the state that actually decides whether an attachment is live: a metadata row
+nothing references, older than a grace period. That covers every route to the orphan — the turn
+guard's 409, an abandoned compose, a failed kickoff — rather than the one route that prompted it.
+
+### What counts as referenced
+
+Candidates are restricted to `source_type = "user"`, which is exactly the class of rows the upload
+endpoint and the interface handlers create. Tool-, script- and email-sourced rows are reachable from
+delegation runs, scripts, and `received_emails.attachment_info`, and are never candidates, so the
+reaper does not need to understand those reference sets.
+
+A candidate row is referenced when any of the following holds:
+
+- `attachment_metadata.message_id` is set;
+- some `message_history.attachments` entry names its `attachment_id` — this is the reference the
+  send path actually writes, since nothing back-fills `message_id` for user attachments;
+- some `notes.attachment_ids` entry names it — the notes tool can attach an uploaded file to a note
+  that outlives the message that carried it.
+
+Both JSON checks are dialect-specific (`jsonb_array_elements` on PostgreSQL, `json_each` on SQLite),
+following the pattern already used for note visibility labels.
+
+### Grace period
+
+A row is only a candidate once it is older than the grace period (24 hours by default), so an
+in-progress compose is never collected out from under the user, and neither is an upload whose send
+is still sitting in the worker queue.
+
+### Ordering and cost
+
+The reaper deletes rows first and unlinks files afterwards, matching `delete_attachment`: a file
+without a row is collectable, a row without a file is a broken attachment. The reference scan runs
+only when a candidate exists, which is the uncommon case, so the usual nightly pass is a single
+indexed lookup that returns nothing.
+
+Each pass is bounded by a batch limit; a backlog drains over successive runs rather than in one long
+transaction.
+
+### `cleanup_orphaned_attachments`
+
+It is kept, with the narrower job it actually does: deleting files that have no metadata row at all
+— leftovers from a store that committed the file but not the row, and the files of rows the reaper
+has just deleted if an unlink failed. It now runs as the second phase of the same task, and only
+considers files older than the grace period, so an upload writing its file while the sweep runs is
+not collected before its row commits.
+
+## Delivery
+
+`attachment_cleanup` is a system task registered alongside the other cleanups and scheduled daily at
+3am local, with a 24-hour grace period.

--- a/docs/design/attachment-orphan-reaper.md
+++ b/docs/design/attachment-orphan-reaper.md
@@ -33,8 +33,12 @@ A candidate row is referenced when any of the following holds:
 - some `notes.attachment_ids` entry names it — the notes tool can attach an uploaded file to a note
   that outlives the message that carried it.
 
-Both JSON checks are dialect-specific (`jsonb_array_elements` on PostgreSQL, `json_each` on SQLite),
-following the pattern already used for note visibility labels.
+Both JSON checks are dialect-specific (`@>` containment on PostgreSQL, `json_each` on SQLite),
+following the pattern already used for note visibility labels, and both are expressed as
+`NOT EXISTS` conditions on the candidate query rather than filtered afterwards. That ordering is
+load-bearing: nothing back-fills `message_id`, so every upload a message references stays in the
+candidate columns forever. Applying the batch limit before the exclusion would let the oldest of
+those fill each pass, and the orphans behind them would never be reached.
 
 ### Grace period
 
@@ -49,8 +53,11 @@ without a row is collectable, a row without a file is a broken attachment. The r
 only when a candidate exists, which is the uncommon case, so the usual nightly pass is a single
 indexed lookup that returns nothing.
 
-Each pass is bounded by a batch limit; a backlog drains over successive runs rather than in one long
-transaction.
+Each pass is bounded by a batch limit on the rows collected — orphans, not candidates — so a backlog
+drains over successive runs rather than in one long transaction.
+
+A missing attachment registry fails the task rather than returning quietly: a pass that collects
+nothing every day while files accumulate should look like the broken worker configuration it is.
 
 ### `cleanup_orphaned_attachments`
 

--- a/docs/design/attachment-orphan-reaper.md
+++ b/docs/design/attachment-orphan-reaper.md
@@ -86,3 +86,14 @@ not collected before its row commits.
 
 `attachment_cleanup` is a system task registered alongside the other cleanups and scheduled daily at
 3am local, with a 24-hour grace period.
+
+Scheduling it surfaced a bug in the shared machinery: a system task keeps one row across occurrences
+(both the recurrence and the startup setup re-enqueue under the same `system_...` id), and the
+upsert updated the schedule and payload but not the status. A row marked `done` by its first run
+therefore stayed `done`, and dequeue — which selects pending, or stale processing, rows — never
+picked it up again. Every recurring system task ran exactly once.
+
+The upsert now hands a finished row back to the queue: a row in a terminal status (`done`, `failed`)
+is reset to `pending` with its retry count and locks cleared, while a row still `pending` or
+`processing` keeps those columns, so a startup upsert cannot resurrect an occurrence a worker is
+running or reset one that is mid-retry.

--- a/docs/design/attachment-orphan-reaper.md
+++ b/docs/design/attachment-orphan-reaper.md
@@ -33,12 +33,27 @@ A candidate row is referenced when any of the following holds:
 - some `notes.attachment_ids` entry names it — the notes tool can attach an uploaded file to a note
   that outlives the message that carried it.
 
-Both JSON checks are dialect-specific (`@>` containment on PostgreSQL, `json_each` on SQLite),
-following the pattern already used for note visibility labels, and both are expressed as
-`NOT EXISTS` conditions on the candidate query rather than filtered afterwards. That ordering is
-load-bearing: nothing back-fills `message_id`, so every upload a message references stays in the
-candidate columns forever. Applying the batch limit before the exclusion would let the oldest of
-those fill each pass, and the orphans behind them would never be reached.
+Both JSON checks are dialect-specific (`jsonb_array_elements` on PostgreSQL, `json_each` on SQLite),
+following the pattern already used for note visibility labels.
+
+### Paging, and why the limit is not applied first
+
+Nothing back-fills `message_id`, so every upload a message references stays in the candidate columns
+forever — the candidate set is "every user attachment ever", not "the orphans". Two things follow,
+and the reaper has to satisfy both at once:
+
+- The batch limit has to bound rows *collected*, not rows *examined*. Limiting candidates first
+  would let the oldest sent uploads fill every pass, and the orphans behind them would never be
+  reached.
+- The reference check has to be a scan per page, not a correlated subquery per candidate. The JSON
+  columns are unindexed, so a `NOT EXISTS` per candidate row makes a pass that collects nothing cost
+  one message-history scan per historical attachment.
+
+So candidates are walked oldest-first in keyset pages of `REAP_PAGE_SIZE`, each page's references
+resolved with one scan of the message JSON and one of the note JSON, and paging continues until the
+limit is filled or the candidates run out. A keyset cursor on `(created_at, attachment_id)` rather
+than an OFFSET keeps a late page as cheap as the first, and stops a deletion from an earlier page
+shifting a later one past the reader.
 
 ### Grace period
 

--- a/docs/user/attachments.md
+++ b/docs/user/attachments.md
@@ -97,6 +97,11 @@ isn't a wall between your own conversations.
 
 If you want something genuinely out of reach, delete it rather than relying on starting a new chat.
 
+**Files you attach but never send:** attaching a file uploads it straight away, before you send the
+message. If you close the tab, or the send doesn't go through, that upload is cleared out
+automatically about a day later. Anything that reached the assistant — in a message, or attached to
+a note — stays.
+
 ## Sending attachments to other people
 
 The assistant can forward an attachment to another known user — "send this image to John" — as part

--- a/src/family_assistant/assistant.py
+++ b/src/family_assistant/assistant.py
@@ -105,6 +105,7 @@ from family_assistant.task_worker import (
     SCHEDULE_AUTOMATION_ADVANCE_TASK_TYPE,
     ReindexDocumentPayload,
     TaskWorker,
+    handle_attachment_cleanup,
     handle_completed_automation_cleanup,
     handle_confirmation_tool_execution,
     handle_llm_callback,
@@ -1836,6 +1837,24 @@ class Assistant:
             except Exception as e:
                 logger.warning(f"Completed automation cleanup task setup: {e}")
 
+            # Upsert the unreferenced attachment reaper. Uploads commit their
+            # row before the message that references them exists, so a send
+            # that never persists a message leaves the row and file behind.
+            try:
+                await db_ctx.tasks.enqueue(
+                    task_id="system_attachment_cleanup_daily",
+                    task_type="attachment_cleanup",
+                    payload={"grace_hours": 24},
+                    scheduled_at=next_3am_utc,
+                    recurrence_rule="FREQ=DAILY;BYHOUR=3;BYMINUTE=0",
+                    max_retries_override=5,
+                )
+                logger.info(
+                    f"Attachment cleanup task scheduled for {next_3am_local} ({local_tz})"
+                )
+            except Exception as e:
+                logger.warning(f"Attachment cleanup task setup: {e}")
+
             try:
                 await enqueue_message_history_backfill_task(db_ctx)
                 logger.info("Message history backfill task scheduled")
@@ -1945,6 +1964,7 @@ class Assistant:
         worker.register_task_handler(
             "completed_automation_cleanup", handle_completed_automation_cleanup
         )
+        worker.register_task_handler("attachment_cleanup", handle_attachment_cleanup)
         worker.register_task_handler("reindex_document", self.handle_reindex_document)
         logger.info(f"Registered task handlers for worker {worker.worker_id}")
         return worker

--- a/src/family_assistant/assistant.py
+++ b/src/family_assistant/assistant.py
@@ -1852,8 +1852,10 @@ class Assistant:
                 logger.info(
                     f"Attachment cleanup task scheduled for {next_3am_local} ({local_tz})"
                 )
-            except Exception as e:
-                logger.warning(f"Attachment cleanup task setup: {e}")
+            except Exception:
+                # The enqueue upserts, so a failure here is a real one, and it
+                # leaves the reaper with no caller until the next restart.
+                logger.exception("Attachment cleanup task setup failed")
 
             try:
                 await enqueue_message_history_backfill_task(db_ctx)

--- a/src/family_assistant/services/attachment_registry.py
+++ b/src/family_assistant/services/attachment_registry.py
@@ -907,6 +907,12 @@ class AttachmentRegistry:
         that survives it is by definition still referenced, so "has a row" is
         the right liveness test here.
 
+        The traversal walks the whole store, which is unbounded in the number
+        of files and entirely blocking, so it runs on a worker thread: a task
+        worker shares the server's event loop, and holding it through a large
+        store would stall web and Telegram traffic — and the handler timeout
+        that is supposed to catch exactly that.
+
         Args:
             db_context: DatabaseExecutor context
             min_age: Only files older than this are collected, so an upload
@@ -920,7 +926,9 @@ class AttachmentRegistry:
         referenced_rows = await db_context.fetch_all(referenced_query)
         referenced_ids = {row["attachment_id"] for row in referenced_rows}
 
-        return self._cleanup_orphaned_files(referenced_ids, min_age=min_age)
+        return await asyncio.to_thread(
+            self._cleanup_orphaned_files, referenced_ids, min_age=min_age
+        )
 
     async def reap_unreferenced_attachments(
         self,

--- a/src/family_assistant/services/attachment_registry.py
+++ b/src/family_assistant/services/attachment_registry.py
@@ -291,6 +291,11 @@ async def _clear_email_attachment_id(
 class AttachmentRegistry:
     """Registry for managing attachment metadata and file storage."""
 
+    # Candidates examined per reference scan while reaping. Each page costs one
+    # pass over the message and note JSON, so this trades a larger page against
+    # holding more ids in one IN list.
+    REAP_PAGE_SIZE: int = 500
+
     def __init__(
         self,
         storage_path: str,
@@ -937,56 +942,59 @@ class AttachmentRegistry:
         (delegation runs, scripts, ``received_emails.attachment_info``), so
         they are never collected.
 
+        Candidates are walked oldest-first in pages, and each page's references
+        are resolved with one scan of the message and note JSON rather than a
+        correlated subquery per row. Nothing back-fills
+        ``attachment_metadata.message_id``, so every upload a message
+        references stays a candidate forever; the limit therefore bounds rows
+        actually collected, and paging keeps a pass that collects nothing to
+        one scan per page instead of one per historical attachment.
+
         Args:
             db_context: DatabaseExecutor context
             grace_period: Rows younger than this are left alone, so an
                 in-progress compose is not collected out from under the user.
             limit: Maximum rows collected in one pass; a backlog drains over
-                successive passes rather than in one long transaction. The
-                exclusions are applied before the limit, so a deployment with
-                many sent-but-unlinked uploads still reaches its orphans.
+                successive passes rather than in one long transaction.
 
         Returns:
             Number of attachments deleted
         """
         cutoff = datetime.now(UTC) - grace_period
-        dialect_name = db_context.dialect_name
-        attachment_id_column = attachment_metadata_table.c.attachment_id
-        orphan_query = (
-            select(
-                attachment_id_column,
-                attachment_metadata_table.c.storage_path,
-            )
-            .where(
-                and_(
-                    attachment_metadata_table.c.source_type == "user",
-                    attachment_metadata_table.c.message_id.is_(None),
-                    attachment_metadata_table.c.created_at < cutoff,
-                    ~self._message_reference_exists(dialect_name, attachment_id_column),
-                    ~self._note_reference_exists(dialect_name, attachment_id_column),
-                )
-            )
-            .order_by(attachment_metadata_table.c.created_at)
-            .limit(limit)
-        )
-        orphan_rows = await db_context.fetch_all(orphan_query)
-        if not orphan_rows:
-            return 0
+        orphans: dict[str, str | None] = {}
+        cursor: tuple[datetime, str] | None = None
 
-        stored_paths = {
-            row["attachment_id"]: row["storage_path"] for row in orphan_rows
-        }
+        while len(orphans) < limit:
+            page = await db_context.fetch_all(
+                self._candidate_page_query(cutoff, cursor, self.REAP_PAGE_SIZE)
+            )
+            if not page:
+                break
+            cursor = (page[-1]["created_at"], page[-1]["attachment_id"])
+
+            referenced = await self._referenced_attachment_ids(
+                db_context, [row["attachment_id"] for row in page]
+            )
+            for row in page:
+                if row["attachment_id"] in referenced:
+                    continue
+                orphans[row["attachment_id"]] = row["storage_path"]
+                if len(orphans) == limit:
+                    break
+
+        if not orphans:
+            return 0
 
         await db_context.execute(
             delete(attachment_metadata_table).where(
-                attachment_id_column.in_(list(stored_paths))
+                attachment_metadata_table.c.attachment_id.in_(list(orphans))
             )
         )
 
         # Files are unlinked only once the rows are gone, since the unlink
         # cannot be rolled back. A file left behind by a failed unlink is
         # collected by ``cleanup_orphaned_attachments``.
-        for attachment_id, stored_path in stored_paths.items():
+        for attachment_id, stored_path in orphans.items():
             self._delete_attachment_file(
                 attachment_id,
                 stored_path=stored_path,
@@ -994,66 +1002,124 @@ class AttachmentRegistry:
             )
 
         logger.info(
-            f"Reaped {len(stored_paths)} unreferenced attachments "
-            f"older than {grace_period}"
+            f"Reaped {len(orphans)} unreferenced attachments older than {grace_period}"
         )
-        return len(stored_paths)
+        return len(orphans)
 
     @staticmethod
-    def _message_reference_exists(
-        dialect_name: str, attachment_id_column: ColumnElement[str]
-    ) -> ColumnElement[bool]:
-        """SQL condition: some message's attachments name this attachment.
+    def _candidate_page_query(
+        cutoff: datetime,
+        cursor: tuple[datetime, str] | None,
+        page_size: int,
+    ) -> sa.Select:  # type: ignore[type-arg]  # Generic Select type params are complex with dialect-specific expressions
+        """One page of reapable candidates, keyed on ``(created_at, id)``.
+
+        The keyset cursor rather than an OFFSET means a page costs the same
+        whether it is the first or the hundredth, and deleting rows from an
+        earlier page cannot shift a later one past the reader.
+        """
+        conditions = [
+            attachment_metadata_table.c.source_type == "user",
+            attachment_metadata_table.c.message_id.is_(None),
+            attachment_metadata_table.c.created_at < cutoff,
+        ]
+        if cursor is not None:
+            conditions.append(
+                sa.tuple_(
+                    attachment_metadata_table.c.created_at,
+                    attachment_metadata_table.c.attachment_id,
+                )
+                > sa.tuple_(sa.literal(cursor[0]), sa.literal(cursor[1]))
+            )
+
+        return (
+            select(
+                attachment_metadata_table.c.attachment_id,
+                attachment_metadata_table.c.storage_path,
+                attachment_metadata_table.c.created_at,
+            )
+            .where(and_(*conditions))
+            .order_by(
+                attachment_metadata_table.c.created_at,
+                attachment_metadata_table.c.attachment_id,
+            )
+            .limit(page_size)
+        )
+
+    async def _referenced_attachment_ids(
+        self, db_context: DatabaseExecutor, attachment_ids: list[str]
+    ) -> set[str]:
+        """Return the subset of ``attachment_ids`` some message or note names.
+
+        Nothing back-fills ``attachment_metadata.message_id`` for user
+        attachments, so the message reference lives in the
+        ``message_history.attachments`` JSON; the notes tool records its own
+        references in ``notes.attachment_ids``.
+        """
+        if not attachment_ids:
+            return set()
+
+        referenced: set[str] = set()
+        for query in (
+            self._message_reference_query(db_context.dialect_name, attachment_ids),
+            self._note_reference_query(db_context.dialect_name, attachment_ids),
+        ):
+            rows = await db_context.fetch_all(query)
+            referenced.update(
+                row["attachment_id"] for row in rows if row["attachment_id"]
+            )
+        return referenced
+
+    @staticmethod
+    def _message_reference_query(
+        dialect_name: str,
+        attachment_ids: list[str],
+    ) -> sa.Select:  # type: ignore[type-arg]  # Generic Select type params are complex with dialect-specific expressions
+        """Query yielding the given ids that appear in a message's attachments.
 
         ``message_history.attachments`` holds a JSON array of objects keyed by
-        ``attachment_id``, and nothing back-fills
-        ``attachment_metadata.message_id`` for user attachments, so this JSON is
-        where the send path's reference actually lives. A row whose value is not
-        an array (including the ``NULL`` of a message with no attachments) is
-        read as an empty array rather than being allowed to fail expansion.
+        ``attachment_id``. A row whose value is not an array (including the
+        ``NULL`` of a message with no attachments) is expanded as an empty
+        array rather than being allowed to fail expansion.
         """
         attachments = message_history_table.c.attachments
         if dialect_name == "postgresql":
-            return sa.exists(
-                sa
-                .select(sa.literal(1))
-                .select_from(message_history_table)
-                .where(
-                    sa.and_(
-                        sa.func.jsonb_typeof(attachments) == "array",
-                        attachments.op("@>")(
-                            sa.func.jsonb_build_array(
-                                sa.func.jsonb_build_object(
-                                    "attachment_id", attachment_id_column
-                                )
-                            )
-                        ),
-                    )
-                )
+            array_value = sa.case(
+                (sa.func.jsonb_typeof(attachments) == "array", attachments),
+                else_=sa.cast(sa.literal("[]"), JSONB),
+            )
+            elements = sa.func.jsonb_array_elements(array_value).table_valued(
+                "value", joins_implicitly=True
+            )
+            attachment_id_expr = sa.func.jsonb_extract_path_text(
+                elements.c.value, "attachment_id"
+            )
+        else:
+            array_value = sa.case(
+                (sa.func.json_type(attachments) == "array", attachments),
+                else_=sa.literal("[]"),
+            )
+            elements = sa.func.json_each(array_value).table_valued(
+                "value", joins_implicitly=True
+            )
+            attachment_id_expr = sa.func.json_extract(
+                elements.c.value, "$.attachment_id"
             )
 
-        array_value = sa.case(
-            (sa.func.json_type(attachments) == "array", attachments),
-            else_=sa.literal("[]"),
-        )
-        elements = sa.func.json_each(array_value).table_valued(
-            "value", joins_implicitly=True
-        )
-        return sa.exists(
+        return (
             sa
-            .select(sa.literal(1))
+            .select(attachment_id_expr.label("attachment_id"))
             .select_from(message_history_table)
-            .where(
-                sa.func.json_extract(elements.c.value, "$.attachment_id")
-                == attachment_id_column
-            )
+            .where(attachment_id_expr.in_(attachment_ids))
+            .distinct()
         )
 
     @staticmethod
-    def _note_reference_exists(
-        dialect_name: str, attachment_id_column: ColumnElement[str]
-    ) -> ColumnElement[bool]:
-        """SQL condition: some note's attachment ids name this attachment.
+    def _note_reference_query(
+        dialect_name: str,
+        attachment_ids: list[str],
+    ) -> sa.Select:  # type: ignore[type-arg]  # Generic Select type params are complex with dialect-specific expressions
+        """Query yielding the given ids that appear in a note's attachment ids.
 
         ``notes.attachment_ids`` holds a JSON array of attachment id strings.
         The notes tool can attach an uploaded file to a note that outlives the
@@ -1061,25 +1127,21 @@ class AttachmentRegistry:
         """
         note_attachments = notes_table.c.attachment_ids
         if dialect_name == "postgresql":
-            return sa.exists(
-                sa
-                .select(sa.literal(1))
-                .select_from(notes_table)
-                .where(
-                    sa.cast(note_attachments, JSONB).op("@>")(
-                        sa.func.jsonb_build_array(attachment_id_column)
-                    )
-                )
+            elements = sa.func.jsonb_array_elements_text(
+                sa.cast(note_attachments, JSONB)
+            ).table_valued("value", joins_implicitly=True)
+        else:
+            elements = sa.func.json_each(note_attachments).table_valued(
+                "value", joins_implicitly=True
             )
+        attachment_id_expr = elements.c.value
 
-        elements = sa.func.json_each(note_attachments).table_valued(
-            "value", joins_implicitly=True
-        )
-        return sa.exists(
+        return (
             sa
-            .select(sa.literal(1))
+            .select(attachment_id_expr.label("attachment_id"))
             .select_from(notes_table)
-            .where(elements.c.value == attachment_id_column)
+            .where(attachment_id_expr.in_(attachment_ids))
+            .distinct()
         )
 
     async def update_attachment_conversation(

--- a/src/family_assistant/services/attachment_registry.py
+++ b/src/family_assistant/services/attachment_registry.py
@@ -942,15 +942,19 @@ class AttachmentRegistry:
             grace_period: Rows younger than this are left alone, so an
                 in-progress compose is not collected out from under the user.
             limit: Maximum rows collected in one pass; a backlog drains over
-                successive passes rather than in one long transaction.
+                successive passes rather than in one long transaction. The
+                exclusions are applied before the limit, so a deployment with
+                many sent-but-unlinked uploads still reaches its orphans.
 
         Returns:
             Number of attachments deleted
         """
         cutoff = datetime.now(UTC) - grace_period
-        candidate_query = (
+        dialect_name = db_context.dialect_name
+        attachment_id_column = attachment_metadata_table.c.attachment_id
+        orphan_query = (
             select(
-                attachment_metadata_table.c.attachment_id,
+                attachment_id_column,
                 attachment_metadata_table.c.storage_path,
             )
             .where(
@@ -958,145 +962,124 @@ class AttachmentRegistry:
                     attachment_metadata_table.c.source_type == "user",
                     attachment_metadata_table.c.message_id.is_(None),
                     attachment_metadata_table.c.created_at < cutoff,
+                    ~self._message_reference_exists(dialect_name, attachment_id_column),
+                    ~self._note_reference_exists(dialect_name, attachment_id_column),
                 )
             )
             .order_by(attachment_metadata_table.c.created_at)
             .limit(limit)
         )
-        candidate_rows = await db_context.fetch_all(candidate_query)
-        if not candidate_rows:
+        orphan_rows = await db_context.fetch_all(orphan_query)
+        if not orphan_rows:
             return 0
 
         stored_paths = {
-            row["attachment_id"]: row["storage_path"] for row in candidate_rows
+            row["attachment_id"]: row["storage_path"] for row in orphan_rows
         }
-        referenced = await self._referenced_attachment_ids(
-            db_context, list(stored_paths)
-        )
-        orphan_ids = [
-            attachment_id
-            for attachment_id in stored_paths
-            if attachment_id not in referenced
-        ]
-        if not orphan_ids:
-            return 0
 
         await db_context.execute(
             delete(attachment_metadata_table).where(
-                attachment_metadata_table.c.attachment_id.in_(orphan_ids)
+                attachment_id_column.in_(list(stored_paths))
             )
         )
 
         # Files are unlinked only once the rows are gone, since the unlink
         # cannot be rolled back. A file left behind by a failed unlink is
         # collected by ``cleanup_orphaned_attachments``.
-        for attachment_id in orphan_ids:
+        for attachment_id, stored_path in stored_paths.items():
             self._delete_attachment_file(
                 attachment_id,
-                stored_path=stored_paths[attachment_id],
+                stored_path=stored_path,
                 source_type="user",
             )
 
         logger.info(
-            f"Reaped {len(orphan_ids)} unreferenced attachments "
+            f"Reaped {len(stored_paths)} unreferenced attachments "
             f"older than {grace_period}"
         )
-        return len(orphan_ids)
-
-    async def _referenced_attachment_ids(
-        self, db_context: DatabaseExecutor, attachment_ids: list[str]
-    ) -> set[str]:
-        """Return the subset of ``attachment_ids`` some message or note names.
-
-        Nothing back-fills ``attachment_metadata.message_id`` for user
-        attachments, so the message reference lives in the
-        ``message_history.attachments`` JSON; the notes tool records its own
-        references in ``notes.attachment_ids``.
-        """
-        if not attachment_ids:
-            return set()
-
-        referenced: set[str] = set()
-        for query in (
-            self._message_reference_query(db_context.dialect_name, attachment_ids),
-            self._note_reference_query(db_context.dialect_name, attachment_ids),
-        ):
-            rows = await db_context.fetch_all(query)
-            referenced.update(
-                row["attachment_id"] for row in rows if row["attachment_id"]
-            )
-        return referenced
+        return len(stored_paths)
 
     @staticmethod
-    def _message_reference_query(
-        dialect_name: str,
-        attachment_ids: list[str],
-    ) -> sa.Select:  # type: ignore[type-arg]  # Generic Select type params are complex with dialect-specific expressions
-        """Query yielding the given ids that appear in a message's attachments.
+    def _message_reference_exists(
+        dialect_name: str, attachment_id_column: ColumnElement[str]
+    ) -> ColumnElement[bool]:
+        """SQL condition: some message's attachments name this attachment.
 
         ``message_history.attachments`` holds a JSON array of objects keyed by
-        ``attachment_id``. A row whose value is not an array (including the
-        ``NULL`` of a message with no attachments) is expanded as an empty
-        array rather than being allowed to fail expansion.
+        ``attachment_id``, and nothing back-fills
+        ``attachment_metadata.message_id`` for user attachments, so this JSON is
+        where the send path's reference actually lives. A row whose value is not
+        an array (including the ``NULL`` of a message with no attachments) is
+        read as an empty array rather than being allowed to fail expansion.
         """
         attachments = message_history_table.c.attachments
         if dialect_name == "postgresql":
-            array_value = sa.case(
-                (sa.func.jsonb_typeof(attachments) == "array", attachments),
-                else_=sa.cast(sa.literal("[]"), JSONB),
-            )
-            elements = sa.func.jsonb_array_elements(array_value).table_valued(
-                "value", joins_implicitly=True
-            )
-            attachment_id_expr = sa.func.jsonb_extract_path_text(
-                elements.c.value, "attachment_id"
-            )
-        else:
-            array_value = sa.case(
-                (sa.func.json_type(attachments) == "array", attachments),
-                else_=sa.literal("[]"),
-            )
-            elements = sa.func.json_each(array_value).table_valued(
-                "value", joins_implicitly=True
-            )
-            attachment_id_expr = sa.func.json_extract(
-                elements.c.value, "$.attachment_id"
+            return sa.exists(
+                sa
+                .select(sa.literal(1))
+                .select_from(message_history_table)
+                .where(
+                    sa.and_(
+                        sa.func.jsonb_typeof(attachments) == "array",
+                        attachments.op("@>")(
+                            sa.func.jsonb_build_array(
+                                sa.func.jsonb_build_object(
+                                    "attachment_id", attachment_id_column
+                                )
+                            )
+                        ),
+                    )
+                )
             )
 
-        return (
+        array_value = sa.case(
+            (sa.func.json_type(attachments) == "array", attachments),
+            else_=sa.literal("[]"),
+        )
+        elements = sa.func.json_each(array_value).table_valued(
+            "value", joins_implicitly=True
+        )
+        return sa.exists(
             sa
-            .select(attachment_id_expr.label("attachment_id"))
+            .select(sa.literal(1))
             .select_from(message_history_table)
-            .where(attachment_id_expr.in_(attachment_ids))
-            .distinct()
+            .where(
+                sa.func.json_extract(elements.c.value, "$.attachment_id")
+                == attachment_id_column
+            )
         )
 
     @staticmethod
-    def _note_reference_query(
-        dialect_name: str,
-        attachment_ids: list[str],
-    ) -> sa.Select:  # type: ignore[type-arg]  # Generic Select type params are complex with dialect-specific expressions
-        """Query yielding the given ids that appear in a note's attachment ids.
+    def _note_reference_exists(
+        dialect_name: str, attachment_id_column: ColumnElement[str]
+    ) -> ColumnElement[bool]:
+        """SQL condition: some note's attachment ids name this attachment.
 
         ``notes.attachment_ids`` holds a JSON array of attachment id strings.
+        The notes tool can attach an uploaded file to a note that outlives the
+        message that carried it.
         """
         note_attachments = notes_table.c.attachment_ids
         if dialect_name == "postgresql":
-            elements = sa.func.jsonb_array_elements_text(
-                sa.cast(note_attachments, JSONB)
-            ).table_valued("value", joins_implicitly=True)
-        else:
-            elements = sa.func.json_each(note_attachments).table_valued(
-                "value", joins_implicitly=True
+            return sa.exists(
+                sa
+                .select(sa.literal(1))
+                .select_from(notes_table)
+                .where(
+                    sa.cast(note_attachments, JSONB).op("@>")(
+                        sa.func.jsonb_build_array(attachment_id_column)
+                    )
+                )
             )
-        attachment_id_expr = elements.c.value
 
-        return (
+        elements = sa.func.json_each(note_attachments).table_valued(
+            "value", joins_implicitly=True
+        )
+        return sa.exists(
             sa
-            .select(attachment_id_expr.label("attachment_id"))
+            .select(sa.literal(1))
             .select_from(notes_table)
-            .where(attachment_id_expr.in_(attachment_ids))
-            .distinct()
+            .where(elements.c.value == attachment_id_column)
         )
 
     async def update_attachment_conversation(

--- a/src/family_assistant/services/attachment_registry.py
+++ b/src/family_assistant/services/attachment_registry.py
@@ -13,13 +13,15 @@ import logging
 import mimetypes
 import os
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import aiofiles
+import sqlalchemy as sa
 from fastapi import HTTPException, UploadFile
 from sqlalchemy import and_, delete, insert, or_, select, update
+from sqlalchemy.dialects.postgresql import JSONB
 
 from family_assistant.storage.base import attachment_metadata_table
 from family_assistant.storage.database import (
@@ -31,10 +33,16 @@ from family_assistant.storage.email import (
     parse_attachment_infos_with_raw,
     received_emails_table,
 )
+from family_assistant.storage.message_history import message_history_table
+from family_assistant.storage.notes import notes_table
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
     from sqlalchemy.sql.elements import ColumnElement
+
+# How long an unreferenced attachment is left alone before it is collected, so
+# an upload whose message is still being composed (or still queued) survives.
+DEFAULT_ATTACHMENT_GRACE_PERIOD = timedelta(hours=24)
 
 
 class AttachmentRegistryConfig(TypedDict, total=False):
@@ -879,24 +887,217 @@ class AttachmentRegistry:
                 f"Background access time update failed for {attachment_id}: {e}"
             )
 
-    async def cleanup_orphaned_attachments(self, db_context: DatabaseExecutor) -> int:
-        """
-        Clean up file system attachments that are no longer referenced in the database.
-        Uses AttachmentService to clean up orphaned files based on current database references.
+    async def cleanup_orphaned_attachments(
+        self,
+        db_context: DatabaseExecutor,
+        *,
+        min_age: timedelta = DEFAULT_ATTACHMENT_GRACE_PERIOD,
+    ) -> int:
+        """Delete registry-managed files that have no ``attachment_metadata`` row.
+
+        This is the file-level half of attachment cleanup: it collects files a
+        store wrote before its row was committed, and the files of rows deleted
+        without their unlink succeeding. Rows nothing references are collected
+        by :meth:`reap_unreferenced_attachments`, which runs first — every row
+        that survives it is by definition still referenced, so "has a row" is
+        the right liveness test here.
 
         Args:
             db_context: DatabaseExecutor context
+            min_age: Only files older than this are collected, so an upload
+                writing its file while the sweep runs is not deleted before it
+                gets to commit its row.
 
         Returns:
-            Number of attachments cleaned up
+            Number of files deleted
         """
-        # Get attachment IDs that are still referenced in the database
         referenced_query = select(attachment_metadata_table.c.attachment_id).distinct()
         referenced_rows = await db_context.fetch_all(referenced_query)
         referenced_ids = {row["attachment_id"] for row in referenced_rows}
 
-        # Clean up orphaned files directly
-        return self._cleanup_orphaned_files(referenced_ids)
+        return self._cleanup_orphaned_files(referenced_ids, min_age=min_age)
+
+    async def reap_unreferenced_attachments(
+        self,
+        db_context: DatabaseExecutor,
+        *,
+        grace_period: timedelta = DEFAULT_ATTACHMENT_GRACE_PERIOD,
+        limit: int = 500,
+    ) -> int:
+        """Delete user attachments that nothing references, with their files.
+
+        An upload commits its row before the message that would reference it
+        exists, so every send that never persists a message — an abandoned
+        compose, a failed kickoff, a refused concurrent turn — leaves the row
+        and file behind. Rows older than ``grace_period`` that no message and
+        no note names are collected here.
+
+        Only ``source_type="user"`` rows are candidates. Tool, script and email
+        attachments are referenced from places this reaper does not read
+        (delegation runs, scripts, ``received_emails.attachment_info``), so
+        they are never collected.
+
+        Args:
+            db_context: DatabaseExecutor context
+            grace_period: Rows younger than this are left alone, so an
+                in-progress compose is not collected out from under the user.
+            limit: Maximum rows collected in one pass; a backlog drains over
+                successive passes rather than in one long transaction.
+
+        Returns:
+            Number of attachments deleted
+        """
+        cutoff = datetime.now(UTC) - grace_period
+        candidate_query = (
+            select(
+                attachment_metadata_table.c.attachment_id,
+                attachment_metadata_table.c.storage_path,
+            )
+            .where(
+                and_(
+                    attachment_metadata_table.c.source_type == "user",
+                    attachment_metadata_table.c.message_id.is_(None),
+                    attachment_metadata_table.c.created_at < cutoff,
+                )
+            )
+            .order_by(attachment_metadata_table.c.created_at)
+            .limit(limit)
+        )
+        candidate_rows = await db_context.fetch_all(candidate_query)
+        if not candidate_rows:
+            return 0
+
+        stored_paths = {
+            row["attachment_id"]: row["storage_path"] for row in candidate_rows
+        }
+        referenced = await self._referenced_attachment_ids(
+            db_context, list(stored_paths)
+        )
+        orphan_ids = [
+            attachment_id
+            for attachment_id in stored_paths
+            if attachment_id not in referenced
+        ]
+        if not orphan_ids:
+            return 0
+
+        await db_context.execute(
+            delete(attachment_metadata_table).where(
+                attachment_metadata_table.c.attachment_id.in_(orphan_ids)
+            )
+        )
+
+        # Files are unlinked only once the rows are gone, since the unlink
+        # cannot be rolled back. A file left behind by a failed unlink is
+        # collected by ``cleanup_orphaned_attachments``.
+        for attachment_id in orphan_ids:
+            self._delete_attachment_file(
+                attachment_id,
+                stored_path=stored_paths[attachment_id],
+                source_type="user",
+            )
+
+        logger.info(
+            f"Reaped {len(orphan_ids)} unreferenced attachments "
+            f"older than {grace_period}"
+        )
+        return len(orphan_ids)
+
+    async def _referenced_attachment_ids(
+        self, db_context: DatabaseExecutor, attachment_ids: list[str]
+    ) -> set[str]:
+        """Return the subset of ``attachment_ids`` some message or note names.
+
+        Nothing back-fills ``attachment_metadata.message_id`` for user
+        attachments, so the message reference lives in the
+        ``message_history.attachments`` JSON; the notes tool records its own
+        references in ``notes.attachment_ids``.
+        """
+        if not attachment_ids:
+            return set()
+
+        referenced: set[str] = set()
+        for query in (
+            self._message_reference_query(db_context.dialect_name, attachment_ids),
+            self._note_reference_query(db_context.dialect_name, attachment_ids),
+        ):
+            rows = await db_context.fetch_all(query)
+            referenced.update(
+                row["attachment_id"] for row in rows if row["attachment_id"]
+            )
+        return referenced
+
+    @staticmethod
+    def _message_reference_query(
+        dialect_name: str,
+        attachment_ids: list[str],
+    ) -> sa.Select:  # type: ignore[type-arg]  # Generic Select type params are complex with dialect-specific expressions
+        """Query yielding the given ids that appear in a message's attachments.
+
+        ``message_history.attachments`` holds a JSON array of objects keyed by
+        ``attachment_id``. A row whose value is not an array (including the
+        ``NULL`` of a message with no attachments) is expanded as an empty
+        array rather than being allowed to fail expansion.
+        """
+        attachments = message_history_table.c.attachments
+        if dialect_name == "postgresql":
+            array_value = sa.case(
+                (sa.func.jsonb_typeof(attachments) == "array", attachments),
+                else_=sa.cast(sa.literal("[]"), JSONB),
+            )
+            elements = sa.func.jsonb_array_elements(array_value).table_valued(
+                "value", joins_implicitly=True
+            )
+            attachment_id_expr = sa.func.jsonb_extract_path_text(
+                elements.c.value, "attachment_id"
+            )
+        else:
+            array_value = sa.case(
+                (sa.func.json_type(attachments) == "array", attachments),
+                else_=sa.literal("[]"),
+            )
+            elements = sa.func.json_each(array_value).table_valued(
+                "value", joins_implicitly=True
+            )
+            attachment_id_expr = sa.func.json_extract(
+                elements.c.value, "$.attachment_id"
+            )
+
+        return (
+            sa
+            .select(attachment_id_expr.label("attachment_id"))
+            .select_from(message_history_table)
+            .where(attachment_id_expr.in_(attachment_ids))
+            .distinct()
+        )
+
+    @staticmethod
+    def _note_reference_query(
+        dialect_name: str,
+        attachment_ids: list[str],
+    ) -> sa.Select:  # type: ignore[type-arg]  # Generic Select type params are complex with dialect-specific expressions
+        """Query yielding the given ids that appear in a note's attachment ids.
+
+        ``notes.attachment_ids`` holds a JSON array of attachment id strings.
+        """
+        note_attachments = notes_table.c.attachment_ids
+        if dialect_name == "postgresql":
+            elements = sa.func.jsonb_array_elements_text(
+                sa.cast(note_attachments, JSONB)
+            ).table_valued("value", joins_implicitly=True)
+        else:
+            elements = sa.func.json_each(note_attachments).table_valued(
+                "value", joins_implicitly=True
+            )
+        attachment_id_expr = elements.c.value
+
+        return (
+            sa
+            .select(attachment_id_expr.label("attachment_id"))
+            .select_from(notes_table)
+            .where(attachment_id_expr.in_(attachment_ids))
+            .distinct()
+        )
 
     async def update_attachment_conversation(
         self,
@@ -1590,17 +1791,25 @@ class AttachmentRegistry:
             return False
         return True
 
-    def _cleanup_orphaned_files(self, referenced_attachment_ids: set[str]) -> int:
+    def _cleanup_orphaned_files(
+        self,
+        referenced_attachment_ids: set[str],
+        *,
+        min_age: timedelta = DEFAULT_ATTACHMENT_GRACE_PERIOD,
+    ) -> int:
         """
         Clean up attachment files that are no longer referenced in the database.
 
         Args:
             referenced_attachment_ids: Set of attachment IDs that are still referenced
+            min_age: Only files last modified longer ago than this are deleted,
+                so a file whose row has not been committed yet survives.
 
         Returns:
             Number of files deleted
         """
         deleted_count = 0
+        cutoff = datetime.now(UTC) - min_age
 
         # Iterate through hash-prefixed directories (00-ff)
         for hash_dir in self.storage_path.glob("*/"):
@@ -1615,15 +1824,30 @@ class AttachmentRegistry:
                 file_stem = file_path.stem
                 try:
                     uuid.UUID(file_stem)  # Validate it's a UUID
-                    if file_stem not in referenced_attachment_ids:
-                        file_path.unlink()
-                        deleted_count += 1
-                        logger.info(f"Deleted orphaned attachment: {file_stem}")
-                except (ValueError, OSError) as e:
-                    logger.warning(
-                        f"Skipping non-UUID file or deletion error: {file_path}: {e}"
-                    )
+                except ValueError:
+                    logger.warning(f"Skipping non-UUID file: {file_path}")
                     continue
+
+                if file_stem in referenced_attachment_ids:
+                    continue
+
+                try:
+                    stat_result = file_path.stat()
+                except OSError as e:
+                    logger.warning(f"Skipping unreadable file {file_path}: {e}")
+                    continue
+
+                if datetime.fromtimestamp(stat_result.st_mtime, tz=UTC) >= cutoff:
+                    continue
+
+                try:
+                    file_path.unlink()
+                except OSError as e:
+                    logger.warning(f"Failed to delete orphaned file {file_path}: {e}")
+                    continue
+
+                deleted_count += 1
+                logger.info(f"Deleted orphaned attachment: {file_stem}")
 
         logger.info(f"Cleaned up {deleted_count} orphaned attachment files")
         return deleted_count

--- a/src/family_assistant/storage/repositories/tasks.py
+++ b/src/family_assistant/storage/repositories/tasks.py
@@ -5,10 +5,11 @@ from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
-from sqlalchemy import and_, insert, or_, select, update
+from sqlalchemy import and_, case, insert, null, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.sql import functions as func
+from sqlalchemy.sql.elements import ColumnElement
 
 from family_assistant.storage.database import DatabaseTransaction
 from family_assistant.storage.repositories.base import BaseRepository
@@ -16,6 +17,42 @@ from family_assistant.storage.tasks import notify_workers, tasks_table
 from family_assistant.storage.types import TaskDict
 
 logger = logging.getLogger(__name__)
+
+# Statuses a system task's row can be in when it has finished with the
+# occurrence it holds, and so can be handed the next one.
+TERMINAL_TASK_STATUSES = ("done", "failed")
+
+
+def _revive_if_terminal(
+    column_name: str,
+    revived_value: object,
+) -> ColumnElement[Any]:
+    """An UPDATE value that resets a finished occurrence and leaves others alone.
+
+    A system task keeps one row across occurrences, so the upsert that schedules
+    the next one has to hand that row back to the queue: without this the row
+    stays ``done`` after its first run and dequeue, which selects only pending
+    (or stale processing) rows, never picks it up again.
+
+    A row that is still ``pending`` or ``processing`` keeps its value — a
+    startup upsert must not resurrect an occurrence a worker is running, or
+    reset the retry count of one that is mid-retry.
+    """
+    return case(
+        (tasks_table.c.status.in_(TERMINAL_TASK_STATUSES), revived_value),
+        else_=tasks_table.c[column_name],
+    )
+
+
+def _revived_occurrence_values() -> dict[str, ColumnElement[Any]]:
+    """The columns an upserted system task resets when its occurrence is over."""
+    return {
+        "status": _revive_if_terminal("status", "pending"),
+        "retry_count": _revive_if_terminal("retry_count", 0),
+        "locked_by": _revive_if_terminal("locked_by", null()),
+        "locked_at": _revive_if_terminal("locked_at", null()),
+        "error": _revive_if_terminal("error", null()),
+    }
 
 
 class TasksRepository(BaseRepository):
@@ -97,6 +134,7 @@ class TasksRepository(BaseRepository):
                         "payload": stmt.excluded.payload,
                         "max_retries": stmt.excluded.max_retries,
                         "recurrence_rule": stmt.excluded.recurrence_rule,
+                        **_revived_occurrence_values(),
                     }
                     stmt = stmt.on_conflict_do_update(
                         index_elements=["task_id"],  # The unique constraint column
@@ -112,6 +150,7 @@ class TasksRepository(BaseRepository):
                             payload=payload,
                             max_retries=max_task_retries,
                             recurrence_rule=recurrence_rule,
+                            **_revived_occurrence_values(),
                         )
                     )
                     result = await txn.execute(update_stmt)

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -3882,8 +3882,13 @@ async def handle_attachment_cleanup(
     """
     registry = exec_context.attachment_registry
     if registry is None:
-        logger.warning("Attachment cleanup skipped: no attachment registry available")
-        return
+        # Returning here would record a successful pass that collected nothing,
+        # every day, while files accumulate. The missing registry is a broken
+        # worker configuration, so fail and let the task retry surface it.
+        raise RuntimeError(
+            "Attachment cleanup requires an attachment registry on the "
+            "execution context, but none was configured"
+        )
 
     grace_period = timedelta(hours=int(payload.get("grace_hours", 24)))
     limit = int(payload.get("limit", 500))

--- a/src/family_assistant/task_worker.py
+++ b/src/family_assistant/task_worker.py
@@ -349,6 +349,13 @@ class CompletedAutomationCleanupPayload(TypedDict, total=False):
     retention_hours: int
 
 
+class AttachmentCleanupPayload(TypedDict, total=False):
+    """Payload for attachment_cleanup tasks."""
+
+    grace_hours: int
+    limit: int
+
+
 class ScheduleAutomationAdvancePayload(TypedDict, total=False):
     """Payload for retryable schedule automation advancement tasks."""
 
@@ -3858,6 +3865,44 @@ async def handle_completed_automation_cleanup(
         raise
 
 
+async def handle_attachment_cleanup(
+    exec_context: ToolExecutionContext,
+    payload: AttachmentCleanupPayload,
+) -> None:
+    """Task handler for collecting attachments nothing references.
+
+    An upload commits its row and file before the message that would reference
+    it exists, so a send that never persists a message leaves both behind. This
+    reaps those rows with their files, then sweeps files that have no row at
+    all.
+
+    Payload can include:
+        grace_hours: Override the default 24-hour grace period
+        limit: Override the default per-pass row limit
+    """
+    registry = exec_context.attachment_registry
+    if registry is None:
+        logger.warning("Attachment cleanup skipped: no attachment registry available")
+        return
+
+    grace_period = timedelta(hours=int(payload.get("grace_hours", 24)))
+    limit = int(payload.get("limit", 500))
+
+    logger.info(f"Starting attachment cleanup (grace period: {grace_period})")
+
+    reaped = await registry.reap_unreferenced_attachments(
+        exec_context.db_context, grace_period=grace_period, limit=limit
+    )
+    files_deleted = await registry.cleanup_orphaned_attachments(
+        exec_context.db_context, min_age=grace_period
+    )
+
+    logger.info(
+        f"Attachment cleanup completed. Reaped {reaped} unreferenced "
+        f"attachments and deleted {files_deleted} files without a row."
+    )
+
+
 async def _process_script_wake_llm(
     exec_context: ToolExecutionContext,
     wake_contexts: list[WakeRequest],
@@ -4991,6 +5036,7 @@ __all__ = [
     "SCHEDULE_AUTOMATION_ADVANCE_TASK_TYPE",
     "TaskWorker",
     "build_script_confirmation_callback",
+    "handle_attachment_cleanup",
     "handle_confirmation_tool_execution",
     "handle_llm_callback",
     "handle_log_message",

--- a/tests/functional/tasks/test_system_task_recurrence.py
+++ b/tests/functional/tasks/test_system_task_recurrence.py
@@ -1,0 +1,85 @@
+"""A recurring system task has to come back after the occurrence it finished.
+
+System tasks keep one row across occurrences — the recurrence and the startup
+setup both re-enqueue under the same ``system_...`` id — so the upsert that
+schedules the next occurrence is the only thing that can hand the row back to
+the queue. Dequeue selects pending (or stale processing) rows, so a row left
+``done`` is a task that has silently stopped running.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import select
+
+from family_assistant.storage.database import Database
+from family_assistant.storage.tasks import tasks_table
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+TASK_ID = "system_probe_cleanup_daily"
+RECURRENCE = "FREQ=DAILY;BYHOUR=3;BYMINUTE=0"
+
+
+async def _enqueue_probe(db_context: Database, *, scheduled_at: datetime) -> None:
+    await db_context.tasks.enqueue(
+        task_id=TASK_ID,
+        task_type="probe_cleanup",
+        payload={},
+        scheduled_at=scheduled_at,
+        recurrence_rule=RECURRENCE,
+        max_retries_override=5,
+    )
+
+
+async def _row(db_context: Database) -> dict:
+    row = await db_context.fetch_one(
+        select(tasks_table).where(tasks_table.c.task_id == TASK_ID)
+    )
+    assert row is not None
+    return dict(row)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("finished_status", ["done", "failed"])
+async def test_next_occurrence_returns_a_finished_row_to_the_queue(
+    db_engine: AsyncEngine, finished_status: str
+) -> None:
+    db_context = Database(engine=db_engine)
+    await _enqueue_probe(db_context, scheduled_at=datetime.now(UTC))
+    await db_context.tasks.update_status(task_id=TASK_ID, status=finished_status)
+
+    next_run = datetime.now(UTC) + timedelta(days=1)
+    await _enqueue_probe(db_context, scheduled_at=next_run)
+
+    row = await _row(db_context)
+    assert row["status"] == "pending"
+    assert row["retry_count"] == 0
+    assert row["locked_by"] is None
+    assert row["locked_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_does_not_resurrect_a_running_occurrence(
+    db_engine: AsyncEngine,
+) -> None:
+    """A startup upsert must not hand a worker's in-flight occurrence back out."""
+    db_context = Database(engine=db_engine)
+    await _enqueue_probe(db_context, scheduled_at=datetime.now(UTC))
+    claimed = await db_context.tasks.dequeue(
+        worker_id="worker-1",
+        task_types=["probe_cleanup"],
+        current_time=datetime.now(UTC),
+    )
+    assert claimed is not None
+    assert claimed["task_id"] == TASK_ID
+
+    await _enqueue_probe(db_context, scheduled_at=datetime.now(UTC) + timedelta(days=1))
+
+    row = await _row(db_context)
+    assert row["status"] == "processing"
+    assert row["locked_by"] == "worker-1"

--- a/tests/unit/attachments/test_attachment_reaper.py
+++ b/tests/unit/attachments/test_attachment_reaper.py
@@ -1,0 +1,323 @@
+"""Unit tests for reaping attachments that nothing references.
+
+An upload commits its ``attachment_metadata`` row and file before the message
+that would reference it exists, so every send that never persists a message —
+an abandoned compose, a failed kickoff, a refused concurrent turn — leaves both
+behind. The reaper collects those rows once they are past the grace period, and
+only those: anything a message or a note names, anything still inside the grace
+period, and anything a producer other than an upload owns stays put.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import select, update
+
+from family_assistant.services.attachment_registry import AttachmentRegistry
+from family_assistant.storage.base import attachment_metadata_table
+from family_assistant.storage.database import Database
+from family_assistant.storage.message_history import add_message_to_history
+from family_assistant.storage.repositories.notes import NoteWritePolicy
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+USER = "user_uploader"
+CONVERSATION = "conversation-1"
+GRACE = timedelta(hours=24)
+
+
+async def _upload(
+    registry: AttachmentRegistry,
+    db_context: Database,
+    *,
+    age: timedelta,
+    filename: str = "photo.png",
+) -> str:
+    """Register a user upload and backdate it by ``age``."""
+    metadata = await registry.register_user_attachment(
+        db_context=db_context,
+        content=b"file bytes",
+        filename=filename,
+        mime_type="image/png",
+        user_id=USER,
+    )
+    await _backdate(registry, db_context, metadata.attachment_id, age)
+    return metadata.attachment_id
+
+
+async def _backdate(
+    registry: AttachmentRegistry,
+    db_context: Database,
+    attachment_id: str,
+    age: timedelta,
+) -> None:
+    """Age both the row and its file, as the passage of time would."""
+    created_at = datetime.now(UTC) - age
+    await db_context.execute(
+        update(attachment_metadata_table)
+        .where(attachment_metadata_table.c.attachment_id == attachment_id)
+        .values(created_at=created_at)
+    )
+    file_path = registry.get_attachment_path(attachment_id)
+    if file_path and file_path.exists():
+        timestamp = created_at.timestamp()
+        os.utime(file_path, (timestamp, timestamp))
+
+
+async def _row_exists(db_context: Database, attachment_id: str) -> bool:
+    row = await db_context.fetch_one(
+        select(attachment_metadata_table.c.attachment_id).where(
+            attachment_metadata_table.c.attachment_id == attachment_id
+        )
+    )
+    return row is not None
+
+
+def _file_exists(registry: AttachmentRegistry, attachment_id: str) -> bool:
+    file_path = registry.get_attachment_path(attachment_id)
+    return file_path is not None and file_path.exists()
+
+
+@pytest.fixture
+def registry_and_db(
+    db_engine: AsyncEngine,
+) -> Generator[tuple[AttachmentRegistry, Database]]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield (
+            AttachmentRegistry(storage_path=temp_dir, db_engine=db_engine, config=None),
+            Database(engine=db_engine),
+        )
+
+
+class TestReapUnreferencedAttachments:
+    @pytest.mark.asyncio
+    async def test_abandoned_upload_is_collected(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        registry, db_context = registry_and_db
+        attachment_id = await _upload(registry, db_context, age=timedelta(days=2))
+
+        reaped = await registry.reap_unreferenced_attachments(
+            db_context, grace_period=GRACE
+        )
+
+        assert reaped == 1
+        assert not await _row_exists(db_context, attachment_id)
+        assert not _file_exists(registry, attachment_id)
+
+    @pytest.mark.asyncio
+    async def test_upload_inside_grace_period_survives(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        registry, db_context = registry_and_db
+        attachment_id = await _upload(registry, db_context, age=timedelta(hours=1))
+
+        reaped = await registry.reap_unreferenced_attachments(
+            db_context, grace_period=GRACE
+        )
+
+        assert reaped == 0
+        assert await _row_exists(db_context, attachment_id)
+        assert _file_exists(registry, attachment_id)
+
+    @pytest.mark.asyncio
+    async def test_attachment_a_message_references_survives(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        registry, db_context = registry_and_db
+        sent = await _upload(registry, db_context, age=timedelta(days=2))
+        abandoned = await _upload(
+            registry, db_context, age=timedelta(days=2), filename="abandoned.png"
+        )
+
+        await add_message_to_history(
+            db_context,
+            interface_type="web",
+            conversation_id=CONVERSATION,
+            interface_message_id=None,
+            turn_id=None,
+            thread_root_id=None,
+            timestamp=datetime.now(UTC),
+            role="user",
+            content="here is a photo",
+            attachments=[
+                {
+                    "type": "image",
+                    "attachment_id": sent,
+                    "mime_type": "image/png",
+                }
+            ],
+        )
+        # A message with no attachments at all must not upset the scan.
+        await add_message_to_history(
+            db_context,
+            interface_type="web",
+            conversation_id=CONVERSATION,
+            interface_message_id=None,
+            turn_id=None,
+            thread_root_id=None,
+            timestamp=datetime.now(UTC),
+            role="assistant",
+            content="nice photo",
+        )
+
+        reaped = await registry.reap_unreferenced_attachments(
+            db_context, grace_period=GRACE
+        )
+
+        assert reaped == 1
+        assert await _row_exists(db_context, sent)
+        assert _file_exists(registry, sent)
+        assert not await _row_exists(db_context, abandoned)
+
+    @pytest.mark.asyncio
+    async def test_attachment_a_note_references_survives(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        registry, db_context = registry_and_db
+        attached_to_note = await _upload(registry, db_context, age=timedelta(days=2))
+
+        await db_context.notes.add_or_update(
+            title="Receipts",
+            content="scanned receipt",
+            attachment_ids=[attached_to_note],
+            write_policy=NoteWritePolicy.UNCONSTRAINED,
+        )
+
+        reaped = await registry.reap_unreferenced_attachments(
+            db_context, grace_period=GRACE
+        )
+
+        assert reaped == 0
+        assert await _row_exists(db_context, attached_to_note)
+        assert _file_exists(registry, attached_to_note)
+
+    @pytest.mark.asyncio
+    async def test_attachment_linked_to_a_message_row_survives(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        registry, db_context = registry_and_db
+        attachment_id = await _upload(registry, db_context, age=timedelta(days=2))
+        message_id = await add_message_to_history(
+            db_context,
+            interface_type="web",
+            conversation_id=CONVERSATION,
+            interface_message_id=None,
+            turn_id=None,
+            thread_root_id=None,
+            timestamp=datetime.now(UTC),
+            role="user",
+            content="linked by column",
+        )
+        await db_context.execute(
+            update(attachment_metadata_table)
+            .where(attachment_metadata_table.c.attachment_id == attachment_id)
+            .values(message_id=message_id)
+        )
+
+        reaped = await registry.reap_unreferenced_attachments(
+            db_context, grace_period=GRACE
+        )
+
+        assert reaped == 0
+        assert await _row_exists(db_context, attachment_id)
+
+    @pytest.mark.asyncio
+    async def test_tool_attachment_is_never_a_candidate(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        registry, db_context = registry_and_db
+        metadata = await registry.store_and_register_tool_attachment(
+            file_content=b"tool output",
+            filename="chart.png",
+            content_type="image/png",
+            tool_name="make_chart",
+            db_context=db_context,
+        )
+        await _backdate(registry, db_context, metadata.attachment_id, timedelta(days=9))
+
+        reaped = await registry.reap_unreferenced_attachments(
+            db_context, grace_period=GRACE
+        )
+
+        assert reaped == 0
+        assert await _row_exists(db_context, metadata.attachment_id)
+        assert _file_exists(registry, metadata.attachment_id)
+
+    @pytest.mark.asyncio
+    async def test_batch_limit_bounds_one_pass(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        registry, db_context = registry_and_db
+        for index in range(3):
+            await _upload(
+                registry,
+                db_context,
+                age=timedelta(days=2),
+                filename=f"abandoned-{index}.png",
+            )
+
+        assert (
+            await registry.reap_unreferenced_attachments(
+                db_context, grace_period=GRACE, limit=2
+            )
+            == 2
+        )
+        assert (
+            await registry.reap_unreferenced_attachments(
+                db_context, grace_period=GRACE, limit=2
+            )
+            == 1
+        )
+
+
+class TestCleanupOrphanedFiles:
+    @pytest.mark.asyncio
+    async def test_file_without_a_row_is_collected_once_it_ages(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        registry, db_context = registry_and_db
+        attachment_id = await _upload(registry, db_context, age=timedelta(days=2))
+        await db_context.execute(
+            attachment_metadata_table.delete().where(
+                attachment_metadata_table.c.attachment_id == attachment_id
+            )
+        )
+
+        deleted = await registry.cleanup_orphaned_attachments(db_context, min_age=GRACE)
+
+        assert deleted == 1
+        assert not _file_exists(registry, attachment_id)
+
+    @pytest.mark.asyncio
+    async def test_freshly_written_file_is_left_for_its_row_to_commit(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        registry, db_context = registry_and_db
+        metadata = await registry.register_user_attachment(
+            db_context=db_context,
+            content=b"just written",
+            filename="in-flight.png",
+            mime_type="image/png",
+            user_id=USER,
+        )
+        # Stand in for the window between the file landing on disk and its row
+        # being committed: the file is new, and no row names it.
+        await db_context.execute(
+            attachment_metadata_table.delete().where(
+                attachment_metadata_table.c.attachment_id == metadata.attachment_id
+            )
+        )
+
+        deleted = await registry.cleanup_orphaned_attachments(db_context, min_age=GRACE)
+
+        assert deleted == 0
+        assert _file_exists(registry, metadata.attachment_id)

--- a/tests/unit/attachments/test_attachment_reaper.py
+++ b/tests/unit/attachments/test_attachment_reaper.py
@@ -295,6 +295,43 @@ class TestReapUnreferencedAttachments:
         assert not await _row_exists(db_context, abandoned)
 
     @pytest.mark.asyncio
+    async def test_orphans_beyond_the_first_page_are_reached(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        """Paging walks past whole pages of referenced candidates."""
+        registry, db_context = registry_and_db
+        registry.REAP_PAGE_SIZE = 2
+        for index in range(4):
+            sent = await _upload(
+                registry,
+                db_context,
+                age=timedelta(days=10),
+                filename=f"sent-{index}.png",
+            )
+            await add_message_to_history(
+                db_context,
+                interface_type="web",
+                conversation_id=CONVERSATION,
+                interface_message_id=None,
+                turn_id=None,
+                thread_root_id=None,
+                timestamp=datetime.now(UTC),
+                role="user",
+                content="here is a photo",
+                attachments=[{"type": "image", "attachment_id": sent}],
+            )
+        abandoned = await _upload(
+            registry, db_context, age=timedelta(days=2), filename="abandoned.png"
+        )
+
+        reaped = await registry.reap_unreferenced_attachments(
+            db_context, grace_period=GRACE
+        )
+
+        assert reaped == 1
+        assert not await _row_exists(db_context, abandoned)
+
+    @pytest.mark.asyncio
     async def test_batch_limit_bounds_one_pass(
         self, registry_and_db: tuple[AttachmentRegistry, Database]
     ) -> None:

--- a/tests/unit/attachments/test_attachment_reaper.py
+++ b/tests/unit/attachments/test_attachment_reaper.py
@@ -253,6 +253,48 @@ class TestReapUnreferencedAttachments:
         assert _file_exists(registry, metadata.attachment_id)
 
     @pytest.mark.asyncio
+    async def test_sent_uploads_do_not_starve_the_limit(
+        self, registry_and_db: tuple[AttachmentRegistry, Database]
+    ) -> None:
+        """Older sent uploads must not consume the pass's budget.
+
+        Nothing back-fills ``message_id``, so every upload a message references
+        stays in the candidate columns forever. If the limit were applied before
+        the reference exclusion, the oldest of those would fill it on every pass
+        and the orphan behind them would never be reached.
+        """
+        registry, db_context = registry_and_db
+        for index in range(3):
+            sent = await _upload(
+                registry,
+                db_context,
+                age=timedelta(days=10),
+                filename=f"sent-{index}.png",
+            )
+            await add_message_to_history(
+                db_context,
+                interface_type="web",
+                conversation_id=CONVERSATION,
+                interface_message_id=None,
+                turn_id=None,
+                thread_root_id=None,
+                timestamp=datetime.now(UTC),
+                role="user",
+                content="here is a photo",
+                attachments=[{"type": "image", "attachment_id": sent}],
+            )
+        abandoned = await _upload(
+            registry, db_context, age=timedelta(days=2), filename="abandoned.png"
+        )
+
+        reaped = await registry.reap_unreferenced_attachments(
+            db_context, grace_period=GRACE, limit=2
+        )
+
+        assert reaped == 1
+        assert not await _row_exists(db_context, abandoned)
+
+    @pytest.mark.asyncio
     async def test_batch_limit_bounds_one_pass(
         self, registry_and_db: tuple[AttachmentRegistry, Database]
     ) -> None:


### PR DESCRIPTION
Fixes #1083.

## The orphan

The web client uploads first and sends second, so the `attachment_metadata` row and its file exist
before the message that would reference them. Every send that never persists a message leaves both
behind forever — an abandoned compose, a failed kickoff, a dropped network, or (since #1077) a send
refused with 409 because the conversation already has a running turn.

Nothing collected them. `cleanup_orphaned_attachments` built its referenced-set from *every* row in
`attachment_metadata`, so it could only delete files with no row at all, and it had no caller
anywhere in the tree.

## The reaper

`AttachmentRegistry.reap_unreferenced_attachments` deletes rows past a grace period (24h) that
nothing references, with their files. That covers every route to the orphan rather than the one the
turn guard added, which is why the fix isn't in the guard.

Candidates are `source_type = "user"` rows only — the class the upload endpoint and interface
handlers create. Tool, script and email rows are referenced from places this reaper does not read
(delegation runs, scripts, `received_emails.attachment_info`), so they are never collected. A
candidate is referenced when `message_id` is set, when a `message_history.attachments` entry names
it (the reference the send path actually writes — nothing back-fills `message_id` for user
attachments), or when a `notes.attachment_ids` entry does. Both JSON checks are dialect-specific,
following the `json_each`/`JSONB` pattern already used for note visibility labels.

Because nothing back-fills `message_id`, the candidate set is "every user attachment ever", not
"the orphans". So the batch limit bounds rows *collected* rather than examined, and candidates are
walked oldest-first in keyset pages with each page's references resolved by one scan of each JSON
column — a pass that collects nothing costs one scan per page, not one per historical attachment.

## `cleanup_orphaned_attachments`

Kept, with the narrower job it actually does: files with no metadata row at all — leftovers from a
store that committed the file but not the row, and files of reaped rows whose unlink failed. It runs
as the second phase of the same task, skips files newer than the grace period so an in-flight upload
isn't collected before its row commits, and runs via `asyncio.to_thread` so the store traversal
never holds the event loop the workers share with web and Telegram.

Both phases run from a new daily `attachment_cleanup` system task, scheduled at 3am local alongside
the other cleanups.

## A recurring system task ran exactly once

Scheduling the new task surfaced a pre-existing bug in shared machinery. A system task keeps one row
across occurrences — the recurrence and the startup setup both re-enqueue under the same `system_`
id — and the upsert updated schedule and payload but not status. A row marked `done` by its first
run stayed `done`, and dequeue selects only pending (or stale processing) rows, so **every**
recurring system task ran once and never again: event cleanup, error logs, worker tasks, completed
automations, the hourly delegation reaper, and this one.

The upsert now resets a terminal row (`done`, `failed`) to `pending` with its retry count zeroed and
locks cleared, on both the PostgreSQL `ON CONFLICT` path and the SQLite update path. A row still
`pending` or `processing` keeps those columns, so a startup upsert cannot resurrect an occurrence a
worker is running or reset one that is mid-retry.

## Testing

`tests/unit/attachments/test_attachment_reaper.py` (11 tests, both backends): abandoned upload
collected with its file; upload inside the grace period survives; upload a message references
survives while its abandoned sibling goes; upload a note references survives; row linked via
`message_id` survives; tool attachment never a candidate; sent uploads don't starve the limit;
orphans behind whole pages of referenced candidates are still reached; batch limit bounds a pass;
file without a row collected once it ages, left alone while fresh.

`tests/functional/tasks/test_system_task_recurrence.py` (3 tests, both backends): a finished row
returns to the queue from either terminal status, and an in-flight occurrence is not resurrected.
Both fail on the pre-fix code.

Design note in `docs/design/attachment-orphan-reaper.md`; user-facing behaviour in
`docs/user/attachments.md`.