### PR TITLE
Validate send_message_to_user targets against real conversations

### DIFF
--- a/docs/user/interfaces.md
+++ b/docs/user/interfaces.md
@@ -170,7 +170,9 @@ clearly. When the request originated somewhere less trusted — a forwarded emai
 to approve the message first. See [confirmations-and-safety.md](confirmations-and-safety.md).
 
 This only reaches people set up as users of your Family Assistant — it isn't a way to send ordinary
-SMS or email to arbitrary contacts.
+SMS or email to arbitrary contacts. The assistant can only message someone in a conversation they
+have already used to talk to it, so a new household member needs to message the assistant once
+before anyone can have a message passed to them.
 
 ## Push notifications
 

--- a/src/family_assistant/tools/communication.py
+++ b/src/family_assistant/tools/communication.py
@@ -134,10 +134,12 @@ COMMUNICATION_TOOLS_DEFINITION: list[ToolDefinition] = [
                 "For normal reminders, simply write the text in your response and it will be delivered to the current user automatically. "
                 "You MUST use the recipient's Chat ID as the target, which is provided in the 'Known users' section of the system prompt. "
                 "Optionally, you can include attachments with the message.\n\n"
+                "The target must be an existing conversation that an authorized user has already used to talk to the assistant; invented or guessed IDs are rejected.\n\n"
                 "Returns: A string indicating the result. "
                 "On success, returns 'Message sent successfully to user with Chat ID [chat_id].'. "
                 "If message is sent but history recording fails, returns 'Message sent to user with Chat ID [chat_id], but failed to record in history.'. "
                 "On error, returns 'Error: Could not send message to Chat ID [chat_id]. Details: [error details]', 'Error: Chat interface not available.',"
+                " 'Error: Chat ID [chat_id] is not a known conversation with an authorized user of this assistant.',"
                 " or 'Error: Cannot use send_message_to_user tool to send a message to the user you are already replying to. The user will receive your final response directly in this conversation.'."
             ),
             "parameters": {
@@ -145,7 +147,7 @@ COMMUNICATION_TOOLS_DEFINITION: list[ToolDefinition] = [
                 "properties": {
                     "target_chat_id": {
                         "type": "string",
-                        "description": "The conversation ID of the recipient. For Telegram conversations, this is the numeric Chat ID. For web conversations, this is a UUID. The ID must be from a known conversation provided in the system context.",
+                        "description": "The conversation ID of the recipient. For Telegram conversations, this is the numeric Chat ID. For web conversations, this is a UUID. The ID must be from a known conversation provided in the system context, and must belong to an authorized user who has already talked to the assistant.",
                     },
                     "message_content": {
                         "type": "string",
@@ -510,6 +512,57 @@ def _parse_optional_datetime(value: str | None, field_name: str) -> datetime | N
         raise ValueError(f"{field_name} must be an ISO datetime.") from exc
 
 
+class UnknownMessageTargetError(ValueError):
+    """Raised when a ``send_message_to_user`` target is not a known conversation."""
+
+
+async def _resolve_send_message_target(
+    exec_context: ToolExecutionContext,
+    target_chat_id: str,
+) -> str:
+    """Resolve the interface type of a validated ``send_message_to_user`` target.
+
+    A conversation is a legitimate target only if an authorized user has already
+    talked to the assistant in it: every interface refuses to persist user
+    messages from identities it cannot authorize, so a conversation carrying a
+    user message is one the bot is allowed to reply into. Without this check the
+    model can name any conversation identifier it likes -- an arbitrary Telegram
+    chat ID, or a UUID belonging to nobody -- which turns the tool into an
+    exfiltration channel for injected instructions.
+
+    Returns:
+        The interface type the target conversation belongs to.
+
+    Raises:
+        UnknownMessageTargetError: If the target is not a conversation an
+            authorized user has talked to the assistant in.
+    """
+    message_history = exec_context.db_context.message_history
+    target_interface_type = await message_history.get_interface_type_for_conversation(
+        target_chat_id
+    )
+    owner_ids = (
+        await message_history.get_conversation_owner_ids(target_chat_id)
+        if target_interface_type is not None
+        else set()
+    )
+    if target_interface_type is None or not owner_ids:
+        logger.warning(
+            "Rejected send_message_to_user to unknown conversation %s "
+            "(interface_type=%s, owners=%d)",
+            target_chat_id,
+            target_interface_type,
+            len(owner_ids),
+        )
+        raise UnknownMessageTargetError(
+            f"Error: Chat ID {target_chat_id} is not a known conversation with an "
+            "authorized user of this assistant. Only use IDs from the 'Known users' "
+            "section of your context, and only for users who have already messaged "
+            "the assistant."
+        )
+    return target_interface_type
+
+
 async def send_message_to_user_tool(
     exec_context: ToolExecutionContext,
     target_chat_id: str,
@@ -544,21 +597,25 @@ async def send_message_to_user_tool(
     # This is useful for linking the sent message back to the originating interaction.
     requesting_turn_id = exec_context.turn_id
 
-    # Detect the interface type for the target conversation
-    target_interface_type = (
-        await db_context.message_history.get_interface_type_for_conversation(
-            target_chat_id
-        )
-    )
-
-    # If no history exists for this conversation, fall back to current interface type
-    # This allows sending first messages to new conversations
-    if not target_interface_type:
-        target_interface_type = exec_context.interface_type
+    # Validate that the user is not trying to send a message to themselves
+    current_conversation_id = exec_context.conversation_id
+    if target_chat_id == current_conversation_id:
         logger.warning(
-            f"No message history found for conversation {target_chat_id}. "
-            f"Defaulting to current interface type: {target_interface_type}."
+            f"Attempt to send message to self: target_chat_id={target_chat_id}, current_conversation_id={current_conversation_id}"
         )
+        return (
+            "Error: Cannot use send_message_to_user tool to send a message to the user you are "
+            "already replying to. The user will receive your final response directly in this conversation."
+        )
+
+    # Detect the interface type for the target conversation, rejecting any
+    # conversation that no authorized user has ever talked to the bot in.
+    try:
+        target_interface_type = await _resolve_send_message_target(
+            exec_context, target_chat_id
+        )
+    except UnknownMessageTargetError as exc:
+        return str(exc)
 
     # Get the appropriate ChatInterface for this interface type
     # Try chat_interfaces dict first (new way), fall back to single chat_interface (old way)
@@ -577,17 +634,6 @@ async def send_message_to_user_tool(
                 "ChatInterface not available in ToolExecutionContext for send_message_to_user_tool."
             )
             return "Error: Chat interface not available."
-
-    # Validate that the user is not trying to send a message to themselves
-    current_conversation_id = exec_context.conversation_id
-    if target_chat_id == current_conversation_id:
-        logger.warning(
-            f"Attempt to send message to self: target_chat_id={target_chat_id}, current_conversation_id={current_conversation_id}"
-        )
-        return (
-            "Error: Cannot use send_message_to_user tool to send a message to the user you are "
-            "already replying to. The user will receive your final response directly in this conversation."
-        )
 
     # Validate attachment IDs if provided
     validated_attachment_ids: list[str] | None = None

--- a/tests/functional/attachments/test_attachment_tools.py
+++ b/tests/functional/attachments/test_attachment_tools.py
@@ -23,6 +23,7 @@ from family_assistant.tools.attachments import attach_to_response_tool
 from family_assistant.tools.communication import send_message_to_user_tool
 from family_assistant.tools.image_tools import highlight_image_tool
 from family_assistant.tools.types import ToolExecutionContext
+from tests.helpers import seed_known_conversation
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -198,6 +199,7 @@ class TestAttachToResponseTool:
         """Test attach_to_response without attachment registry."""
 
         db_context = Database(db_engine)
+        await seed_known_conversation(db_engine, "456789")
         exec_context = ToolExecutionContext(
             conversation_id="test_conversation",
             interface_type="telegram",
@@ -265,6 +267,7 @@ class TestSendMessageToUserWithAttachments:
             storage_path=mock_attachment_metadata.storage_path,
             conversation_id=mock_attachment_metadata.conversation_id,
         )
+        await seed_known_conversation(db_engine, "456789")
 
         exec_context = ToolExecutionContext(
             conversation_id="test_conversation",
@@ -317,6 +320,7 @@ class TestSendMessageToUserWithAttachments:
         mock_chat_interface.send_message = AsyncMock(return_value="message_123")
 
         db_context = Database(db_engine)
+        await seed_known_conversation(db_engine, "456789")
         exec_context = ToolExecutionContext(
             conversation_id="test_conversation",
             interface_type="telegram",

--- a/tests/functional/attachments/test_attachment_workflows.py
+++ b/tests/functional/attachments/test_attachment_workflows.py
@@ -35,7 +35,7 @@ from family_assistant.tools import (
 )
 from family_assistant.tools import AVAILABLE_FUNCTIONS as local_tool_implementations
 from family_assistant.tools.types import ToolExecutionContext, ToolResult
-from tests.helpers import wait_for_tasks_to_complete
+from tests.helpers import seed_known_conversation, wait_for_tasks_to_complete
 from tests.mocks.mock_llm import LLMOutput, RuleBasedMockLLMClient
 
 if TYPE_CHECKING:
@@ -338,6 +338,7 @@ class TestAttachmentWorkflows:
         # Step 3: Send processed image to another user
         # We'll use a fake target chat ID for testing
         target_chat_id = 987654321
+        await seed_known_conversation(db_engine, str(target_chat_id))
 
         # Create a mock chat interface for testing
         mock_chat_interface = AsyncMock()

--- a/tests/functional/telegram/test_telegram_send_message_tool.py
+++ b/tests/functional/telegram/test_telegram_send_message_tool.py
@@ -12,7 +12,7 @@ from telegram.ext import ContextTypes
 
 from family_assistant.context_providers import KnownUsersContextProvider
 from family_assistant.llm import ToolCallFunction, ToolCallItem
-from family_assistant.llm.messages import ToolMessage
+from family_assistant.llm.messages import ToolMessage, UserMessage
 from tests.mocks.mock_llm import (
     LLMOutput,
     MatcherArgs,
@@ -111,6 +111,16 @@ async def test_send_message_to_user_tool(
     # Make a copy of the list to avoid modifying the original fixture's list if it's shared
     original_providers = list(fix.processing_service.context_providers)
     fix.processing_service.context_providers.append(known_users_provider)
+
+    # Bob is only a legitimate target because he has already talked to the
+    # assistant -- the tool refuses conversations it has no user message for.
+    await fix.database.message_history.add_message(
+        UserMessage(content="Hi assistant"),
+        interface_type="telegram",
+        conversation_id=str(bob_chat_id),
+        timestamp=datetime.now(UTC),
+        user_id=str(bob_chat_id),
+    )
 
     user_a_text = (
         f"Hey assistant, please tell {bob_name} that 'the meeting is at 3 PM'."

--- a/tests/functional/tools/test_send_message_target_validation.py
+++ b/tests/functional/tools/test_send_message_target_validation.py
@@ -1,0 +1,183 @@
+"""Target validation for the ``send_message_to_user`` tool.
+
+The tool may only deliver to conversations an authorized user has actually used
+to talk to the assistant; anything else (an invented Telegram chat ID, a UUID
+belonging to nobody) has to be refused before a message leaves the system.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, Mock
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from family_assistant.llm.messages import AssistantMessage
+from family_assistant.storage.database import Database
+from family_assistant.tools.communication import send_message_to_user_tool
+from family_assistant.tools.types import ToolExecutionContext
+from tests.helpers import seed_known_conversation
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+KNOWN_CHAT_ID = "555000"
+UNKNOWN_CHAT_ID = "999111"
+
+
+def _build_exec_context(
+    db_context: Database,
+    chat_interface: Mock,
+) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        interface_type="web",
+        conversation_id="current-conversation",
+        user_name="Alice",
+        user_id="alice",
+        turn_id="turn-1",
+        db_context=db_context,
+        processing_service=None,
+        clock=None,
+        home_assistant_client=None,
+        event_sources=None,
+        attachment_registry=None,
+        camera_backend=None,
+        credential_resolvers=None,
+        api_backend=None,
+        timezone=ZoneInfo("UTC"),
+        chat_interfaces={"telegram": chat_interface, "web": chat_interface},
+    )
+
+
+@pytest.fixture
+def chat_interface() -> Mock:
+    interface = Mock()
+    interface.send_message = AsyncMock(return_value="sent_message_1")
+    return interface
+
+
+async def test_sends_to_conversation_of_known_user(
+    db_engine: AsyncEngine,
+    chat_interface: Mock,
+) -> None:
+    """A conversation an authorized user has messaged in is a valid target."""
+    await seed_known_conversation(db_engine, KNOWN_CHAT_ID, user_id="bob")
+    exec_context = _build_exec_context(Database(db_engine), chat_interface)
+
+    result = await send_message_to_user_tool(
+        exec_context=exec_context,
+        target_chat_id=KNOWN_CHAT_ID,
+        message_content="Dinner is at 7",
+    )
+
+    assert "Message sent successfully" in result
+    assert chat_interface.send_message.await_args.kwargs["conversation_id"] == (
+        KNOWN_CHAT_ID
+    )
+
+
+async def test_rejects_conversation_with_no_history(
+    db_engine: AsyncEngine,
+    chat_interface: Mock,
+) -> None:
+    """An identifier the assistant has never seen is not a deliverable target."""
+    exec_context = _build_exec_context(Database(db_engine), chat_interface)
+
+    result = await send_message_to_user_tool(
+        exec_context=exec_context,
+        target_chat_id=UNKNOWN_CHAT_ID,
+        message_content="Exfiltrated secrets",
+    )
+
+    assert f"Chat ID {UNKNOWN_CHAT_ID} is not a known conversation" in result
+    chat_interface.send_message.assert_not_awaited()
+
+
+async def test_rejects_conversation_without_authorized_sender(
+    db_engine: AsyncEngine,
+    chat_interface: Mock,
+) -> None:
+    """A conversation the assistant wrote into but nobody talked in is refused.
+
+    Messages from unauthorized identities are never persisted, so a conversation
+    that holds no user message has no authorized user behind it.
+    """
+    db_context = Database(db_engine)
+    await db_context.message_history.add_message(
+        AssistantMessage(content="Anyone there?"),
+        interface_type="telegram",
+        conversation_id=UNKNOWN_CHAT_ID,
+        timestamp=datetime.now(UTC),
+    )
+    exec_context = _build_exec_context(db_context, chat_interface)
+
+    result = await send_message_to_user_tool(
+        exec_context=exec_context,
+        target_chat_id=UNKNOWN_CHAT_ID,
+        message_content="Exfiltrated secrets",
+    )
+
+    assert f"Chat ID {UNKNOWN_CHAT_ID} is not a known conversation" in result
+    chat_interface.send_message.assert_not_awaited()
+
+
+async def test_rejects_numeric_target_supplied_as_integer(
+    db_engine: AsyncEngine,
+    chat_interface: Mock,
+) -> None:
+    """Integer chat IDs from JSON deserialization are validated the same way."""
+    exec_context = _build_exec_context(Database(db_engine), chat_interface)
+
+    result = await send_message_to_user_tool(
+        exec_context=exec_context,
+        target_chat_id=int(UNKNOWN_CHAT_ID),  # type: ignore[arg-type]
+        message_content="Exfiltrated secrets",
+    )
+
+    assert f"Chat ID {UNKNOWN_CHAT_ID} is not a known conversation" in result
+    chat_interface.send_message.assert_not_awaited()
+
+
+async def test_routes_to_the_targets_own_interface(
+    db_engine: AsyncEngine,
+) -> None:
+    """Delivery uses the interface the target conversation belongs to."""
+    telegram_interface = Mock()
+    telegram_interface.send_message = AsyncMock(return_value="sent_message_1")
+    web_interface = Mock()
+    web_interface.send_message = AsyncMock(return_value="sent_message_2")
+
+    await seed_known_conversation(
+        db_engine, KNOWN_CHAT_ID, interface_type="telegram", user_id="bob"
+    )
+    db_context = Database(db_engine)
+    exec_context = ToolExecutionContext(
+        interface_type="web",
+        conversation_id="current-conversation",
+        user_name="Alice",
+        user_id="alice",
+        turn_id="turn-1",
+        db_context=db_context,
+        processing_service=None,
+        clock=None,
+        home_assistant_client=None,
+        event_sources=None,
+        attachment_registry=None,
+        camera_backend=None,
+        credential_resolvers=None,
+        api_backend=None,
+        timezone=ZoneInfo("UTC"),
+        chat_interfaces={"telegram": telegram_interface, "web": web_interface},
+    )
+
+    result = await send_message_to_user_tool(
+        exec_context=exec_context,
+        target_chat_id=KNOWN_CHAT_ID,
+        message_content="Dinner is at 7",
+    )
+
+    assert "Message sent successfully" in result
+    telegram_interface.send_message.assert_awaited_once()
+    web_interface.send_message.assert_not_awaited()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,6 +23,7 @@ from sqlalchemy.sql.functions import (
     count as sql_count,
 )
 
+from family_assistant.llm.messages import UserMessage
 from family_assistant.storage.database import Database
 from family_assistant.storage.tasks import tasks_table
 
@@ -407,9 +408,35 @@ async def wait_for_server(
     )
 
 
+async def seed_known_conversation(
+    engine: AsyncEngine,
+    conversation_id: str,
+    *,
+    interface_type: str = "telegram",
+    user_id: str = "known-user",
+    text: str = "Hello",
+) -> None:
+    """Persist a user message so ``conversation_id`` is a known message target.
+
+    ``send_message_to_user`` only delivers to conversations an authorized user
+    has already talked to the assistant in, which is how a real conversation
+    comes to exist. Tests that send to a conversation they did not otherwise
+    drive traffic through need this to make the target legitimate.
+    """
+    db = Database(engine)
+    await db.message_history.add_message(
+        UserMessage(content=text),
+        interface_type=interface_type,
+        conversation_id=conversation_id,
+        timestamp=datetime.now(UTC),
+        user_id=user_id,
+    )
+
+
 __all__ = [
     "find_free_port",
     "require_executable",
+    "seed_known_conversation",
     "wait_for_condition",
     "wait_for_server",
     "wait_for_tasks_to_complete",


### PR DESCRIPTION
## Problem

`send_message_to_user` accepted any conversation identifier the model supplied. It looked up the target's interface type in message history, and when it found nothing it **fell back to the current interface type and delivered anyway**:

```python
if not target_interface_type:
    target_interface_type = exec_context.interface_type
    logger.warning("No message history found ... Defaulting to current interface type")
```

So an arbitrary Telegram chat ID, or a UUID belonging to nobody, was a valid destination. That makes the tool an exfiltration channel for injected instructions — precisely the chain the Rule-of-Two profile boundaries exist to break.

## Change

`_resolve_send_message_target` now resolves the target through message history and requires both:

- a known interface type for the conversation, and
- at least one persisted user message (`get_conversation_owner_ids` non-empty).

Every interface refuses to persist user messages from identities it cannot authorize — the Telegram handler drops batches from unauthorized users before processing, web/API conversations are authenticated at the boundary — so a conversation carrying a user message is one the assistant is allowed to reply into. Unknown targets return an error naming the constraint rather than delivering.

Two smaller consequences: the self-send check now runs first (before any database work), and delivery always routes to the target conversation's own interface instead of guessing the caller's.

Rejecting targets with no history also matches Telegram's own rule — a bot cannot message a user who has never started a chat with it — so the removed fallback was not buying working behaviour.

## Tests

New `tests/functional/tools/test_send_message_target_validation.py` covers the accepted case, an unseen conversation, a conversation holding only assistant messages, an integer chat ID from JSON deserialization, and cross-interface routing.

Existing tests that sent to unseeded conversations (attachment tools, attachment workflows, the Telegram end-to-end test) now seed a real conversation first, via a new `seed_known_conversation` helper in `tests/helpers.py`.

`scripts/format-and-lint.sh` passes; `poe test` was still running at the time of writing, so CI is the authority on the full suite.

## Docs

`docs/user/interfaces.md` notes that a new household member has to message the assistant once before anyone can have a message passed to them. The tool description and `target_chat_id` schema now state the constraint and the new error string.

---
_Generated by [Claude Code](https://claude.ai/code/session_0167cSA9f7E1HMQ4gJt77N6m)_