### PR TITLE
Share conversations with authorized users

### DIFF
--- a/alembic/versions/2026_08_10-add_conversation_shares.py
+++ b/alembic/versions/2026_08_10-add_conversation_shares.py
@@ -1,0 +1,52 @@
+"""Add active read-only conversation shares.
+
+Revision ID: conversation_shares
+Revises: mh_conversation_owner_idx
+Create Date: 2026-08-10
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "conversation_shares"
+down_revision: str | None = "mh_conversation_owner_idx"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "conversation_shares",
+        sa.Column("conversation_id", sa.String(length=255), nullable=False),
+        sa.Column("owner_user_id", sa.String(length=255), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("conversation_id"),
+    )
+    op.create_index(
+        "ix_conversation_shares_owner_user_id",
+        "conversation_shares",
+        ["owner_user_id"],
+    )
+    op.create_index(
+        "ix_conversation_shares_token_hash",
+        "conversation_shares",
+        ["token_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conversation_shares_token_hash", table_name="conversation_shares")
+    op.drop_index(
+        "ix_conversation_shares_owner_user_id", table_name="conversation_shares"
+    )
+    op.drop_table("conversation_shares")

--- a/docs/design/conversation-share-links.md
+++ b/docs/design/conversation-share-links.md
@@ -48,6 +48,7 @@ recovery mechanism if it is exposed accidentally.
 Endpoints:
 
 - `POST /api/v1/chat/conversations/{conversation_id}/share` rotates and returns the link.
+- `GET /api/v1/chat/conversations/{conversation_id}/share` reports whether a share is active.
 - `DELETE /api/v1/chat/conversations/{conversation_id}/share` revokes it.
 - `GET /api/v1/shared-conversations/{token}/messages` returns the visible main-conversation rows.
 - `GET /api/v1/shared-conversations/{token}/attachments/{attachment_id}` serves a scoped file.

--- a/docs/design/conversation-share-links.md
+++ b/docs/design/conversation-share-links.md
@@ -1,0 +1,56 @@
+# Conversation Share Links
+
+## Goal
+
+Let the owner of a web conversation give another authorized Family Assistant user a link to a
+read-only view. The link is a privacy speedbump between household members, not an authorization
+substitute: every request still requires an authenticated, allowlisted user.
+
+## User experience
+
+- A persisted conversation has a **Share** action in the chat header.
+- Sharing rotates the conversation's one active link and copies the replacement URL.
+- The owner can stop sharing, immediately invalidating the link.
+- A recipient opens `/shared/conversations/{token}` and sees a dedicated read-only transcript.
+- Shared conversations never appear in the recipient's conversation list and cannot be continued,
+  steered, or used to approve tool calls.
+- The transcript is live at read time: later persisted messages appear after a refresh.
+
+## Authorization model
+
+The URL carries a 256-bit random bearer token. The database stores only its SHA-256 digest. A
+successful shared read requires both:
+
+1. normal Family Assistant authentication through OIDC or another accepted application identity;
+2. an active share row whose digest matches the supplied token.
+
+Creating or revoking a link uses the existing sole-canonical-owner conversation check. Shared read
+endpoints do not call the owner-only message endpoint and do not weaken its invariant.
+
+Attachment downloads use a share-scoped endpoint. It serves a file only when the active share
+matches and the attachment registry row names the shared conversation. This avoids granting the
+recipient general access to the owner's attachment registry.
+
+The token is intentionally sufficient for any authenticated household user. Shares do not target a
+specific recipient, expire automatically, or provide an audit trail; those controls would add
+machinery beyond the stated household privacy boundary. Rotating or revoking the link is the
+recovery mechanism if it is exposed accidentally.
+
+## Storage and API
+
+`conversation_shares` contains one row per conversation:
+
+- `conversation_id` (primary key)
+- `owner_user_id`
+- `token_hash` (unique SHA-256 hex digest)
+- `created_at`
+
+Endpoints:
+
+- `POST /api/v1/chat/conversations/{conversation_id}/share` rotates and returns the link.
+- `DELETE /api/v1/chat/conversations/{conversation_id}/share` revokes it.
+- `GET /api/v1/shared-conversations/{token}/messages` returns the visible main-conversation rows.
+- `GET /api/v1/shared-conversations/{token}/attachments/{attachment_id}` serves a scoped file.
+
+All endpoints declare the normal current-user dependency. Invalid, revoked, foreign, and malformed
+tokens return 404 so the API does not distinguish why access failed.

--- a/docs/user/interfaces.md
+++ b/docs/user/interfaces.md
@@ -47,6 +47,17 @@ profile's context stays separate — but anything you have already typed comes w
 draft a message and then decide who should handle it. If the chat is still empty, switching just
 changes the profile and keeps you where you are.
 
+**Share a conversation.** Open a conversation that already has messages and select the share icon in
+the chat header. Family Assistant copies a link to a read-only transcript. The recipient must sign
+in as an authorized Family Assistant user, and the conversation does not appear in their history
+list. Selecting share again replaces the old link; select the stop-sharing icon to make the current
+link unavailable. The transcript reflects messages added after the link was created when the
+recipient refreshes it.
+
+Treat the link as private within your household. It is meant to stop another authorized user from
+casually browsing your history, not to protect a conversation from someone who obtains the link and
+deliberately tries to access it.
+
 **Stop or steer a running reply.** While the assistant is generating, the chat box doubles as a
 steering box:
 

--- a/frontend/src/chat/ChatApp.tsx
+++ b/frontend/src/chat/ChatApp.tsx
@@ -384,6 +384,7 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(window.innerWidth > 768);
   const [conversationId, setConversationId] = useState<string | null>(null);
+  const [persistedConversationId, setPersistedConversationId] = useState<string | null>(null);
   // Always-current mirror of conversationId, so a deferred follow-up timer can
   // synchronously check whether the conversation changed before it fires.
   const conversationIdRef = useRef<string | null>(null);
@@ -804,6 +805,9 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
       // clock can't pin it.
       if (turnId) {
         pendingOptimisticConversationsRef.current.delete(turnId);
+      }
+      if (!kickoffFailed && conversationId) {
+        setPersistedConversationId(conversationId);
       }
 
       if (messageId) {
@@ -1402,6 +1406,9 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
           // A stream is active for this conversation — its own completion will
           // reconcile. Don't clobber it, and treat this as a supersession.
           return 'bailed' as const;
+        }
+        if (data.messages.length > 0 && conversationIdRef.current === convId) {
+          setPersistedConversationId(convId);
         }
 
         // A foreground load means the user just opened this conversation (every
@@ -2505,7 +2512,9 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
               <div className="flex items-center gap-2 ml-auto">
                 <ShareConversationButton
                   conversationId={conversationId}
-                  hasMessages={messages.length > 0}
+                  hasPersistedMessages={
+                    messages.length > 0 && persistedConversationId === conversationId
+                  }
                 />
                 <NotificationSettings
                   enabled={notificationsEnabled}
@@ -2577,7 +2586,9 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
               <div className="flex items-center gap-2 ml-auto">
                 <ShareConversationButton
                   conversationId={conversationId}
-                  hasMessages={messages.length > 0}
+                  hasPersistedMessages={
+                    messages.length > 0 && persistedConversationId === conversationId
+                  }
                 />
                 <NotificationSettings
                   enabled={notificationsEnabled}

--- a/frontend/src/chat/ChatApp.tsx
+++ b/frontend/src/chat/ChatApp.tsx
@@ -16,6 +16,7 @@ import { NotificationSettings } from './NotificationSettings';
 import { PendingConfirmationsTray } from './PendingConfirmationsTray';
 import ProfileSelector from './ProfileSelector';
 import { PushNotificationButton } from './PushNotificationButton';
+import { ShareConversationButton } from './ShareConversationButton';
 import { ChatControlsContext, type SteerResult } from './chatControls';
 import { Thread } from './Thread';
 import { ToolConfirmationProvider } from './ToolConfirmationContext';
@@ -2502,6 +2503,10 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
               </div>
 
               <div className="flex items-center gap-2 ml-auto">
+                <ShareConversationButton
+                  conversationId={conversationId}
+                  hasMessages={messages.length > 0}
+                />
                 <NotificationSettings
                   enabled={notificationsEnabled}
                   onEnabledChange={handleNotificationEnabledChange}
@@ -2570,6 +2575,10 @@ const ChatApp: React.FC<ChatAppProps> = ({ profileId = 'default_assistant' }) =>
               </div>
 
               <div className="flex items-center gap-2 ml-auto">
+                <ShareConversationButton
+                  conversationId={conversationId}
+                  hasMessages={messages.length > 0}
+                />
                 <NotificationSettings
                   enabled={notificationsEnabled}
                   onEnabledChange={handleNotificationEnabledChange}

--- a/frontend/src/chat/ShareConversationButton.tsx
+++ b/frontend/src/chat/ShareConversationButton.tsx
@@ -4,14 +4,14 @@ import { Button } from '@/components/ui/button';
 
 interface ShareConversationButtonProps {
   conversationId: string | null;
-  hasMessages: boolean;
+  hasPersistedMessages: boolean;
 }
 
 type ShareStatus = 'loading' | 'active' | 'inactive' | 'error';
 
 export const ShareConversationButton: React.FC<ShareConversationButtonProps> = ({
   conversationId,
-  hasMessages,
+  hasPersistedMessages,
 }) => {
   const [shareStatus, setShareStatus] = useState<ShareStatus>('loading');
   const [busy, setBusy] = useState(false);
@@ -25,7 +25,7 @@ export const ShareConversationButton: React.FC<ShareConversationButtonProps> = (
     setFeedback(null);
     setManualShareUrl(null);
     mutationStartedRef.current = false;
-    if (!conversationId || !hasMessages) {
+    if (!conversationId || !hasPersistedMessages) {
       return;
     }
     const controller = new AbortController();
@@ -47,9 +47,9 @@ export const ShareConversationButton: React.FC<ShareConversationButtonProps> = (
         }
       });
     return () => controller.abort();
-  }, [conversationId, hasMessages, statusRequestVersion]);
+  }, [conversationId, hasPersistedMessages, statusRequestVersion]);
 
-  if (!conversationId || !hasMessages) {
+  if (!conversationId || !hasPersistedMessages) {
     return null;
   }
 

--- a/frontend/src/chat/ShareConversationButton.tsx
+++ b/frontend/src/chat/ShareConversationButton.tsx
@@ -1,4 +1,4 @@
-import { Link2Off, Share2 } from 'lucide-react';
+import { Link2Off, RefreshCw, Share2 } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 
@@ -7,18 +7,21 @@ interface ShareConversationButtonProps {
   hasMessages: boolean;
 }
 
+type ShareStatus = 'loading' | 'active' | 'inactive' | 'error';
+
 export const ShareConversationButton: React.FC<ShareConversationButtonProps> = ({
   conversationId,
   hasMessages,
 }) => {
-  const [active, setActive] = useState(false);
+  const [shareStatus, setShareStatus] = useState<ShareStatus>('loading');
   const [busy, setBusy] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [manualShareUrl, setManualShareUrl] = useState<string | null>(null);
+  const [statusRequestVersion, setStatusRequestVersion] = useState(0);
   const mutationStartedRef = useRef(false);
 
   useEffect(() => {
-    setActive(false);
+    setShareStatus('loading');
     setFeedback(null);
     setManualShareUrl(null);
     mutationStartedRef.current = false;
@@ -32,16 +35,19 @@ export const ShareConversationButton: React.FC<ShareConversationButtonProps> = (
       .then((response) => (response.ok ? response.json() : Promise.reject(response)))
       .then((data: { active: boolean }) => {
         if (!mutationStartedRef.current) {
-          setActive(data.active);
+          setShareStatus(data.active ? 'active' : 'inactive');
         }
       })
       .catch((error: unknown) => {
         if (!(error instanceof DOMException && error.name === 'AbortError')) {
           console.error('Failed to load conversation share status:', error);
+          if (!mutationStartedRef.current) {
+            setShareStatus('error');
+          }
         }
       });
     return () => controller.abort();
-  }, [conversationId, hasMessages]);
+  }, [conversationId, hasMessages, statusRequestVersion]);
 
   if (!conversationId || !hasMessages) {
     return null;
@@ -61,7 +67,7 @@ export const ShareConversationButton: React.FC<ShareConversationButtonProps> = (
       }
       const data = (await response.json()) as { share_url: string };
       const absoluteUrl = new URL(data.share_url, window.location.origin).toString();
-      setActive(true);
+      setShareStatus('active');
       try {
         await navigator.clipboard.writeText(absoluteUrl);
         setFeedback('Link copied');
@@ -90,7 +96,7 @@ export const ShareConversationButton: React.FC<ShareConversationButtonProps> = (
       if (!response.ok) {
         throw new Error(`Revoke request failed with status ${response.status}`);
       }
-      setActive(false);
+      setShareStatus('inactive');
       setFeedback('Sharing stopped');
     } catch (error) {
       console.error('Failed to stop sharing conversation:', error);
@@ -99,6 +105,32 @@ export const ShareConversationButton: React.FC<ShareConversationButtonProps> = (
       setBusy(false);
     }
   };
+
+  const retryShareStatus = () => {
+    mutationStartedRef.current = false;
+    setStatusRequestVersion((version) => version + 1);
+  };
+
+  const active = shareStatus === 'active';
+
+  if (shareStatus === 'error') {
+    return (
+      <div className="flex items-center gap-1" aria-live="polite">
+        <span className="hidden text-xs text-destructive sm:inline">
+          Could not load sharing status
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={retryShareStatus}
+          aria-label="Retry loading sharing status"
+          title="Retry loading sharing status"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className="flex items-center gap-1" aria-live="polite">
@@ -119,9 +151,21 @@ export const ShareConversationButton: React.FC<ShareConversationButtonProps> = (
         variant="ghost"
         size="sm"
         onClick={createShare}
-        disabled={busy}
-        aria-label={active ? 'Replace shared conversation link' : 'Share conversation'}
-        title={active ? 'Replace shared conversation link' : 'Share conversation'}
+        disabled={busy || shareStatus === 'loading'}
+        aria-label={
+          shareStatus === 'loading'
+            ? 'Loading sharing status'
+            : active
+              ? 'Replace shared conversation link'
+              : 'Share conversation'
+        }
+        title={
+          shareStatus === 'loading'
+            ? 'Loading sharing status'
+            : active
+              ? 'Replace shared conversation link'
+              : 'Share conversation'
+        }
       >
         <Share2 className="h-4 w-4" />
       </Button>

--- a/frontend/src/chat/ShareConversationButton.tsx
+++ b/frontend/src/chat/ShareConversationButton.tsx
@@ -1,0 +1,142 @@
+import { Link2Off, Share2 } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface ShareConversationButtonProps {
+  conversationId: string | null;
+  hasMessages: boolean;
+}
+
+export const ShareConversationButton: React.FC<ShareConversationButtonProps> = ({
+  conversationId,
+  hasMessages,
+}) => {
+  const [active, setActive] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [manualShareUrl, setManualShareUrl] = useState<string | null>(null);
+  const mutationStartedRef = useRef(false);
+
+  useEffect(() => {
+    setActive(false);
+    setFeedback(null);
+    setManualShareUrl(null);
+    mutationStartedRef.current = false;
+    if (!conversationId || !hasMessages) {
+      return;
+    }
+    const controller = new AbortController();
+    void fetch(`/api/v1/chat/conversations/${conversationId}/share`, {
+      signal: controller.signal,
+    })
+      .then((response) => (response.ok ? response.json() : Promise.reject(response)))
+      .then((data: { active: boolean }) => {
+        if (!mutationStartedRef.current) {
+          setActive(data.active);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!(error instanceof DOMException && error.name === 'AbortError')) {
+          console.error('Failed to load conversation share status:', error);
+        }
+      });
+    return () => controller.abort();
+  }, [conversationId, hasMessages]);
+
+  if (!conversationId || !hasMessages) {
+    return null;
+  }
+
+  const createShare = async () => {
+    mutationStartedRef.current = true;
+    setBusy(true);
+    setFeedback(null);
+    setManualShareUrl(null);
+    try {
+      const response = await fetch(`/api/v1/chat/conversations/${conversationId}/share`, {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        throw new Error(`Share request failed with status ${response.status}`);
+      }
+      const data = (await response.json()) as { share_url: string };
+      const absoluteUrl = new URL(data.share_url, window.location.origin).toString();
+      setActive(true);
+      try {
+        await navigator.clipboard.writeText(absoluteUrl);
+        setFeedback('Link copied');
+      } catch (error) {
+        console.error('Failed to copy conversation share link:', error);
+        setManualShareUrl(absoluteUrl);
+        setFeedback('Open the link to copy it');
+      }
+    } catch (error) {
+      console.error('Failed to share conversation:', error);
+      setFeedback('Could not share conversation');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const revokeShare = async () => {
+    mutationStartedRef.current = true;
+    setBusy(true);
+    setFeedback(null);
+    setManualShareUrl(null);
+    try {
+      const response = await fetch(`/api/v1/chat/conversations/${conversationId}/share`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        throw new Error(`Revoke request failed with status ${response.status}`);
+      }
+      setActive(false);
+      setFeedback('Sharing stopped');
+    } catch (error) {
+      console.error('Failed to stop sharing conversation:', error);
+      setFeedback('Could not stop sharing');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1" aria-live="polite">
+      {feedback && (
+        <span className="hidden text-xs text-muted-foreground sm:inline">{feedback}</span>
+      )}
+      {manualShareUrl && (
+        <a
+          href={manualShareUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-xs text-primary underline"
+        >
+          Open
+        </a>
+      )}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={createShare}
+        disabled={busy}
+        aria-label={active ? 'Replace shared conversation link' : 'Share conversation'}
+        title={active ? 'Replace shared conversation link' : 'Share conversation'}
+      >
+        <Share2 className="h-4 w-4" />
+      </Button>
+      {active && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={revokeShare}
+          disabled={busy}
+          aria-label="Stop sharing conversation"
+          title="Stop sharing conversation"
+        >
+          <Link2Off className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/chat/SharedConversationPage.tsx
+++ b/frontend/src/chat/SharedConversationPage.tsx
@@ -19,6 +19,17 @@ function messageText(message: BackendConversationMessage): string {
   return '';
 }
 
+function isConversationResponse(
+  value: unknown
+): value is { messages: BackendConversationMessage[] } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'messages' in value &&
+    Array.isArray(value.messages)
+  );
+}
+
 const SharedAttachments: React.FC<{ attachments?: BackendAttachment[] }> = ({ attachments }) => {
   if (!attachments?.length) {
     return null;
@@ -88,13 +99,15 @@ const SharedMessage: React.FC<{ message: BackendConversationMessage }> = ({ mess
 const SharedConversationPage: React.FC = () => {
   const { token } = useParams<{ token: string }>();
   const [messages, setMessages] = useState<BackendConversationMessage[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [notFound, setNotFound] = useState(false);
+  const [loadState, setLoadState] = useState<
+    'loading' | 'ready' | 'not-found' | 'authentication-required' | 'error'
+  >('loading');
+  const [requestVersion, setRequestVersion] = useState(0);
 
   useEffect(() => {
+    setLoadState('loading');
     if (!token) {
-      setNotFound(true);
-      setLoading(false);
+      setLoadState('not-found');
       return;
     }
     const controller = new AbortController();
@@ -102,20 +115,37 @@ const SharedConversationPage: React.FC = () => {
       signal: controller.signal,
     })
       .then(async (response) => {
+        if (response.status === 404) {
+          setLoadState('not-found');
+          return null;
+        }
+        if (response.status === 401 || response.status === 403) {
+          setLoadState('authentication-required');
+          return null;
+        }
         if (!response.ok) {
-          throw new Error(String(response.status));
+          throw new Error(`Shared conversation request failed with status ${response.status}`);
         }
         return response.json();
       })
-      .then((data: { messages: BackendConversationMessage[] }) => setMessages(data.messages))
+      .then((data: unknown) => {
+        if (data === null) {
+          return;
+        }
+        if (!isConversationResponse(data)) {
+          throw new Error('Shared conversation response is malformed');
+        }
+        setMessages(data.messages);
+        setLoadState('ready');
+      })
       .catch((error: unknown) => {
         if (!(error instanceof DOMException && error.name === 'AbortError')) {
-          setNotFound(true);
+          console.error('Failed to load shared conversation:', error);
+          setLoadState('error');
         }
-      })
-      .finally(() => setLoading(false));
+      });
     return () => controller.abort();
-  }, [token]);
+  }, [token, requestVersion]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -135,8 +165,10 @@ const SharedConversationPage: React.FC = () => {
         </div>
       </header>
       <main className="mx-auto max-w-4xl space-y-4 px-4 py-8">
-        {loading && <p className="text-center text-muted-foreground">Loading conversation…</p>}
-        {notFound && (
+        {loadState === 'loading' && (
+          <p className="text-center text-muted-foreground">Loading conversation…</p>
+        )}
+        {loadState === 'not-found' && (
           <Card className="p-6 text-center">
             <h2 className="font-semibold">This shared conversation is unavailable</h2>
             <p className="mt-2 text-sm text-muted-foreground">
@@ -144,8 +176,29 @@ const SharedConversationPage: React.FC = () => {
             </p>
           </Card>
         )}
-        {!loading &&
-          !notFound &&
+        {loadState === 'authentication-required' && (
+          <Card className="p-6 text-center">
+            <h2 className="font-semibold">Sign in to view this conversation</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Shared conversations are available only to authorized Family Assistant users.
+            </p>
+            <Button asChild className="mt-4">
+              <a href={window.location.href}>Sign in again</a>
+            </Button>
+          </Card>
+        )}
+        {loadState === 'error' && (
+          <Card className="p-6 text-center">
+            <h2 className="font-semibold">Could not load the shared conversation</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Check your connection and try again.
+            </p>
+            <Button className="mt-4" onClick={() => setRequestVersion((version) => version + 1)}>
+              Try again
+            </Button>
+          </Card>
+        )}
+        {loadState === 'ready' &&
           messages.map((message) => <SharedMessage key={message.internal_id} message={message} />)}
       </main>
     </div>

--- a/frontend/src/chat/SharedConversationPage.tsx
+++ b/frontend/src/chat/SharedConversationPage.tsx
@@ -1,0 +1,155 @@
+import { ArrowLeft, LockKeyhole } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import type { BackendAttachment, BackendConversationMessage } from './types';
+import { MarkdownText } from './MarkdownText';
+
+function messageText(message: BackendConversationMessage): string {
+  if (typeof message.content === 'string') {
+    return message.content;
+  }
+  if (Array.isArray(message.content)) {
+    return message.content
+      .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
+      .map((part) => part.text)
+      .join('\n\n');
+  }
+  return '';
+}
+
+const SharedAttachments: React.FC<{ attachments?: BackendAttachment[] }> = ({ attachments }) => {
+  if (!attachments?.length) {
+    return null;
+  }
+  return (
+    <div className="mt-3 flex flex-wrap gap-3">
+      {attachments.map((attachment) => {
+        const url = attachment.content_url;
+        if (!url || !attachment.attachment_id) {
+          return null;
+        }
+        const name = attachment.name || String(attachment.description || 'Attachment');
+        const mimeType = String(attachment.mime_type || '');
+        return mimeType.startsWith('image/') ? (
+          <a key={attachment.attachment_id} href={url} target="_blank" rel="noreferrer">
+            <img src={url} alt={name} className="max-h-80 rounded-lg border object-contain" />
+          </a>
+        ) : (
+          <a
+            key={attachment.attachment_id}
+            href={url}
+            className="text-sm text-primary underline underline-offset-4"
+          >
+            {name}
+          </a>
+        );
+      })}
+    </div>
+  );
+};
+
+const SharedMessage: React.FC<{ message: BackendConversationMessage }> = ({ message }) => {
+  const isUser = message.role === 'user';
+  const text = messageText(message);
+  if (!text && !message.attachments?.length && !message.tool_calls?.length) {
+    return null;
+  }
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+      <Card
+        className={`max-w-[85%] px-4 py-3 ${
+          isUser ? 'bg-primary text-primary-foreground' : 'bg-card'
+        }`}
+      >
+        <div className="mb-2 text-xs font-medium opacity-70">
+          {isUser
+            ? 'Conversation owner'
+            : message.role === 'assistant'
+              ? 'Assistant'
+              : message.role}
+        </div>
+        {text && <MarkdownText text={text} />}
+        {message.tool_calls?.map((toolCall) => (
+          <details key={toolCall.id} className="mt-2 text-sm">
+            <summary>Tool: {toolCall.function?.name || toolCall.name || 'unknown'}</summary>
+            <pre className="mt-2 overflow-x-auto whitespace-pre-wrap text-xs">
+              {String(toolCall.function?.arguments || toolCall.arguments || '')}
+            </pre>
+          </details>
+        ))}
+        <SharedAttachments attachments={message.attachments} />
+      </Card>
+    </div>
+  );
+};
+
+const SharedConversationPage: React.FC = () => {
+  const { token } = useParams<{ token: string }>();
+  const [messages, setMessages] = useState<BackendConversationMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setNotFound(true);
+      setLoading(false);
+      return;
+    }
+    const controller = new AbortController();
+    void fetch(`/api/v1/shared-conversations/${token}/messages`, {
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(String(response.status));
+        }
+        return response.json();
+      })
+      .then((data: { messages: BackendConversationMessage[] }) => setMessages(data.messages))
+      .catch((error: unknown) => {
+        if (!(error instanceof DOMException && error.name === 'AbortError')) {
+          setNotFound(true);
+        }
+      })
+      .finally(() => setLoading(false));
+    return () => controller.abort();
+  }, [token]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center gap-3 px-4 py-3">
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/chat" aria-label="Back to chat">
+              <ArrowLeft className="h-4 w-4" />
+            </Link>
+          </Button>
+          <div>
+            <h1 className="font-semibold">Shared conversation</h1>
+            <p className="flex items-center gap-1 text-xs text-muted-foreground">
+              <LockKeyhole className="h-3 w-3" /> Read only
+            </p>
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto max-w-4xl space-y-4 px-4 py-8">
+        {loading && <p className="text-center text-muted-foreground">Loading conversation…</p>}
+        {notFound && (
+          <Card className="p-6 text-center">
+            <h2 className="font-semibold">This shared conversation is unavailable</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              The link may be invalid, replaced, or no longer shared.
+            </p>
+          </Card>
+        )}
+        {!loading &&
+          !notFound &&
+          messages.map((message) => <SharedMessage key={message.internal_id} message={message} />)}
+      </main>
+    </div>
+  );
+};
+
+export default SharedConversationPage;

--- a/frontend/src/chat/__tests__/ChatApp.test.tsx
+++ b/frontend/src/chat/__tests__/ChatApp.test.tsx
@@ -1,7 +1,9 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
 import { vi } from 'vitest';
 import { mockLocalStorage, resetLocalStorageMock } from '../../test/mocks/localStorageMock';
+import { server } from '../../test/setup.js';
 import { renderChatApp } from '../../test/utils/renderChatApp';
 import { waitForMessageSent } from '../../test/utils/waitHelpers';
 import { mergeConsecutiveToolOnlyAssistantMessages } from '../ChatApp';
@@ -63,6 +65,60 @@ describe('ChatApp', () => {
     // @assistant-ui/react runtime behavior, which may not show messages
     // in the DOM in the same way as a traditional chat UI
   }, 30000);
+
+  it('waits for a new conversation to persist before loading share status', async () => {
+    const user = userEvent.setup();
+    const statusRequest = vi.fn(() => HttpResponse.json({ active: false }));
+    let conversationId = '';
+    let turnId = '';
+    let finishStream: (() => void) | undefined;
+    server.use(
+      http.get('/api/v1/chat/conversations/:conversationId/share', statusRequest),
+      http.post('/api/v1/chat/turns', async ({ request }) => {
+        const body = (await request.json()) as {
+          conversation_id: string;
+          turn_id: string;
+        };
+        conversationId = body.conversation_id;
+        turnId = body.turn_id;
+        return HttpResponse.json({
+          conversation_id: conversationId,
+          turn_id: turnId,
+          first_seq: 0,
+        });
+      }),
+      http.get('/api/v1/chat/conversations/:conversationId/stream', () => {
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                `event: turn_started\ndata: ${JSON.stringify({ turn_id: turnId, seq: 0 })}\n\n`
+              )
+            );
+            finishStream = () => {
+              controller.enqueue(
+                encoder.encode(
+                  `event: turn_ended\ndata: ${JSON.stringify({ turn_id: turnId, seq: 1, status: 'complete' })}\n\n`
+                )
+              );
+              controller.close();
+            };
+          },
+        });
+        return new HttpResponse(stream, { headers: { 'Content-Type': 'text/event-stream' } });
+      })
+    );
+    await renderChatApp({ waitForReady: true });
+
+    await user.type(screen.getByPlaceholderText('Message Family Assistant...'), 'Hello');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(finishStream).toBeDefined());
+    expect(statusRequest).not.toHaveBeenCalled();
+
+    finishStream?.();
+    await waitFor(() => expect(statusRequest).toHaveBeenCalledOnce());
+  });
 
   it('handles conversation loading', async () => {
     await renderChatApp({ waitForReady: true });

--- a/frontend/src/chat/__tests__/ShareConversationButton.test.tsx
+++ b/frontend/src/chat/__tests__/ShareConversationButton.test.tsx
@@ -43,4 +43,31 @@ describe('ShareConversationButton', () => {
       screen.queryByRole('button', { name: 'Stop sharing conversation' })
     ).not.toBeInTheDocument();
   });
+
+  it('blocks share mutations and offers retry when status cannot load', async () => {
+    const user = userEvent.setup();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    let attempts = 0;
+    server.use(
+      http.get('/api/v1/chat/conversations/conversation-1/share', () => {
+        attempts += 1;
+        return attempts === 1
+          ? HttpResponse.json({ detail: 'Unavailable' }, { status: 503 })
+          : HttpResponse.json({ active: true });
+      })
+    );
+    render(<ShareConversationButton conversationId="conversation-1" hasMessages={true} />);
+
+    await screen.findByRole('button', { name: 'Retry loading sharing status' });
+    expect(screen.queryByRole('button', { name: 'Share conversation' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Stop sharing conversation' })
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Retry loading sharing status' }));
+    expect(
+      await screen.findByRole('button', { name: 'Stop sharing conversation' })
+    ).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
 });

--- a/frontend/src/chat/__tests__/ShareConversationButton.test.tsx
+++ b/frontend/src/chat/__tests__/ShareConversationButton.test.tsx
@@ -27,7 +27,7 @@ describe('ShareConversationButton', () => {
         return new HttpResponse(null, { status: 204 });
       })
     );
-    render(<ShareConversationButton conversationId="conversation-1" hasMessages={true} />);
+    render(<ShareConversationButton conversationId="conversation-1" hasPersistedMessages={true} />);
 
     await user.click(await screen.findByRole('button', { name: 'Share conversation' }));
     await waitFor(() => {
@@ -56,7 +56,7 @@ describe('ShareConversationButton', () => {
           : HttpResponse.json({ active: true });
       })
     );
-    render(<ShareConversationButton conversationId="conversation-1" hasMessages={true} />);
+    render(<ShareConversationButton conversationId="conversation-1" hasPersistedMessages={true} />);
 
     await screen.findByRole('button', { name: 'Retry loading sharing status' });
     expect(screen.queryByRole('button', { name: 'Share conversation' })).not.toBeInTheDocument();
@@ -69,5 +69,22 @@ describe('ShareConversationButton', () => {
       await screen.findByRole('button', { name: 'Stop sharing conversation' })
     ).toBeInTheDocument();
     consoleError.mockRestore();
+  });
+
+  it('does not request status for optimistic messages before they persist', async () => {
+    const statusRequest = vi.fn(() => HttpResponse.json({ active: false }));
+    server.use(http.get('/api/v1/chat/conversations/conversation-1/share', statusRequest));
+    const { rerender } = render(
+      <ShareConversationButton conversationId="conversation-1" hasPersistedMessages={false} />
+    );
+
+    await Promise.resolve();
+    expect(statusRequest).not.toHaveBeenCalled();
+
+    rerender(
+      <ShareConversationButton conversationId="conversation-1" hasPersistedMessages={true} />
+    );
+    expect(await screen.findByRole('button', { name: 'Share conversation' })).toBeInTheDocument();
+    expect(statusRequest).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/chat/__tests__/ShareConversationButton.test.tsx
+++ b/frontend/src/chat/__tests__/ShareConversationButton.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { vi } from 'vitest';
+import { server } from '../../test/setup.js';
+import { ShareConversationButton } from '../ShareConversationButton';
+
+describe('ShareConversationButton', () => {
+  it('copies a rotated link and can revoke it', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    let active = false;
+    server.use(
+      http.get('/api/v1/chat/conversations/conversation-1/share', () =>
+        HttpResponse.json({ active })
+      ),
+      http.post('/api/v1/chat/conversations/conversation-1/share', () => {
+        active = true;
+        return HttpResponse.json({ share_url: '/shared/conversations/new-token' });
+      }),
+      http.delete('/api/v1/chat/conversations/conversation-1/share', () => {
+        active = false;
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+    render(<ShareConversationButton conversationId="conversation-1" hasMessages={true} />);
+
+    await user.click(await screen.findByRole('button', { name: 'Share conversation' }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/shared/conversations/new-token`
+      );
+    });
+    expect(screen.getByText('Link copied')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Stop sharing conversation' }));
+    expect(await screen.findByText('Sharing stopped')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Stop sharing conversation' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/chat/__tests__/SharedConversationPage.test.tsx
+++ b/frontend/src/chat/__tests__/SharedConversationPage.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { server } from '../../test/setup.js';
+import SharedConversationPage from '../SharedConversationPage';
+
+describe('SharedConversationPage', () => {
+  it('renders a read-only transcript from the share endpoint', async () => {
+    server.use(
+      http.get('/api/v1/shared-conversations/share-token/messages', () =>
+        HttpResponse.json({
+          messages: [
+            {
+              internal_id: '1',
+              role: 'user',
+              timestamp: '2026-08-10T12:00:00Z',
+              content: 'Which gift should I choose?',
+            },
+            {
+              internal_id: '2',
+              role: 'assistant',
+              timestamp: '2026-08-10T12:00:01Z',
+              content: 'The blue one.',
+            },
+          ],
+        })
+      )
+    );
+    render(
+      <MemoryRouter initialEntries={['/shared/conversations/share-token']}>
+        <Routes>
+          <Route path="/shared/conversations/:token" element={<SharedConversationPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Which gift should I choose?')).toBeInTheDocument();
+    expect(screen.getByText('The blue one.')).toBeInTheDocument();
+    expect(screen.getByText('Read only')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Message Family Assistant...')).not.toBeInTheDocument();
+  });
+
+  it('shows an unavailable state for a revoked link', async () => {
+    server.use(
+      http.get('/api/v1/shared-conversations/revoked/messages', () =>
+        HttpResponse.json({ detail: 'Not found' }, { status: 404 })
+      )
+    );
+    render(
+      <MemoryRouter initialEntries={['/shared/conversations/revoked']}>
+        <Routes>
+          <Route path="/shared/conversations/:token" element={<SharedConversationPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('This shared conversation is unavailable')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/chat/__tests__/SharedConversationPage.test.tsx
+++ b/frontend/src/chat/__tests__/SharedConversationPage.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
 import { server } from '../../test/setup.js';
 import SharedConversationPage from '../SharedConversationPage';
 
@@ -55,5 +57,62 @@ describe('SharedConversationPage', () => {
     );
 
     expect(await screen.findByText('This shared conversation is unavailable')).toBeInTheDocument();
+  });
+
+  it('shows a retryable error for server failures and recovers', async () => {
+    const user = userEvent.setup();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    let attempts = 0;
+    server.use(
+      http.get('/api/v1/shared-conversations/retry/messages', () => {
+        attempts += 1;
+        return attempts === 1
+          ? HttpResponse.json({ detail: 'Unavailable' }, { status: 503 })
+          : HttpResponse.json({
+              messages: [
+                {
+                  internal_id: '3',
+                  role: 'assistant',
+                  timestamp: '2026-08-10T12:00:00Z',
+                  content: 'Recovered transcript',
+                },
+              ],
+            });
+      })
+    );
+    render(
+      <MemoryRouter initialEntries={['/shared/conversations/retry']}>
+        <Routes>
+          <Route path="/shared/conversations/:token" element={<SharedConversationPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Could not load the shared conversation')).toBeInTheDocument();
+    expect(screen.queryByText('This shared conversation is unavailable')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(await screen.findByText('Recovered transcript')).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it('shows an authentication message for an expired session', async () => {
+    server.use(
+      http.get('/api/v1/shared-conversations/sign-in/messages', () =>
+        HttpResponse.json({ detail: 'Not authenticated' }, { status: 401 })
+      )
+    );
+    render(
+      <MemoryRouter initialEntries={['/shared/conversations/sign-in']}>
+        <Routes>
+          <Route path="/shared/conversations/:token" element={<SharedConversationPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Sign in to view this conversation')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sign in again' })).toHaveAttribute(
+      'href',
+      window.location.href
+    );
   });
 });

--- a/frontend/src/chat/__tests__/TurnControl.test.tsx
+++ b/frontend/src/chat/__tests__/TurnControl.test.tsx
@@ -1637,7 +1637,7 @@ describe('Web turn control (Stop / Steer)', () => {
             screen.getByText(/Couldn't confirm the assistant received this/i)
           ).toBeInTheDocument();
         }, WAIT);
-        expect(screen.getByText(/and the dentist too/)).toBeInTheDocument();
+        expect(screen.getByTestId('steer-error')).toHaveTextContent('and the dentist too');
         // Handed back, not resent for the user.
         expect(turnsPosts).toBe(1);
       } finally {

--- a/frontend/src/shared/AppRouter.jsx
+++ b/frontend/src/shared/AppRouter.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 // Lazy load all route components for code splitting
 const Layout = lazy(() => import('./Layout.tsx'));
 const ChatPage = lazy(() => import('../chat/ChatApp'));
+const SharedConversationPage = lazy(() => import('../chat/SharedConversationPage'));
 const ToolsApp = lazy(() => import('../tools/ToolsApp'));
 const ErrorsApp = lazy(() => import('../errors/ErrorsApp'));
 const ContextPage = lazy(() => import('./ContextPage.tsx'));
@@ -69,6 +70,14 @@ const AppRouter = () => {
           element={
             <Suspense fallback={<LoadingSpinner />}>
               <ChatPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/shared/conversations/:token"
+          element={
+            <Suspense fallback={<LoadingSpinner />}>
+              <SharedConversationPage />
             </Suspense>
           }
         />

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -95,6 +95,10 @@ export const handlers = [
     });
   }),
 
+  http.get('/api/v1/chat/conversations/:conversationId/share', () => {
+    return HttpResponse.json({ active: false });
+  }),
+
   // Mock conversation messages endpoint
   http.get('/api/v1/chat/conversations/:conversationId/messages', ({ params }) => {
     const { conversationId } = params;

--- a/src/family_assistant/storage/__init__.py
+++ b/src/family_assistant/storage/__init__.py
@@ -29,6 +29,7 @@ from family_assistant.storage.base import (
 
 # Import table definitions for direct use
 from family_assistant.storage.confirmation_requests import confirmation_requests_table
+from family_assistant.storage.conversation_shares import conversation_shares_table
 from family_assistant.storage.database import Database
 from family_assistant.storage.delegation_runs import delegation_runs_table
 from family_assistant.storage.email import received_emails_table
@@ -359,6 +360,7 @@ __all__ = [
     "EventSourceType",
     "InterfaceType",
     "confirmation_requests_table",
+    "conversation_shares_table",
     "create_engine_with_sqlite_optimizations",
     "delegation_runs_table",
     "error_logs_table",

--- a/src/family_assistant/storage/conversation_shares.py
+++ b/src/family_assistant/storage/conversation_shares.py
@@ -1,0 +1,20 @@
+"""Storage table for read-only conversation share links."""
+
+from sqlalchemy import Column, DateTime, String, Table
+from sqlalchemy.sql import functions as func
+
+from family_assistant.storage.base import metadata
+
+conversation_shares_table = Table(
+    "conversation_shares",
+    metadata,
+    Column("conversation_id", String(255), primary_key=True),
+    Column("owner_user_id", String(255), nullable=False, index=True),
+    Column("token_hash", String(64), nullable=False, unique=True, index=True),
+    Column(
+        "created_at",
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    ),
+)

--- a/src/family_assistant/storage/database.py
+++ b/src/family_assistant/storage/database.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     from family_assistant.storage.repositories import (
         AutomationsRepository,
         ConfirmationRequestsRepository,
+        ConversationSharesRepository,
         DelegationRunsRepository,
         EmailRepository,
         ErrorLogsRepository,
@@ -506,6 +507,15 @@ class DatabaseExecutor(ABC):
         )
 
         return self._repository(ConfirmationRequestsRepository)
+
+    @property
+    def conversation_shares(self) -> ConversationSharesRepository:
+        """Get the conversation shares repository instance."""
+        from family_assistant.storage.repositories import (  # noqa: PLC0415
+            ConversationSharesRepository,
+        )
+
+        return self._repository(ConversationSharesRepository)
 
     @property
     def error_logs(self) -> ErrorLogsRepository:

--- a/src/family_assistant/storage/repositories/__init__.py
+++ b/src/family_assistant/storage/repositories/__init__.py
@@ -4,6 +4,7 @@ from .a2a_tasks import A2ATasksRepository
 from .automations import AutomationsRepository
 from .base import BaseRepository
 from .confirmation_requests import ConfirmationRequestsRepository
+from .conversation_shares import ConversationSharesRepository
 from .delegation_runs import DelegationRunsRepository
 from .email import EmailRepository
 from .error_logs import ErrorLogsRepository
@@ -25,6 +26,7 @@ __all__ = [
     "AutomationsRepository",
     "BaseRepository",
     "ConfirmationRequestsRepository",
+    "ConversationSharesRepository",
     "DelegationRunsRepository",
     "EmailRepository",
     "ErrorLogsRepository",

--- a/src/family_assistant/storage/repositories/conversation_shares.py
+++ b/src/family_assistant/storage/repositories/conversation_shares.py
@@ -1,0 +1,89 @@
+"""Repository for read-only conversation share links."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from family_assistant.storage.conversation_shares import conversation_shares_table
+from family_assistant.storage.repositories.base import BaseRepository
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationShare:
+    """A persisted active conversation share."""
+
+    conversation_id: str
+    owner_user_id: str
+    token_hash: str
+    created_at: datetime
+
+
+def _share_from_row(row: dict[str, object]) -> ConversationShare:
+    return ConversationShare(
+        conversation_id=str(row["conversation_id"]),
+        owner_user_id=str(row["owner_user_id"]),
+        token_hash=str(row["token_hash"]),
+        created_at=row["created_at"],  # type: ignore[arg-type]
+    )
+
+
+class ConversationSharesRepository(BaseRepository):
+    """Store one rotatable active share per conversation."""
+
+    async def rotate(
+        self, conversation_id: str, owner_user_id: str, token_hash: str
+    ) -> ConversationShare:
+        """Create or replace the active share for a conversation."""
+        insert_ctor = (
+            pg_insert if self._db.dialect_name == "postgresql" else sqlite_insert
+        )
+        base_stmt = insert_ctor(conversation_shares_table).values(
+            conversation_id=conversation_id,
+            owner_user_id=owner_user_id,
+            token_hash=token_hash,
+        )
+        stmt = base_stmt.on_conflict_do_update(
+            index_elements=[conversation_shares_table.c.conversation_id],
+            set_={
+                "owner_user_id": base_stmt.excluded.owner_user_id,
+                "token_hash": base_stmt.excluded.token_hash,
+                "created_at": base_stmt.excluded.created_at,
+            },
+        )
+        await self._db.execute(stmt)
+        share = await self.get_by_conversation(conversation_id)
+        if share is None:  # pragma: no cover - row exists after successful upsert
+            raise RuntimeError("Conversation share missing immediately after rotation")
+        return share
+
+    async def get_by_conversation(
+        self, conversation_id: str
+    ) -> ConversationShare | None:
+        """Return the active share for a conversation, if any."""
+        row = await self._db.fetch_one(
+            select(conversation_shares_table).where(
+                conversation_shares_table.c.conversation_id == conversation_id
+            )
+        )
+        return _share_from_row(row) if row is not None else None
+
+    async def get_by_token_hash(self, token_hash: str) -> ConversationShare | None:
+        """Return the active share matching a token digest, if any."""
+        row = await self._db.fetch_one(
+            select(conversation_shares_table).where(
+                conversation_shares_table.c.token_hash == token_hash
+            )
+        )
+        return _share_from_row(row) if row is not None else None
+
+    async def revoke(self, conversation_id: str) -> bool:
+        """Remove the active share for a conversation."""
+        result = await self._db.execute(
+            delete(conversation_shares_table).where(
+                conversation_shares_table.c.conversation_id == conversation_id
+            )
+        )
+        return result.rowcount > 0

