### PR TITLE
Reserve a hub turn for non-streaming sends

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -171,6 +171,31 @@ POST /api/v1/chat/send_message
 returns the already-persisted reply instead of re-driving the LLM and persisting a second copy. The
 retry's response carries `already_complete: true`. Omit `turn_id` to always generate a fresh reply.
 
+**409 Conflict — the conversation already has a running turn.** `/send_message` takes the same
+one-turn-per-conversation reservation as `POST /v1/chat/turns`, so a send that lands while a turn is
+already running on that conversation — from the web UI, another device, or another API client — is
+refused rather than started alongside it. The refusal carries the same payload as the streaming
+path:
+
+```json
+{
+  "detail": {
+    "message": "This conversation already has a running turn. Steer that turn instead of starting a new one.",
+    "active_turn_id": "uuid-of-the-running-turn",
+    "active_turn_first_seq": 12
+  }
+}
+```
+
+A non-streaming turn is not steerable — it publishes no event stream to carry a steer echo — so a
+client refused by one should wait for it to finish and resend, or send into a different
+conversation. Turns started by `/send_message` are short-lived; there is no lingering reservation to
+wait out once the reply is returned.
+
+A `turn_id` that this backend has already run but that produced no persisted reply (its turn failed)
+is also refused with 409, carrying `turn_id` and `turn_status` instead of `active_turn_id`. Retry
+that message under a fresh `turn_id`.
+
 **Response:**
 
 ```json

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -376,9 +376,10 @@ Replays buffered events with `seq >= from_seq`, then tails live events.
   `{"request_id": "...", "approved": true | false}`.
 - `error` - Error occurred: `{"error": "message", "error_id": "..."}`
 - `message` - Content-free "new messages were persisted" nudge published outside the token stream
-  (e.g. by the non-streaming `/send_message` path or a reply delivered from another interface):
+  (e.g. a reply delivered from another interface, such as a scheduled callback):
   `{"new_messages": true}`. A follow client reacts by reloading conversation history rather than
-  rendering tokens.
+  rendering tokens. A `/send_message` turn does not publish one — its `turn_ended` already tells a
+  follower to reload.
 - `turn_ended` - The turn finished: `{"status": "complete" | "failed", "reasoning_info": {...}}`.
   After handling this, a client should `POST /ack` with its `seq`.
 - `heartbeat` - Keep-alive on `follow=true` (and idle non-follow) streams: `{}`.

--- a/docs/design/resumable_streaming.md
+++ b/docs/design/resumable_streaming.md
@@ -103,6 +103,38 @@ that invariant:
   attaches to the user's own new conversation before any message is sent. `conversation_id`s are
   unguessable UUIDs, so this is not a meaningful way to wait on someone else's future conversation.
 
+### One turn at a time, on every turn-producing endpoint
+
+A conversation runs one turn at a time. Two LLM loops over one history interleave their writes, and
+the newcomer rebuilds history mid-flight: it sees the running turn's unanswered tool call and fills
+it with the "abandoned" placeholder while the real result is still coming.
+
+The reservation lives in the hub, not in the endpoint: `start_turn(reject_if_running=True)` refuses
+registration under the same lock that performs it, so two concurrent kickoffs cannot both find the
+conversation idle. Every endpoint that drives a turn takes it, which is what makes the invariant
+hold across surfaces rather than within one of them:
+
+- `POST /turns` reserves before launching its producer task; the producer's terminal `end_turn`
+  (with the hub's done-callback as the safety net) releases it. Its record outlives the turn — the
+  buffer replay, the ack and the push-suppression window all read it — and is aged out by
+  `_prune_completed_turns`.
+- `POST /send_message` reserves for the duration of `handle_chat_interaction` and ends the turn with
+  a terminal status in a `finally`, so an exception, a 500, or a client hanging up mid-turn releases
+  the conversation rather than wedging it at `running` (neither pruning nor eviction touches a
+  running turn). It then **discards** the record: a non-streaming turn has no task, no deltas to
+  replay and no ack to wait for, and keeping the record would burn its `turn_id` for a retry of a
+  turn that failed without persisting a reply.
+
+Rivals in either direction get the same 409 naming the running turn. A streaming turn is steerable,
+so its rival can hand its prompt to the running turn instead; a `/send_message` turn is not — it
+publishes no stream to carry the steer echo — so a client refused by one waits and resends. That is
+tolerable because such a turn is short-lived and holds the reservation only while the request is in
+flight; making it steerable would mean giving a headless caller an event stream it never reads.
+
+`/send_message`'s idempotency is unaffected: it is settled from the persisted reply, not the hub
+record, so a retry that already produced a reply returns it (`already_complete: true`) without
+reaching the reservation at all.
+
 ## Deployment constraints (load-bearing)
 
 This is a **single-process** FastAPI deployment serving 1–2 users. The hub is **in-memory only**:

--- a/src/family_assistant/web/conversation_stream_hub.py
+++ b/src/family_assistant/web/conversation_stream_hub.py
@@ -350,6 +350,38 @@ class ConversationStreamHub:
         for turn in prunable[:excess]:
             state.turns.pop(turn.turn_id, None)
 
+    async def discard_turn(self, conversation_id: str, turn_id: str) -> None:
+        """Forget a turn record entirely, releasing its ``turn_id``.
+
+        For turns whose record exists only to hold the one-turn-per-conversation
+        reservation — the non-streaming ``POST /send_message`` path, which has no
+        producer task, no buffered deltas to replay and no ack to wait for. Once
+        such a turn has ended, keeping its record would make its ``turn_id``
+        permanently unusable: ``start_turn`` refuses a duplicate id, so a client
+        retrying a turn that failed without persisting a reply could never
+        re-drive it. Streaming turns are NOT discarded here — their records own
+        the hub's only strong reference to the producer task and are aged out by
+        ``_prune_completed_turns`` instead.
+
+        No-op for an unknown conversation or turn, so it is safe in a ``finally``
+        that may run after the record was already dropped.
+        """
+        state = self._get_state(conversation_id)
+        if state is None:
+            return
+        async with state.lock:
+            turn = state.turns.get(turn_id)
+            if turn is None:
+                return
+            if turn.task is not None and not turn.task.done():
+                logger.warning(
+                    "Refusing to discard turn %s in conv=%s: producer task still live",
+                    turn_id,
+                    conversation_id,
+                )
+                return
+            del state.turns[turn_id]
+
     def get_turn(self, conversation_id: str, turn_id: str) -> TurnRecord | None:
         """Return a turn record by id, or None if not in the hub."""
         state = self._get_state(conversation_id)

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -5,7 +5,9 @@ import json
 import logging
 import mimetypes
 import uuid
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
@@ -61,6 +63,7 @@ from family_assistant.web.conversation_stream_hub import (
     StreamEvent,
     TurnAlreadyExistsError,
     TurnRecord,
+    TurnStatus,
 )
 from family_assistant.web.dependencies import (
     get_attachment_registry,
@@ -723,9 +726,15 @@ def _running_turn_conflict(
 ) -> HTTPException:
     """Build the 409 that refuses a rival turn and names the running one.
 
-    Raised from two places — the early check in ``POST /turns`` and the
-    authoritative one inside ``start_turn`` — so the client sees one shape
-    regardless of where the rival lost.
+    Raised from three places — the early check in ``POST /turns``, the
+    authoritative one inside ``start_turn``, and the reservation taken by
+    ``POST /send_message`` — so the client sees one shape regardless of where
+    the rival lost, and regardless of which endpoint holds the conversation.
+
+    A running turn started by ``/send_message`` carries no mid-turn controller,
+    so steering it answers 409 and the client falls back to holding the prompt.
+    That is the intended outcome: a non-streaming turn is short-lived and has no
+    event stream to carry a steer echo, so its rivals wait rather than steer.
     """
     logger.info(
         "Rejecting turn %s: conversation %s already has running turn %s.",
@@ -747,6 +756,122 @@ def _running_turn_conflict(
             "active_turn_first_seq": running_turn.first_seq,
         },
     )
+
+
+def _duplicate_turn_conflict(
+    conversation_id: str, turn_id: str, existing_turn: TurnRecord
+) -> HTTPException:
+    """Build the 409 that refuses a ``turn_id`` this process already finished.
+
+    ``POST /send_message`` is idempotent on ``turn_id`` via the persisted reply,
+    so a retry of a turn that produced one never reaches here. What does is a
+    retry of a turn that ended WITHOUT a reply (it failed, or it was a streaming
+    turn of the same id that failed): re-driving it under the same id would
+    collide with the finished record, so the client is told to retry under a new
+    one rather than being handed a misleading "a turn is running" conflict.
+    """
+    logger.info(
+        "Rejecting send_message turn %s in conversation %s: turn id already used "
+        "(status=%s).",
+        turn_id,
+        conversation_id,
+        existing_turn.status,
+    )
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "message": (
+                "This turn id has already been used and produced no reply. "
+                "Retry with a new turn id."
+            ),
+            "turn_id": turn_id,
+            "turn_status": existing_turn.status,
+        },
+    )
+
+
+@dataclass(slots=True)
+class _NonStreamingTurnReservation:
+    """Mutable outcome handle for a ``/send_message`` hub reservation.
+
+    The turn is assumed to have failed until the endpoint says otherwise, so an
+    exception (or a return path that never reached the reply) ends the hub turn
+    with a terminal ``failed`` status rather than leaving it wedged at
+    ``running`` and blocking the conversation.
+    """
+
+    turn: TurnRecord
+    status: TurnStatus = "failed"
+    error: str | None = "An internal error occurred."
+
+    def mark_complete(self) -> None:
+        """Record that the turn produced a reply."""
+        self.status = "complete"
+        self.error = None
+
+
+@asynccontextmanager
+async def _reserve_non_streaming_turn(
+    hub: ConversationStreamHub,
+    conversation_id: str,
+    *,
+    turn_id: str,
+    user_id: str,
+) -> AsyncIterator[_NonStreamingTurnReservation]:
+    """Hold the one-turn-per-conversation reservation across a non-streaming send.
+
+    ``POST /send_message`` drives a full LLM loop over the same history as the
+    streaming path, so it must take the same reservation: two loops on one
+    conversation interleave their writes, and a turn that rebuilds history while
+    another's tool call is in flight answers that call with the "abandoned"
+    placeholder even though the real result is about to be written.
+
+    The record is created before any of the turn's work, ended with a terminal
+    status in a ``finally`` (so a failure or a client disconnect mid-turn
+    releases it), and then discarded — it exists only as the reservation, and
+    keeping it would burn its ``turn_id`` for retries.
+    """
+    try:
+        turn = await hub.start_turn(
+            conversation_id,
+            turn_id=turn_id,
+            user_id=user_id,
+            started_at=datetime.now(UTC),
+            reject_if_running=True,
+        )
+    except ConversationTurnRunningError as exc:
+        raise _running_turn_conflict(conversation_id, turn_id, exc.turn) from exc
+    except TurnAlreadyExistsError as exc:
+        if exc.turn.user_id != user_id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND) from exc
+        if exc.turn.status == "running":
+            # A concurrent request carrying the same turn_id is still driving it.
+            raise _running_turn_conflict(conversation_id, turn_id, exc.turn) from exc
+        raise _duplicate_turn_conflict(conversation_id, turn_id, exc.turn) from exc
+
+    reservation = _NonStreamingTurnReservation(turn=turn)
+    try:
+        yield reservation
+    except asyncio.CancelledError:
+        # The client hung up (an App Intent timing out, say). The turn stopped
+        # where it stood; say so rather than reporting a failure.
+        reservation.status = "cancelled"
+        reservation.error = None
+        raise
+    finally:
+        # ``discard_turn`` sits in its own ``finally``: if ``end_turn`` is
+        # interrupted (it can await a contended lock while this task is being
+        # cancelled), the record must still be released or the conversation
+        # would refuse every later turn.
+        try:
+            await hub.end_turn(
+                conversation_id,
+                turn_id=turn_id,
+                status=reservation.status,
+                error=reservation.error,
+            )
+        finally:
+            await hub.discard_turn(conversation_id, turn_id)
 
 
 # Lifecycle/control frames that an ``event_types`` allow-list must never filter
@@ -2001,10 +2126,12 @@ async def api_chat_send_message(
     # turn_id idempotency (minimal): the client may supply a UUID so a retried
     # /send_message returns the already-persisted reply instead of re-driving
     # the LLM and double-persisting. Mirrors /turns — in-memory hub fast path
-    # plus durable DB fallback — but without the hub turn lifecycle.
+    # plus durable DB fallback. The hub turn taken below is the reservation, not
+    # the idempotency record: it is discarded when the send ends, so a turn that
+    # produced a reply is recognised from the database rather than from memory.
     response_turn_id = payload.turn_id or str(uuid.uuid4())
+    hub = _get_hub(request)
     if payload.turn_id is not None:
-        hub = _get_hub(request)
         existing_turn = hub.get_turn(conversation_id, payload.turn_id)
         if existing_turn is not None and existing_turn.user_id != user_id:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
@@ -2053,214 +2180,224 @@ async def api_chat_send_message(
             f"API chat request (no profile_id specified). Using default profile: '{default_processing_service.service_config.id}'. Conversation ID: {conversation_id}, Prompt: '{payload.prompt[:100]}...'"
         )
 
-    # Process user attachments if present
-    trigger_content_parts: list[ContentPartDict] = [
-        {"type": "text", "text": payload.prompt}  # type: ignore[typeddict-item]  # Runtime dict matches TypedDict structure
-    ]
-    trigger_attachments: list[MessageAttachmentMetadata] | None = None
+    # One turn at a time per conversation: hold the same hub reservation the
+    # streaming path takes, so a non-streaming send (an iOS App Intent, Siri, or
+    # an API client) cannot drive a second LLM loop over a history a running turn
+    # is still writing to. Rivals in either direction get the same 409.
+    async with _reserve_non_streaming_turn(
+        hub, conversation_id, turn_id=response_turn_id, user_id=user_id
+    ) as reservation:
+        # Process user attachments if present
+        trigger_content_parts: list[ContentPartDict] = [
+            {"type": "text", "text": payload.prompt}  # type: ignore[typeddict-item]  # Runtime dict matches TypedDict structure
+        ]
+        trigger_attachments: list[MessageAttachmentMetadata] | None = None
 
-    if payload.attachments:
-        # Only get attachment registry when we actually have attachments
-        attachment_registry = await get_attachment_registry(request)
-        trigger_content_parts, trigger_attachments = await _process_user_attachments(
-            payload,
-            conversation_id,
-            attachment_registry,
-            db_context,
-            current_user["user_identifier"],
-        )
-
-    # Determine interface type - default to "api" if not specified
-    interface_type = payload.interface_type or "api"
-
-    # Call the new centralized interaction handler
-    # user_name surfaces in the system prompt and message history, so derive it
-    # from the authenticated user rather than a generic placeholder.
-    user_name_for_api = _user_name_for_chat(current_user)
-
-    # Get chat_interfaces registry from app state for cross-interface messaging
-    chat_interfaces = getattr(request.app.state, "chat_interfaces", None)
-    confirmation_ui_managers = getattr(
-        request.app.state,
-        "confirmation_ui_managers",
-        None,
-    )
-
-    # Non-streaming callers (e.g. iOS App Intents / Siri) cannot wait on a live
-    # confirmation channel, so a tool needing approval records a durable pending
-    # confirmation the user can approve later from another client (the
-    # confirmation service push-notifies them). The deferred tool result tells
-    # the model the action is awaiting approval so the reply reflects that.
-    api_confirmation_service = _get_confirmation_service(request)
-
-    async def api_confirmation_callback(
-        interface_type: str,
-        conversation_id: str,
-        turn_id: str | None,
-        tool_name: str,
-        call_id: str,
-        # ast-grep-ignore: no-dict-any - Tool arguments vary per tool and cannot be statically typed
-        tool_args: dict[str, Any],
-        timeout_seconds: float,
-        context: ToolExecutionContext,
-    ) -> ConfirmationOutcome:
-        taint_state_json = (
-            context.taint_tracker.snapshot().to_metadata()
-            if context.taint_tracker is not None
-            else None
-        )
-        durable_request = await create_durable_confirmation(
-            confirmation_service=api_confirmation_service,
-            db_context=context.db_context,
-            target_user_id=current_user["user_identifier"],
-            tool_name=tool_name,
-            tool_call_id=call_id,
-            tool_args=tool_args,
-            confirmation_prompt=(
-                f"Do you want to execute '{tool_name}' with these parameters?"
-            ),
-            timeout_seconds=timeout_seconds,
-            turn_id=turn_id,
-            now=datetime.now(UTC),
-            processing_profile_id=context.processing_profile_id,
-            origin_interface_type=context.interface_type,
-            origin_conversation_id=context.conversation_id,
-            taint_state_json=taint_state_json,
-        )
-        return ConfirmationOutcome(
-            kind="completed",
-            result=(
-                f"I've requested your approval to run '{tool_name}' "
-                f"(request {durable_request['id']}). It hasn't run yet — approve it "
-                "from your pending confirmations to continue."
-            ),
-        )
-
-    result = await selected_processing_service.handle_chat_interaction(
-        db_context=db_context,
-        interface_type=interface_type,  # Use the interface_type from request or default "api"
-        conversation_id=conversation_id,
-        trigger_content_parts=trigger_content_parts,
-        trigger_interface_message_id=None,  # API prompts don't have a prior interface ID
-        user_name=user_name_for_api,
-        user_id=current_user["user_identifier"],
-        replied_to_interface_id=None,  # payload.replied_to_message_id is not available on ChatPromptRequest
-        chat_interface=web_chat_interface,  # Use WebChatInterface for message delivery
-        chat_interfaces=chat_interfaces,  # Pass all registered chat interfaces
-        confirmation_ui_managers=confirmation_ui_managers,
-        request_confirmation_callback=api_confirmation_callback,
-        trigger_attachments=trigger_attachments,  # Pass attachment metadata
-        turn_id=response_turn_id,  # Persist under the (idempotency) turn_id
-    )
-
-    final_reply_content = result.text_reply
-    final_assistant_message_internal_id = result.assistant_message_internal_id
-    _final_reasoning_info = result.reasoning_info  # Not used by API response
-    error_traceback = result.error_traceback
-    _response_attachment_ids = result.attachment_ids  # Not yet included in API response
-
-    if error_traceback:
-        logger.error(
-            f"Error processing API chat request for Conversation ID {conversation_id}: {error_traceback}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error processing request: {error_traceback if getattr(request.app.state, 'debug_mode', False) else 'An internal error occurred.'}",
-        )
-
-    if final_reply_content is None:
-        logger.error(
-            f"No final assistant reply content found for API chat. Conversation ID: {conversation_id}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Assistant did not provide a textual reply.",
-        )
-
-    # Fetch recent messages to get tool_calls if any
-    tool_calls_response = None
-    if final_assistant_message_internal_id:
-        # Get recent messages from this conversation
-        recent_messages = await db_context.message_history.get_recent(
-            interface_type=interface_type,
-            conversation_id=conversation_id,
-            limit=5,  # Get last few messages
-            max_age=timedelta(minutes=5),
-        )
-        # Find the most recent assistant message (repository returns typed LLMMessage objects)
-        # Note: Cannot match by internal_id since typed messages don't include database metadata
-        # Use the most recent AssistantMessage from the list
-        assistant_msg = next(
+        if payload.attachments:
+            # Only get attachment registry when we actually have attachments
+            attachment_registry = await get_attachment_registry(request)
             (
-                msg
-                for msg in reversed(recent_messages)
-                if isinstance(msg, AssistantMessage) and msg.tool_calls
-            ),
+                trigger_content_parts,
+                trigger_attachments,
+            ) = await _process_user_attachments(
+                payload,
+                conversation_id,
+                attachment_registry,
+                db_context,
+                current_user["user_identifier"],
+            )
+
+        # Determine interface type - default to "api" if not specified
+        interface_type = payload.interface_type or "api"
+
+        # Call the new centralized interaction handler
+        # user_name surfaces in the system prompt and message history, so derive it
+        # from the authenticated user rather than a generic placeholder.
+        user_name_for_api = _user_name_for_chat(current_user)
+
+        # Get chat_interfaces registry from app state for cross-interface messaging
+        chat_interfaces = getattr(request.app.state, "chat_interfaces", None)
+        confirmation_ui_managers = getattr(
+            request.app.state,
+            "confirmation_ui_managers",
             None,
         )
-        if assistant_msg and assistant_msg.tool_calls:
-            # Convert ToolCallItem objects to dicts for API response
-            tool_calls_response = []
-            for tc in assistant_msg.tool_calls:
-                if isinstance(tc, ToolCallItem):
-                    # Ensure arguments is a JSON string
-                    args = tc.function.arguments
-                    if not isinstance(args, str):
-                        args = json.dumps(args)
-                    tool_calls_response.append({
-                        "id": tc.id,
-                        "type": tc.type,
-                        "function": {
-                            "name": tc.function.name,
-                            "arguments": args,
-                        },
-                    })
-                elif isinstance(tc, dict):
-                    tool_calls_response.append(tc)
 
-    # This non-streaming path persists the reply but never published to the hub,
-    # so a second device of the same user with an open follow-stream wouldn't
-    # reload. Publish a content-free `message` event (the same nudge
-    # WebChatInterface uses) so open follow-streams refetch history.
-    # Nudge other clients now that this request's writes are durable: the reply
-    # is committed by the time the persisting call returns, so a follower that
-    # refetches /messages sees it. Two nudges: a per-conversation ``message`` event so a client
-    # already following THIS thread reloads its history, and an account-global
-    # activity ping so the conversation surfaces/bumps in the owner's list on a
-    # second tab/device (this non-streaming path has no start_turn/end_turn
-    # lifecycle of its own).
-    send_hub = _get_hub(request)
-    activity_loop = asyncio.get_running_loop()
+        # Non-streaming callers (e.g. iOS App Intents / Siri) cannot wait on a live
+        # confirmation channel, so a tool needing approval records a durable pending
+        # confirmation the user can approve later from another client (the
+        # confirmation service push-notifies them). The deferred tool result tells
+        # the model the action is awaiting approval so the reply reflects that.
+        api_confirmation_service = _get_confirmation_service(request)
 
-    def _publish_send_nudges() -> None:
-        message_task = activity_loop.create_task(
-            send_hub.publish(
-                conversation_id,
-                "message",
-                turn_id=None,
-                payload={"conversation_id": conversation_id, "new_messages": True},
+        async def api_confirmation_callback(
+            interface_type: str,
+            conversation_id: str,
+            turn_id: str | None,
+            tool_name: str,
+            call_id: str,
+            # ast-grep-ignore: no-dict-any - Tool arguments vary per tool and cannot be statically typed
+            tool_args: dict[str, Any],
+            timeout_seconds: float,
+            context: ToolExecutionContext,
+        ) -> ConfirmationOutcome:
+            taint_state_json = (
+                context.taint_tracker.snapshot().to_metadata()
+                if context.taint_tracker is not None
+                else None
             )
-        )
-        _ACTIVITY_PUBLISH_TASKS.add(message_task)
-        message_task.add_done_callback(_ACTIVITY_PUBLISH_TASKS.discard)
-
-        activity_task = activity_loop.create_task(
-            send_hub.publish_activity(
-                conversation_id, user_id=user_id, reason="message"
+            durable_request = await create_durable_confirmation(
+                confirmation_service=api_confirmation_service,
+                db_context=context.db_context,
+                target_user_id=current_user["user_identifier"],
+                tool_name=tool_name,
+                tool_call_id=call_id,
+                tool_args=tool_args,
+                confirmation_prompt=(
+                    f"Do you want to execute '{tool_name}' with these parameters?"
+                ),
+                timeout_seconds=timeout_seconds,
+                turn_id=turn_id,
+                now=datetime.now(UTC),
+                processing_profile_id=context.processing_profile_id,
+                origin_interface_type=context.interface_type,
+                origin_conversation_id=context.conversation_id,
+                taint_state_json=taint_state_json,
             )
+            return ConfirmationOutcome(
+                kind="completed",
+                result=(
+                    f"I've requested your approval to run '{tool_name}' "
+                    f"(request {durable_request['id']}). It hasn't run yet — approve it "
+                    "from your pending confirmations to continue."
+                ),
+            )
+
+        result = await selected_processing_service.handle_chat_interaction(
+            db_context=db_context,
+            interface_type=interface_type,  # Use the interface_type from request or default "api"
+            conversation_id=conversation_id,
+            trigger_content_parts=trigger_content_parts,
+            trigger_interface_message_id=None,  # API prompts don't have a prior interface ID
+            user_name=user_name_for_api,
+            user_id=current_user["user_identifier"],
+            replied_to_interface_id=None,  # payload.replied_to_message_id is not available on ChatPromptRequest
+            chat_interface=web_chat_interface,  # Use WebChatInterface for message delivery
+            chat_interfaces=chat_interfaces,  # Pass all registered chat interfaces
+            confirmation_ui_managers=confirmation_ui_managers,
+            request_confirmation_callback=api_confirmation_callback,
+            trigger_attachments=trigger_attachments,  # Pass attachment metadata
+            turn_id=response_turn_id,  # Persist under the (idempotency) turn_id
         )
-        _ACTIVITY_PUBLISH_TASKS.add(activity_task)
-        activity_task.add_done_callback(_ACTIVITY_PUBLISH_TASKS.discard)
 
-    _publish_send_nudges()
+        final_reply_content = result.text_reply
+        final_assistant_message_internal_id = result.assistant_message_internal_id
+        _final_reasoning_info = result.reasoning_info  # Not used by API response
+        error_traceback = result.error_traceback
+        _response_attachment_ids = (
+            result.attachment_ids
+        )  # Not yet included in API response
 
-    return ChatMessageResponse(
-        reply=final_reply_content,  # Back to original field name
-        conversation_id=conversation_id,  # Return the used/generated conversation_id
-        turn_id=response_turn_id,  # Return the turn_id generated for the response model
-        attachments=trigger_attachments,  # Include processed attachments in response
-        tool_calls=tool_calls_response,  # Include tool calls if any
-    )
+        if error_traceback:
+            logger.error(
+                f"Error processing API chat request for Conversation ID {conversation_id}: {error_traceback}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Error processing request: {error_traceback if getattr(request.app.state, 'debug_mode', False) else 'An internal error occurred.'}",
+            )
+
+        if final_reply_content is None:
+            logger.error(
+                f"No final assistant reply content found for API chat. Conversation ID: {conversation_id}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Assistant did not provide a textual reply.",
+            )
+
+        # Fetch recent messages to get tool_calls if any
+        tool_calls_response = None
+        if final_assistant_message_internal_id:
+            # Get recent messages from this conversation
+            recent_messages = await db_context.message_history.get_recent(
+                interface_type=interface_type,
+                conversation_id=conversation_id,
+                limit=5,  # Get last few messages
+                max_age=timedelta(minutes=5),
+            )
+            # Find the most recent assistant message (repository returns typed LLMMessage objects)
+            # Note: Cannot match by internal_id since typed messages don't include database metadata
+            # Use the most recent AssistantMessage from the list
+            assistant_msg = next(
+                (
+                    msg
+                    for msg in reversed(recent_messages)
+                    if isinstance(msg, AssistantMessage) and msg.tool_calls
+                ),
+                None,
+            )
+            if assistant_msg and assistant_msg.tool_calls:
+                # Convert ToolCallItem objects to dicts for API response
+                tool_calls_response = []
+                for tc in assistant_msg.tool_calls:
+                    if isinstance(tc, ToolCallItem):
+                        # Ensure arguments is a JSON string
+                        args = tc.function.arguments
+                        if not isinstance(args, str):
+                            args = json.dumps(args)
+                        tool_calls_response.append({
+                            "id": tc.id,
+                            "type": tc.type,
+                            "function": {
+                                "name": tc.function.name,
+                                "arguments": args,
+                            },
+                        })
+                    elif isinstance(tc, dict):
+                        tool_calls_response.append(tc)
+
+        # This non-streaming path publishes no deltas, so a second device of the
+        # same user with an open follow-stream has nothing to render the reply
+        # from. Nudge other clients now that this request's writes are durable:
+        # the reply is committed by the time the persisting call returns, so a
+        # follower that refetches /messages sees it. Two nudges: a
+        # per-conversation ``message`` event (the same content-free nudge
+        # WebChatInterface uses) so a client already following THIS thread
+        # reloads its history, and an account-global activity ping so the
+        # conversation surfaces/bumps in the owner's list on a second
+        # tab/device. The reservation's ``turn_ended`` follows on exit; it tells
+        # a follower the conversation is free again, not what was said.
+        activity_loop = asyncio.get_running_loop()
+
+        def _publish_send_nudges() -> None:
+            message_task = activity_loop.create_task(
+                hub.publish(
+                    conversation_id,
+                    "message",
+                    turn_id=None,
+                    payload={"conversation_id": conversation_id, "new_messages": True},
+                )
+            )
+            _ACTIVITY_PUBLISH_TASKS.add(message_task)
+            message_task.add_done_callback(_ACTIVITY_PUBLISH_TASKS.discard)
+
+            activity_task = activity_loop.create_task(
+                hub.publish_activity(conversation_id, user_id=user_id, reason="message")
+            )
+            _ACTIVITY_PUBLISH_TASKS.add(activity_task)
+            activity_task.add_done_callback(_ACTIVITY_PUBLISH_TASKS.discard)
+
+        _publish_send_nudges()
+
+        reservation.mark_complete()
+        return ChatMessageResponse(
+            reply=final_reply_content,  # Back to original field name
+            conversation_id=conversation_id,  # Return the used/generated conversation_id
+            turn_id=response_turn_id,  # Return the turn_id generated for the response model
+            attachments=trigger_attachments,  # Include processed attachments in response
+            tool_calls=tool_calls_response,  # Include tool calls if any
+        )
 
 
 @chat_api_router.get("/v1/chat/conversations")

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -99,13 +99,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 chat_api_router = APIRouter()
 
-# Strong references to fire-and-forget post-commit hub publishes (activity ping
-# + per-conversation message tickle) so the event loop doesn't garbage-collect
-# them before they run. Heterogeneous result types (publish -> StreamEvent,
-# publish_activity -> None), so the element type is Task[Any].
-_ACTIVITY_PUBLISH_TASKS: set[asyncio.Task[Any]] = set()
-
-
 _TOKEN_IDENTITY_SOURCES = {"api_token", "app_token_session"}
 
 
@@ -2357,39 +2350,14 @@ async def api_chat_send_message(
                     elif isinstance(tc, dict):
                         tool_calls_response.append(tc)
 
-        # This non-streaming path publishes no deltas, so a second device of the
-        # same user with an open follow-stream has nothing to render the reply
-        # from. Nudge other clients now that this request's writes are durable:
-        # the reply is committed by the time the persisting call returns, so a
-        # follower that refetches /messages sees it. Two nudges: a
-        # per-conversation ``message`` event (the same content-free nudge
-        # WebChatInterface uses) so a client already following THIS thread
-        # reloads its history, and an account-global activity ping so the
-        # conversation surfaces/bumps in the owner's list on a second
-        # tab/device. The reservation's ``turn_ended`` follows on exit; it tells
-        # a follower the conversation is free again, not what was said.
-        activity_loop = asyncio.get_running_loop()
-
-        def _publish_send_nudges() -> None:
-            message_task = activity_loop.create_task(
-                hub.publish(
-                    conversation_id,
-                    "message",
-                    turn_id=None,
-                    payload={"conversation_id": conversation_id, "new_messages": True},
-                )
-            )
-            _ACTIVITY_PUBLISH_TASKS.add(message_task)
-            message_task.add_done_callback(_ACTIVITY_PUBLISH_TASKS.discard)
-
-            activity_task = activity_loop.create_task(
-                hub.publish_activity(conversation_id, user_id=user_id, reason="message")
-            )
-            _ACTIVITY_PUBLISH_TASKS.add(activity_task)
-            activity_task.add_done_callback(_ACTIVITY_PUBLISH_TASKS.discard)
-
-        _publish_send_nudges()
-
+        # A follower of this conversation learns about the reply from the
+        # reservation's ``turn_ended``, published as the ``async with`` exits:
+        # the web and iOS follow-streams treat it exactly as they treat the
+        # content-free ``message`` nudge — refetch history, refresh the
+        # conversation list, ack the seq — and ``end_turn`` broadcasts the
+        # account-global activity ping alongside it. Publishing a ``message``
+        # nudge here as well would have every connected client fetch history and
+        # the conversation list twice per send.
         reservation.mark_complete()
         return ChatMessageResponse(
             reply=final_reply_content,  # Back to original field name

--- a/tests/functional/web/api/test_chat_turn_control.py
+++ b/tests/functional/web/api/test_chat_turn_control.py
@@ -1738,3 +1738,195 @@ async def test_steer_rejects_conversation_owned_by_another_user(
         json={"conversation_id": conversation_id, "prompt": "let me steer"},
     )
     assert response.status_code == 404, response.text
+
+
+async def test_send_message_while_a_turn_is_running_returns_409(
+    app_fixture: FastAPI,
+    api_test_client: AsyncClient,
+    api_mock_llm_client: RuleBasedMockLLMClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The non-streaming send takes the same one-turn-per-conversation guard.
+
+    A Siri/App Intent send landing while the GUI has a turn running would
+    otherwise drive a second LLM loop over the same history: the two interleave
+    their writes, and the newcomer answers the running turn's in-flight tool
+    call with the 'abandoned' placeholder.
+    """
+    user_prompt = "Start something long"
+    api_mock_llm_client.rules.append((
+        lambda args: _user_message_contains(args, user_prompt),
+        _reply("done"),
+    ))
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    monkeypatch.setattr(
+        api_mock_llm_client,
+        "generate_response",
+        _gate_first_llm_call(api_mock_llm_client.generate_response, started, release),
+    )
+
+    turn_id = str(uuid.uuid4())
+    conversation_id = f"conv_sendoverlap_{uuid.uuid4().hex[:8]}"
+    post = await api_test_client.post(
+        "/api/v1/chat/turns",
+        json={
+            "turn_id": turn_id,
+            "conversation_id": conversation_id,
+            "prompt": user_prompt,
+            "interface_type": "web",
+        },
+    )
+    assert post.status_code == 200, post.text
+
+    hub: ConversationStreamHub = app_fixture.state.conversation_stream_hub
+    try:
+        await asyncio.wait_for(started.wait(), timeout=5.0)
+
+        rival = await api_test_client.post(
+            "/api/v1/chat/send_message",
+            json={
+                "conversation_id": conversation_id,
+                "prompt": "and another thing",
+                "interface_type": "web",
+            },
+        )
+    finally:
+        release.set()
+
+    assert rival.status_code == 409, rival.text
+    detail = rival.json()["detail"]
+    assert detail["active_turn_id"] == turn_id
+    running = hub.get_turn(conversation_id, turn_id)
+    assert running is not None
+    assert detail["active_turn_first_seq"] == running.first_seq
+
+    await wait_for_condition(
+        _turn_complete(hub, conversation_id, turn_id), description="turn complete"
+    )
+
+
+async def test_turn_while_a_send_message_is_running_returns_409(
+    app_fixture: FastAPI,
+    api_test_client: AsyncClient,
+    api_mock_llm_client: RuleBasedMockLLMClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard holds in the other direction too: a send_message turn is visible
+    in the hub, so a streaming kickoff racing it is refused rather than admitted.
+    """
+    user_prompt = "Siri is talking"
+    api_mock_llm_client.rules.append((
+        lambda args: _user_message_contains(args, user_prompt),
+        _reply("done"),
+    ))
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    monkeypatch.setattr(
+        api_mock_llm_client,
+        "generate_response",
+        _gate_first_llm_call(api_mock_llm_client.generate_response, started, release),
+    )
+
+    conversation_id = f"conv_sendholds_{uuid.uuid4().hex[:8]}"
+    send_turn_id = str(uuid.uuid4())
+    send = asyncio.ensure_future(
+        api_test_client.post(
+            "/api/v1/chat/send_message",
+            json={
+                "turn_id": send_turn_id,
+                "conversation_id": conversation_id,
+                "prompt": user_prompt,
+                "interface_type": "web",
+            },
+        )
+    )
+    hub: ConversationStreamHub = app_fixture.state.conversation_stream_hub
+    try:
+        await asyncio.wait_for(started.wait(), timeout=5.0)
+
+        rival = await api_test_client.post(
+            "/api/v1/chat/turns",
+            json={
+                "turn_id": str(uuid.uuid4()),
+                "conversation_id": conversation_id,
+                "prompt": "meanwhile, in the GUI",
+                "interface_type": "web",
+            },
+        )
+        assert rival.status_code == 409, rival.text
+        assert rival.json()["detail"]["active_turn_id"] == send_turn_id
+    finally:
+        release.set()
+
+    send_response = await asyncio.wait_for(send, timeout=10.0)
+    assert send_response.status_code == 200, send_response.text
+
+    # The reservation exists only for the duration of the send: once it ends the
+    # record is discarded, so the conversation is free and the turn id is reusable.
+    assert hub.get_turn(conversation_id, send_turn_id) is None
+    follow_up = await api_test_client.post(
+        "/api/v1/chat/send_message",
+        json={
+            "conversation_id": conversation_id,
+            "prompt": user_prompt,
+            "interface_type": "web",
+        },
+    )
+    assert follow_up.status_code == 200, follow_up.text
+
+
+async def test_failed_send_message_releases_its_reservation(
+    app_fixture: FastAPI,
+    api_test_client: AsyncClient,
+    api_mock_llm_client: RuleBasedMockLLMClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A send that blows up mid-turn must not wedge the conversation.
+
+    Without a terminal ``end_turn`` in a ``finally`` the record would sit at
+    'running' forever — pruning and eviction both skip running turns — and every
+    later turn on that conversation would take a 409.
+    """
+    user_prompt = "This one explodes"
+
+    working_generate = api_mock_llm_client.generate_response
+
+    async def _explode(*_args: object, **_kwargs: object) -> LLMOutput:
+        raise RuntimeError("LLM unavailable")
+
+    monkeypatch.setattr(api_mock_llm_client, "generate_response", _explode)
+
+    conversation_id = f"conv_sendfails_{uuid.uuid4().hex[:8]}"
+    failed = await api_test_client.post(
+        "/api/v1/chat/send_message",
+        json={
+            "conversation_id": conversation_id,
+            "prompt": user_prompt,
+            "interface_type": "web",
+        },
+    )
+    assert failed.status_code == 500, failed.text
+
+    hub: ConversationStreamHub = app_fixture.state.conversation_stream_hub
+    assert not [
+        turn for turn in hub.active_turns(conversation_id) if turn.status == "running"
+    ]
+
+    recovery_prompt = "Now it works"
+    api_mock_llm_client.rules.append((
+        lambda args: _user_message_contains(args, recovery_prompt),
+        _reply("done"),
+    ))
+    monkeypatch.setattr(api_mock_llm_client, "generate_response", working_generate)
+    retry = await api_test_client.post(
+        "/api/v1/chat/send_message",
+        json={
+            "conversation_id": conversation_id,
+            "prompt": recovery_prompt,
+            "interface_type": "web",
+        },
+    )
+    assert retry.status_code == 200, retry.text

--- a/tests/functional/web/api/test_chat_turn_control.py
+++ b/tests/functional/web/api/test_chat_turn_control.py
@@ -61,6 +61,8 @@ from tests.mocks.mock_llm import RuleBasedMockLLMClient
 
 if TYPE_CHECKING:
     from family_assistant.web.conversation_stream_hub import (
+        ActivitySubscriptionHandle,
+        ConversationActivity,
         StreamEvent,
         SubscriptionHandle,
     )
@@ -120,6 +122,15 @@ def _turn_complete(
         return turn is not None and turn.status == "complete"
 
     return _check
+
+
+def _drain_activity(
+    handle: "ActivitySubscriptionHandle",
+) -> "list[ConversationActivity]":
+    pings = []
+    while not handle.queue.empty():
+        pings.append(handle.queue.get_nowait())
+    return pings
 
 
 def _drain(handle: "SubscriptionHandle") -> "list[StreamEvent]":
@@ -1930,3 +1941,47 @@ async def test_failed_send_message_releases_its_reservation(
         },
     )
     assert retry.status_code == 200, retry.text
+
+
+async def test_send_message_signals_followers_once(
+    app_fixture: FastAPI,
+    api_test_client: AsyncClient,
+    api_mock_llm_client: RuleBasedMockLLMClient,
+) -> None:
+    """One completed send is one reload signal, not two.
+
+    The reservation's ``turn_ended`` is what tells a follower the reply landed:
+    the web and iOS follow-streams treat it exactly as they treat a content-free
+    ``message`` nudge (refetch history, refresh the list, ack the seq), and
+    ``end_turn`` broadcasts the account-global activity ping with it. Publishing
+    a ``message`` nudge as well would have every connected client fetch history
+    and the conversation list twice per send.
+    """
+    user_prompt = "Tell the followers once"
+    api_mock_llm_client.rules.append((
+        lambda args: _user_message_contains(args, user_prompt),
+        _reply("done"),
+    ))
+
+    conversation_id = f"conv_sendnudge_{uuid.uuid4().hex[:8]}"
+    hub: ConversationStreamHub = app_fixture.state.conversation_stream_hub
+    handle = await hub.subscribe(conversation_id, from_seq=0)
+    activity = hub.subscribe_activity("test_user")
+    try:
+        sent = await api_test_client.post(
+            "/api/v1/chat/send_message",
+            json={
+                "conversation_id": conversation_id,
+                "prompt": user_prompt,
+                "interface_type": "web",
+            },
+        )
+        assert sent.status_code == 200, sent.text
+
+        events = _drain(handle)
+    finally:
+        hub.unsubscribe(conversation_id, handle.queue)
+        hub.unsubscribe_activity(activity.queue)
+
+    assert [event.type for event in events] == ["turn_started", "turn_ended"]
+    assert [item.reason for item in _drain_activity(activity)] == ["turn_ended"]

--- a/tests/unit/web/test_conversation_stream_hub.py
+++ b/tests/unit/web/test_conversation_stream_hub.py
@@ -7,6 +7,7 @@ producer task lives in tests/functional/web/api/test_chat_streaming.py.
 """
 
 import asyncio
+import contextlib
 from datetime import UTC, datetime
 
 import pytest
@@ -720,6 +721,66 @@ async def test_reject_if_running_still_reports_a_duplicate_turn_id() -> None:
             started_at=_now(),
             reject_if_running=True,
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_db
+async def test_discard_turn_frees_the_turn_id_for_a_retry() -> None:
+    """``discard_turn`` forgets an ended record entirely.
+
+    A non-streaming send holds its hub record only as the reservation. Keeping
+    it after the send would burn the ``turn_id``: ``start_turn`` refuses a
+    duplicate id, so a client retrying a turn that failed without persisting a
+    reply could never re-drive it.
+    """
+    hub = ConversationStreamHub()
+    await hub.start_turn("conv", turn_id="t1", user_id="u1", started_at=_now())
+    await hub.end_turn("conv", turn_id="t1", status="failed")
+
+    await hub.discard_turn("conv", "t1")
+
+    assert hub.get_turn("conv", "t1") is None
+    retried = await hub.start_turn(
+        "conv",
+        turn_id="t1",
+        user_id="u1",
+        started_at=_now(),
+        reject_if_running=True,
+    )
+    assert retried.turn_id == "t1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_db
+async def test_discard_turn_keeps_a_record_whose_producer_is_still_live() -> None:
+    """The record holds the hub's only strong reference to the producer task, so
+    discarding one still in flight would let that task be collected mid-turn."""
+    hub = ConversationStreamHub()
+    await hub.start_turn("conv", turn_id="t1", user_id="u1", started_at=_now())
+
+    async def parks() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.ensure_future(parks())
+    hub.attach_producer_task("conv", "t1", task)
+    try:
+        await hub.discard_turn("conv", "t1")
+        assert hub.get_turn("conv", "t1") is not None
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.no_db
+async def test_discard_turn_is_a_no_op_for_unknown_ids() -> None:
+    """Safe in a ``finally`` that may run after the record was already dropped."""
+    hub = ConversationStreamHub()
+    await hub.discard_turn("nonexistent", "t1")
+    await hub.start_turn("conv", turn_id="t1", user_id="u1", started_at=_now())
+    await hub.discard_turn("conv", "unknown")
+    assert hub.get_turn("conv", "t1") is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1082.

## Problem

`POST /api/v1/chat/send_message` drove a full LLM loop without registering or consulting a hub turn, so a non-streaming send — an iOS App Intent, a Siri request, an API client — could start a second loop on a conversation that already had a turn running from the GUI. The two interleave their writes on one history, and the newcomer's history rebuild sees the running turn's unanswered tool call and fills it with the "abandoned" placeholder while the real result is still coming. That is the failure #1077 exists to prevent, and it only covered the streaming path.

## What changed

- **`/send_message` takes the same reservation as `POST /turns`.** A new `_reserve_non_streaming_turn` async context manager registers a hub turn with `reject_if_running=True` and ends it with a terminal status in a `finally`: `complete` on a reply, `cancelled` when the client hangs up mid-turn, `failed` otherwise. Without that, a crash inside `handle_chat_interaction` would leave the record at `running` — which neither pruning nor eviction touches — and refuse every later turn on the conversation.
- **The record is discarded when the send ends** (new `ConversationStreamHub.discard_turn`). A non-streaming turn has no producer task, no buffered deltas to replay and no ack to wait for, so the record exists only as the reservation; retaining it would burn its `turn_id` for a retry of a turn that failed without persisting a reply. `discard_turn` refuses to drop a record whose producer task is still live, since that record holds the hub's only strong reference to the task.
- **Rivals in either direction get the same 409** naming the running turn (`active_turn_id` / `active_turn_first_seq`), so a `/turns` kickoff racing a running send is refused too. A `turn_id` this process already ran that produced no reply gets a distinct 409 rather than a misleading "a turn is running".
- **Profile resolution moved ahead of the reservation** so a request rejected for naming a remote-only profile no longer publishes a `turn_started`/`turn_ended` pair for a turn that never runs.

## The open question in the issue: is `/send_message` steerable?

No — the 409 tells its callers to wait. A non-streaming turn publishes no event stream to carry a steer echo, and an echo (not the steer's 200) is what settles a submission for the clients that steer. Making it steerable would mean handing a headless caller a stream it never reads. In practice this costs nothing: iOS App Intents always mint a fresh `conversation_id`, and the iOS 409 path already falls back to holding the prompt as a draft when a steer is refused. `/send_message` turns are short-lived and hold the reservation only while the request is in flight.

Idempotency is unaffected: `/send_message` settles a retry from the persisted reply, not the hub record, so a retry of a turn that already answered returns it (`already_complete: true`) without reaching the reservation.

## Tests

- Functional (`tests/functional/web/api/test_chat_turn_control.py`): a send refused while a streaming turn runs; a streaming kickoff refused while a send runs, then the reservation released and the turn id reusable once it finishes; a send whose LLM raises releasing its reservation so the next send succeeds.
- Unit (`tests/unit/web/test_conversation_stream_hub.py`): `discard_turn` frees the turn id for a retry, keeps a record whose producer is still live, and no-ops on unknown ids.
- `poe test`: PASSED (pytest, frontend tests, basedpyright, pylint, frontend lint, frontend typecheck).

## Docs

- `docs/api/README.md` — the 409 shape and semantics for `/send_message`, including the "wait, don't steer" guidance and the already-used-`turn_id` refusal.
- `docs/design/resumable_streaming.md` — a section on the reservation model: where it lives, why it is in the hub rather than the endpoint, and how the two endpoints' record lifetimes differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016q9sksuHbPQ3YrjWLL6Y2k)_