--- a/src/family_assistant/web/routers/chat_api.py
+++ b/src/family_assistant/web/routers/chat_api.py
@@ -1,9 +1,11 @@
 import asyncio
 import base64
 import binascii
+import hashlib
 import json
 import logging
 import mimetypes
+import secrets
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Mapping
 from contextlib import asynccontextmanager
@@ -11,8 +13,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
 
 from family_assistant.llm import ToolCallItem
@@ -51,6 +53,7 @@ from family_assistant.services.user_identity import (
     UserIdentityResolver,
 )
 from family_assistant.storage.database import Database
+from family_assistant.storage.repositories.conversation_shares import ConversationShare
 from family_assistant.storage.types import MessageHistoryRow
 from family_assistant.tools import MCPToolsProvider, find_provider_by_type
 from family_assistant.tools.infrastructure import ToolDescriptorProvider
@@ -538,6 +541,18 @@ class ConversationMessagesResponse(BaseModel):
             "client distinguish durable tool-only replies from partial rows."
         ),
     )
+
+
+class ConversationShareResponse(BaseModel):
+    """New active share link for a conversation."""
+
+    share_url: str
+
+
+class ConversationShareStatusResponse(BaseModel):
+    """Whether a conversation currently has an active share."""
+
+    active: bool
 
 
 class ActiveTurnInfo(BaseModel):
@@ -1119,6 +1134,50 @@ async def _ensure_user_owns_conversation(
         # isolation. (Empty conversations are handled above.)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return raw_user_id
+
+
+async def _ensure_user_owns_persisted_conversation(
+    request: Request,
+    current_user: Mapping[str, object],
+    conversation_id: str,
+) -> str:
+    """Return the owner id for a non-empty conversation owned by the caller."""
+    user_id = await _ensure_user_owns_conversation(
+        request, current_user, conversation_id, allow_new=False
+    )
+    db_context = Database(request.app.state.database_engine)
+    if not await db_context.message_history.get_conversation_owner_ids(conversation_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return user_id
+
+
+def _share_token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+async def _get_active_conversation_share(
+    request: Request,
+    db_context: Database,
+    token: str,
+) -> ConversationShare:
+    """Resolve an active token without revealing why an invalid share failed."""
+    if len(token) != 43:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    share = await db_context.conversation_shares.get_by_token_hash(
+        _share_token_hash(token)
+    )
+    if share is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    owners = await db_context.message_history.get_conversation_owner_ids(
+        share.conversation_id
+    )
+    resolver = get_user_identity_resolver(request)
+    if not owners or not _caller_is_sole_canonical_owner(
+        resolver, owners, share.owner_user_id
+    ):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return share
 
 
 # ----------------------------------------------------------------------- #
@@ -2491,6 +2550,110 @@ async def get_conversations(
     )
 
 
+@chat_api_router.get(
+    "/v1/chat/conversations/{conversation_id}/share",
+)
+async def get_conversation_share_status(
+    conversation_id: str,
+    request: Request,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    db_context: Annotated[Database, Depends(get_db)],
+) -> ConversationShareStatusResponse:
+    """Return share status to the authenticated conversation owner."""
+    await _ensure_user_owns_persisted_conversation(
+        request, current_user, conversation_id
+    )
+    share = await db_context.conversation_shares.get_by_conversation(conversation_id)
+    return ConversationShareStatusResponse(active=share is not None)
+
+
+@chat_api_router.post(
+    "/v1/chat/conversations/{conversation_id}/share",
+)
+async def create_conversation_share(
+    conversation_id: str,
+    request: Request,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    db_context: Annotated[Database, Depends(get_db)],
+) -> ConversationShareResponse:
+    """Rotate and return a read-only share link for the conversation owner."""
+    owner_user_id = await _ensure_user_owns_persisted_conversation(
+        request, current_user, conversation_id
+    )
+    token = secrets.token_urlsafe(32)
+    await db_context.conversation_shares.rotate(
+        conversation_id, owner_user_id, _share_token_hash(token)
+    )
+    return ConversationShareResponse(share_url=f"/shared/conversations/{token}")
+
+
+@chat_api_router.delete(
+    "/v1/chat/conversations/{conversation_id}/share",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_model=None,
+)
+async def revoke_conversation_share(
+    conversation_id: str,
+    request: Request,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    db_context: Annotated[Database, Depends(get_db)],
+) -> Response:
+    """Revoke the active read-only share as the conversation owner."""
+    await _ensure_user_owns_persisted_conversation(
+        request, current_user, conversation_id
+    )
+    await db_context.conversation_shares.revoke(conversation_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+def _serialize_conversation_messages(
+    messages: list[MessageHistoryRow],
+) -> list[ConversationMessage]:
+    """Convert visible history rows to the public conversation message shape."""
+    response_messages: list[ConversationMessage] = []
+    for msg in messages:
+        if not all(key in msg for key in ["internal_id", "role", "timestamp"]):
+            continue
+
+        tool_calls_dicts = None
+        msg_tool_calls = msg.get("tool_calls")
+        if msg_tool_calls:
+            tool_calls_dicts = []
+            for tool_call in msg_tool_calls:
+                if isinstance(tool_call, ToolCallItem):
+                    arguments = tool_call.function.arguments
+                    if not isinstance(arguments, str):
+                        arguments = json.dumps(arguments)
+                    tool_calls_dicts.append({
+                        "id": tool_call.id,
+                        "type": tool_call.type,
+                        "function": {
+                            "name": tool_call.function.name,
+                            "arguments": arguments,
+                        },
+                    })
+                elif isinstance(tool_call, dict):
+                    tool_calls_dicts.append(tool_call)
+
+        response_messages.append(
+            ConversationMessage(
+                internal_id=msg["internal_id"],
+                turn_id=msg.get("turn_id"),
+                role=msg["role"],
+                content=msg.get("content"),
+                timestamp=msg["timestamp"],
+                tool_calls=tool_calls_dicts,
+                tool_call_id=msg.get("tool_call_id"),
+                error_traceback=msg.get("error_traceback"),
+                attachments=msg.get("attachments"),
+                processing_profile_id=msg.get("processing_profile_id"),
+                reasoning_info=msg.get("reasoning_info"),
+                metadata=None,
+            )
+        )
+    return response_messages
+
+
 @chat_api_router.get("/v1/chat/conversations/{conversation_id}/messages")
 async def get_conversation_messages(
     conversation_id: str,
@@ -2592,55 +2755,7 @@ async def get_conversation_messages(
         acting_user_id=user_id,
     )
 
-    # Convert to response format
-    response_messages = []
-    for msg in messages:
-        # Skip messages with missing required fields
-        if not all(key in msg for key in ["internal_id", "role", "timestamp"]):
-            continue
-
-        # Convert tool_calls from ToolCallItem objects to dicts for Pydantic
-        tool_calls_dicts = None
-        msg_tool_calls = msg.get("tool_calls")
-        if msg_tool_calls:
-            tool_calls_dicts = []
-            for tc in msg_tool_calls:
-                if isinstance(tc, ToolCallItem):
-                    # Convert ToolCallItem to dict
-                    # Ensure arguments is always a JSON string
-                    args = tc.function.arguments
-                    if not isinstance(args, str):
-                        args = json.dumps(args)
-                    tc_dict = {
-                        "id": tc.id,
-                        "type": tc.type,
-                        "function": {
-                            "name": tc.function.name,
-                            "arguments": args,
-                        },
-                    }
-                    # Note: provider_metadata is not included in API response
-                    tool_calls_dicts.append(tc_dict)
-                elif isinstance(tc, dict):
-                    # Already a dict, use as-is
-                    tool_calls_dicts.append(tc)
-
-        response_messages.append(
-            ConversationMessage(
-                internal_id=msg["internal_id"],
-                turn_id=msg.get("turn_id"),
-                role=msg["role"],
-                content=msg.get("content"),
-                timestamp=msg["timestamp"],
-                tool_calls=tool_calls_dicts,
-                tool_call_id=msg.get("tool_call_id"),
-                error_traceback=msg.get("error_traceback"),
-                attachments=msg.get("attachments"),
-                processing_profile_id=msg.get("processing_profile_id"),
-                reasoning_info=msg.get("reasoning_info"),
-                metadata=None,
-            )
-        )
+    response_messages = _serialize_conversation_messages(messages)
 
     # Get total message count for the conversation
     total_message_count = (
@@ -2670,6 +2785,126 @@ async def get_conversation_messages(
         has_more_after=has_more_after,
         latest_user_profile_id=latest_user_profile_id,
         active_turns=active_turns,
+    )
+
+
+@chat_api_router.get(
+    "/v1/shared-conversations/{token}/messages",
+)
+async def get_shared_conversation_messages(
+    token: str,
+    request: Request,
+    _current_user: Annotated[dict, Depends(get_current_user)],
+    db_context: Annotated[Database, Depends(get_db)],
+    attachment_registry: Annotated[
+        "AttachmentRegistry", Depends(get_attachment_registry)
+    ],
+) -> ConversationMessagesResponse:
+    """Return a read-only transcript to an authenticated share-link holder."""
+    share = await _get_active_conversation_share(request, db_context, token)
+    history_by_chat = await db_context.message_history.get_all_grouped(
+        interface_type=None,
+        conversation_id=share.conversation_id,
+        include_subconversations=False,
+    )
+    messages = [
+        message
+        for (
+            _interface_type,
+            conversation_id,
+        ), conversation_messages in history_by_chat.items()
+        if conversation_id == share.conversation_id
+        for message in conversation_messages
+    ]
+    messages.sort(
+        key=lambda message: message.get("timestamp", datetime.min.replace(tzinfo=UTC))
+    )
+    await _enrich_persisted_attachments(
+        messages,
+        db_context=db_context,
+        attachment_registry=attachment_registry,
+        acting_user_id=share.owner_user_id,
+    )
+    for message in messages:
+        for attachment in message.get("attachments") or []:
+            attachment_id = attachment.get("attachment_id")
+            if attachment_id:
+                shared_url = (
+                    f"/api/v1/shared-conversations/{token}/attachments/{attachment_id}"
+                )
+                attachment["content_url"] = shared_url
+                attachment["url"] = shared_url
+
+    response_messages = _serialize_conversation_messages(messages)
+    return ConversationMessagesResponse(
+        conversation_id=share.conversation_id,
+        messages=response_messages,
+        count=len(response_messages),
+        total_messages=len(response_messages),
+        has_more_before=False,
+        has_more_after=False,
+        latest_user_profile_id=None,
+        active_turns=[],
+    )
+
+
+@chat_api_router.get(
+    "/v1/shared-conversations/{token}/attachments/{attachment_id}",
+    response_class=FileResponse,
+)
+async def serve_shared_conversation_attachment(
+    token: str,
+    attachment_id: str,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    _current_user: Annotated[dict, Depends(get_current_user)],
+    db_context: Annotated[Database, Depends(get_db)],
+    attachment_registry: Annotated[
+        "AttachmentRegistry", Depends(get_attachment_registry)
+    ],
+) -> FileResponse:
+    """Serve one attachment scoped to an active authenticated share link."""
+    try:
+        uuid.UUID(attachment_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND) from exc
+
+    share = await _get_active_conversation_share(request, db_context, token)
+    attachment = await attachment_registry.get_attachment(
+        db_context,
+        attachment_id,
+        acting_user_id=share.owner_user_id,
+    )
+    if attachment is None or attachment.conversation_id != share.conversation_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    file_path = attachment_registry.get_attachment_path(
+        attachment_id,
+        stored_path=attachment.storage_path,
+        source_type=attachment.source_type,
+    )
+    if file_path is None or not file_path.exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    background_tasks.add_task(
+        attachment_registry.update_access_time_background,
+        attachment_id,
+        acting_user_id=share.owner_user_id,
+    )
+    original_filename = attachment.metadata.get("original_filename")
+    filename = (
+        original_filename
+        if isinstance(original_filename, str) and original_filename
+        else file_path.name
+    )
+    return FileResponse(
+        path=str(file_path),
+        media_type=attachment_registry.get_content_type(file_path),
+        filename=filename,
+        headers={
+            "Cache-Control": "private, no-store",
+            "ETag": f'"{attachment_id}"',
+        },
     )
 
 

--- a/src/family_assistant/web/routers/vite_pages.py
+++ b/src/family_assistant/web/routers/vite_pages.py
@@ -124,6 +124,15 @@ async def chat_ui(request: Request) -> Response:
     return _serve_vite_html_file(request, "router.html")
 
 
+@vite_pages_router.get(
+    "/shared/conversations/{token:str}", name="shared_conversation_ui"
+)
+async def shared_conversation_ui(request: Request, token: str) -> Response:
+    """Serve the authenticated read-only shared conversation page."""
+    del token
+    return _serve_vite_html_file(request, "router.html")
+
+
 @vite_pages_router.get("/context", name="context_ui")
 async def context_ui(request: Request) -> Response:
     """Serve the React context page via router."""

--- a/tests/functional/web/api/test_chat_messages.py
+++ b/tests/functional/web/api/test_chat_messages.py
@@ -2,7 +2,8 @@ import json
 import logging
 import uuid
 from collections.abc import AsyncGenerator
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
@@ -28,10 +29,12 @@ from family_assistant.llm import (
 )
 from family_assistant.llm.messages import (
     AssistantMessage,
+    MessageAttachmentMetadata,
     ToolMessage,
     UserMessage,
 )
 from family_assistant.processing import ProcessingService, ProcessingServiceConfig
+from family_assistant.services.attachment_registry import AttachmentRegistry
 from family_assistant.storage import init_db
 from family_assistant.storage.database import Database
 from family_assistant.tools import (
@@ -48,6 +51,7 @@ from family_assistant.tools import (
     ToolsProvider,
 )
 from family_assistant.web.app_creator import app as actual_app
+from family_assistant.web.dependencies import get_current_user
 from family_assistant.web.models import ChatMessageResponse
 from family_assistant.web.web_chat_interface import WebChatInterface
 from tests.mocks.mock_llm import (
@@ -583,3 +587,129 @@ async def test_api_chat_send_message_persists_user_id_no_tools(
     logger.info(
         f"Successfully verified user_id '{expected_user_id}' was persisted for all messages without tools."
     )
+
+
+@pytest.mark.asyncio
+async def test_conversation_share_is_authenticated_read_only_and_revocable(
+    test_client: AsyncClient,
+    app_fixture: FastAPI,
+    db_context: Database,
+    tmp_path: Path,
+) -> None:
+    conversation_id = str(uuid.uuid4())
+    await db_context.message_history.add_message(
+        UserMessage(content="Please help me choose a gift"),
+        interface_type="web",
+        conversation_id=conversation_id,
+        timestamp=datetime.now(UTC),
+        user_id="test_user",
+    )
+    attachment_registry = AttachmentRegistry(str(tmp_path), db_context.engine)
+    app_fixture.state.attachment_registry = attachment_registry
+    attachment = await attachment_registry.register_user_attachment(
+        db_context,
+        b"shared details",
+        "details.txt",
+        "text/plain",
+        conversation_id=conversation_id,
+        user_id="test_user",
+    )
+    await db_context.message_history.add_message(
+        AssistantMessage(content="Here are the gift options."),
+        interface_type="web",
+        conversation_id=conversation_id,
+        timestamp=datetime.now(UTC),
+        user_id="test_user",
+        attachments=[
+            MessageAttachmentMetadata(
+                type="attachment_reference",
+                attachment_id=attachment.attachment_id,
+            )
+        ],
+    )
+    foreign_attachment = await attachment_registry.register_user_attachment(
+        db_context,
+        b"private",
+        "private.txt",
+        "text/plain",
+        conversation_id=str(uuid.uuid4()),
+        user_id="test_user",
+    )
+
+    create_response = await test_client.post(
+        f"/api/v1/chat/conversations/{conversation_id}/share"
+    )
+    assert create_response.status_code == 200
+    share_url = create_response.json()["share_url"]
+    token = share_url.rsplit("/", 1)[-1]
+    stored_share = await db_context.conversation_shares.get_by_conversation(
+        conversation_id
+    )
+    assert stored_share is not None
+    assert stored_share.token_hash != token
+    assert len(stored_share.token_hash) == 64
+    status_response = await test_client.get(
+        f"/api/v1/chat/conversations/{conversation_id}/share"
+    )
+    assert status_response.json() == {"active": True}
+
+    replacement_response = await test_client.post(
+        f"/api/v1/chat/conversations/{conversation_id}/share"
+    )
+    replacement_token = replacement_response.json()["share_url"].rsplit("/", 1)[-1]
+    assert replacement_token != token
+
+    async def wife_user() -> dict[str, str]:
+        return {"user_identifier": "wife"}
+
+    app_fixture.dependency_overrides[get_current_user] = wife_user
+    non_owner_share = await test_client.post(
+        f"/api/v1/chat/conversations/{conversation_id}/share"
+    )
+    assert non_owner_share.status_code == 404
+    replaced_read = await test_client.get(
+        f"/api/v1/shared-conversations/{token}/messages"
+    )
+    assert replaced_read.status_code == 404
+    token = replacement_token
+    owner_read = await test_client.get(
+        f"/api/v1/chat/conversations/{conversation_id}/messages"
+    )
+    assert owner_read.status_code == 404
+
+    shared_read = await test_client.get(
+        f"/api/v1/shared-conversations/{token}/messages"
+    )
+    assert shared_read.status_code == 200
+    payload = shared_read.json()
+    assert [message["content"] for message in payload["messages"]] == [
+        "Please help me choose a gift",
+        "Here are the gift options.",
+    ]
+    shared_attachment_url = payload["messages"][1]["attachments"][0]["content_url"]
+    attachment_response = await test_client.get(shared_attachment_url)
+    assert attachment_response.status_code == 200
+    assert attachment_response.content == b"shared details"
+    foreign_attachment_response = await test_client.get(
+        f"/api/v1/shared-conversations/{token}/attachments/"
+        f"{foreign_attachment.attachment_id}"
+    )
+    assert foreign_attachment_response.status_code == 404
+
+    conversation_list = await test_client.get(
+        "/api/v1/chat/conversations?interface_type=web"
+    )
+    assert conversation_list.status_code == 200
+    assert conversation_list.json()["conversations"] == []
+
+    app_fixture.dependency_overrides.pop(get_current_user)
+    revoke_response = await test_client.delete(
+        f"/api/v1/chat/conversations/{conversation_id}/share"
+    )
+    assert revoke_response.status_code == 204
+    app_fixture.dependency_overrides[get_current_user] = wife_user
+    revoked_read = await test_client.get(
+        f"/api/v1/shared-conversations/{token}/messages"
+    )
+    assert revoked_read.status_code == 404
+    app_fixture.dependency_overrides.pop(get_current_user)

--- a/tests/unit/web/test_auth_public_paths.py
+++ b/tests/unit/web/test_auth_public_paths.py
@@ -56,6 +56,7 @@ def _is_public(path: str) -> bool:
     "path",
     [
         "/notes",
+        "/shared/conversations/secret-token",
         "/manifest.json",
         "/manifest.jsonx",
         "/sw.json",


### PR DESCRIPTION
## Summary

- add owner-controlled, rotating conversation share links backed by hashed bearer tokens
- add an authenticated read-only transcript page with conversation-scoped attachment downloads
- keep shared conversations out of the recipient's history and preserve all existing owner-only chat APIs
- add revoke/replace controls, user documentation, a design note, and a database migration

## Security model

The link is a household privacy speedbump: the recipient must still be an authorized Family Assistant user. The opaque URL token grants read-only access to one conversation; it cannot send or steer messages, approve tools, enumerate conversation history, or fetch attachments from another conversation. Creating a new link invalidates the old one, and the owner can revoke sharing.

## Validation

- `poe test` — passed all 5,564 backend tests, frontend tests, Python type/lint, frontend lint, and TypeScript checks
- frontend production build — passed
- Alembic upgrade from an empty SQLite database through `conversation_shares` — passed
- focused share API tests — passed on SQLite and PostgreSQL
